### PR TITLE
Add executable roadmap phases via CLI phase-status/phase-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ CI runs all four checks on every push (GitHub Actions).
 
 ---
 
+## Roadmap execution commands
+
+You can inspect and run roadmap phases directly from the CLI:
+
+```bash
+# Show phase 2-6 completion, blockers, and the next suggested action
+uv run trippy phase-status
+
+# Run a specific phase workflow
+uv run trippy phase-run 2
+uv run trippy phase-run 3 --folder-id <drive_folder_id>
+uv run trippy phase-run 4 --trip-idea "Japan next March"
+uv run trippy phase-run 5 --max-emails 50
+uv run trippy phase-run 6 --trip-id japan-2027
+```
+
+---
+
 ## Current Status
 
 **Phase 1 — Hermes-native foundation: complete.**

--- a/tests/unit/test_phase_planner.py
+++ b/tests/unit/test_phase_planner.py
@@ -1,0 +1,78 @@
+"""Tests for roadmap phase status/orchestration service."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from trippy.memory.store import MemoryStore
+from trippy.models.trip import Trip, TripStatus
+from trippy.services.phase_planner import PhasePlannerService
+from trippy.services.trip_state import TripStateService
+
+
+def test_status_shows_phase_2_complete_when_google_files_exist(tmp_path, monkeypatch) -> None:
+    from trippy import config
+
+    creds = tmp_path / "gmail_credentials.json"
+    token = tmp_path / "gmail_token.json"
+    creds.write_text("{}", encoding="utf-8")
+    token.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(config, "GMAIL_CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(config, "GMAIL_TOKEN_PATH", token)
+    monkeypatch.setattr(config, "GOOGLE_TOKEN_PATH", tmp_path / "google_token.json")
+
+    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    phases = planner.status()
+    phase2 = next(p for p in phases if p.phase == 2)
+    assert phase2.complete
+    assert not phase2.blockers
+
+
+def test_status_marks_phase_3_complete_with_trips_and_preferences(tmp_path) -> None:
+    memory = MemoryStore(tmp_path / "memory.json")
+    memory.set(
+        key="pref:preferences_object",
+        value={"comfort_over_price": True},
+        category="preference",
+        confidence=0.9,
+        source="test",
+    )
+
+    trip_svc = TripStateService(tmp_path / "trips")
+    trip_svc.save(
+        Trip(
+            trip_id="japan-2027",
+            name="Japan 2027",
+            status=TripStatus.BOOKED,
+            start_date=date(2027, 3, 10),
+            end_date=date(2027, 3, 24),
+        )
+    )
+
+    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    phases = planner.status()
+    phase3 = next(p for p in phases if p.phase == 3)
+    assert phase3.complete
+
+
+def test_run_phase_2_reports_file_existence(tmp_path, monkeypatch) -> None:
+    from trippy import config
+
+    creds = tmp_path / "gmail_credentials.json"
+    creds.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(config, "GMAIL_CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(config, "GMAIL_TOKEN_PATH", tmp_path / "gmail_token.json")
+    monkeypatch.setattr(config, "GOOGLE_TOKEN_PATH", tmp_path / "google_token.json")
+
+    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    result = planner.run_phase(2)
+    assert result["phase"] == 2
+    assert result["credentials_exist"] is True
+    assert result["token_exists"] is False
+
+
+def test_run_phase_unsupported_returns_error(tmp_path) -> None:
+    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    result = planner.run_phase(99)
+    assert "error" in result

--- a/trippy/cli.py
+++ b/trippy/cli.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
+from rich.json import JSON
 from rich.table import Table
 
 if TYPE_CHECKING:
@@ -328,6 +329,83 @@ def friction_audit(
             (r.recommended_fix or "")[:60],
         )
     console.print(t)
+
+
+@app.command("phase-status")
+def phase_status() -> None:
+    """Show roadmap phases 2-6 and what is blocked next."""
+    from trippy.services.phase_planner import PhasePlannerService
+
+    planner = PhasePlannerService()
+    phases = planner.status()
+
+    table = Table(title="Trippy Roadmap Status", show_lines=True)
+    table.add_column("Phase", style="bold")
+    table.add_column("Title")
+    table.add_column("Status")
+    table.add_column("Blockers")
+    table.add_column("Next Step")
+
+    for phase in phases:
+        status = "[green]Complete[/green]" if phase.complete else "[yellow]Pending[/yellow]"
+        blockers = "None" if not phase.blockers else " • ".join(phase.blockers)
+        table.add_row(
+            f"{phase.phase}",
+            phase.title,
+            status,
+            blockers,
+            phase.next_step,
+        )
+
+    console.print(table)
+
+    pending = [p for p in phases if not p.complete]
+    if pending:
+        next_phase = pending[0]
+        console.print(
+            f"\n[bold]Next actionable phase:[/bold] Phase {next_phase.phase} — {next_phase.title}"
+        )
+
+
+@app.command("phase-run")
+def phase_run(
+    phase: int = typer.Argument(..., help="Roadmap phase number (2-6)"),
+    folder_id: str = typer.Option("", "--folder-id", help="Drive folder ID (phase 3/4)"),
+    query: str = typer.Option("trip", "--query", help="Drive search query (phase 3)"),
+    max_sheets: int = typer.Option(50, "--max-sheets", help="Max sheets to scan (phase 3)"),
+    min_evidence_trips: int = typer.Option(
+        2, "--min-evidence-trips", help="Trips required for preference extraction (phase 3)"
+    ),
+    trip_idea: str = typer.Option("", "--trip-idea", help="Trip idea text (phase 4)"),
+    template_sheet_id: str = typer.Option("", "--template-sheet-id", help="Sheet template ID"),
+    max_emails: int = typer.Option(50, "--max-emails", help="Max emails to reconcile (phase 5)"),
+    trip_id: str = typer.Option("", "--trip-id", help="Trip ID for friction audit (phase 6)"),
+) -> None:
+    """Run one roadmap phase workflow and print structured output."""
+    from trippy.services.phase_planner import PhasePlannerService
+
+    if phase < 2 or phase > 6:
+        console.print("[red]Phase must be between 2 and 6.[/red]")
+        raise typer.Exit(1)
+
+    planner = PhasePlannerService()
+    result = planner.run_phase(
+        phase=phase,
+        folder_id=folder_id or None,
+        query=query,
+        max_sheets=max_sheets,
+        min_evidence_trips=min_evidence_trips,
+        trip_idea=trip_idea,
+        template_sheet_id=template_sheet_id or None,
+        max_emails=max_emails,
+        trip_id=trip_id or None,
+    )
+
+    if result.get("error"):
+        console.print(f"[red]{result['error']}[/red]")
+        raise typer.Exit(1)
+
+    console.print(JSON.from_data(result))
 
 
 # ---------------------------------------------------------------------------

--- a/trippy/services/phase_planner.py
+++ b/trippy/services/phase_planner.py
@@ -1,0 +1,200 @@
+"""Roadmap phase status checks + orchestration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(slots=True)
+class PhaseStatus:
+    phase: int
+    title: str
+    complete: bool
+    blockers: list[str]
+    next_step: str
+
+
+class PhasePlannerService:
+    """Determines readiness/completion of roadmap phases 2-6.
+
+    The checks are intentionally deterministic and lightweight, so teams can
+    quickly see what to do next without running a full agent session.
+    """
+
+    def __init__(self, memory_path: Path | None = None, trips_dir: Path | None = None) -> None:
+        from trippy import config
+
+        self._memory_path = memory_path or config.MEMORY_PATH
+        self._trips_dir = trips_dir or config.TRIPS_PATH
+
+    def status(self) -> list[PhaseStatus]:
+        from trippy import config
+        from trippy.memory.store import MemoryStore
+        from trippy.services.trip_state import TripStateService
+
+        memory = MemoryStore(self._memory_path)
+        trip_svc = TripStateService(self._trips_dir)
+        trips = trip_svc.load_all()
+
+        has_google_creds = (
+            config.GMAIL_CREDENTIALS_PATH.exists()
+            and (config.GMAIL_TOKEN_PATH.exists() or config.GOOGLE_TOKEN_PATH.exists())
+        )
+        has_trips = len(trips) > 0
+        has_preferences = memory.get_value("pref:preferences_object") is not None
+        has_sheeted_trip = any(bool(t.sync.google_sheet_id) for t in trips)
+        has_confirmation = any(bool(t.confirmations) for t in trips)
+        has_risks = any(bool(t.risk_flags) for t in trips)
+
+        phases: list[PhaseStatus] = []
+        phases.append(
+            PhaseStatus(
+                phase=2,
+                title="Live Google credentials",
+                complete=has_google_creds,
+                blockers=[] if has_google_creds else ["Missing Google credentials/token files"],
+                next_step="Run: trippy phase-run 2",
+            )
+        )
+        phases.append(
+            PhaseStatus(
+                phase=3,
+                title="Past trip mining + preference extraction",
+                complete=has_trips and has_preferences,
+                blockers=[
+                    *([] if has_trips else ["No canonical trips found in ~/.trippy/trips"]),
+                    *([] if has_preferences else ["No extracted preferences in memory store"]),
+                ],
+                next_step="Run: trippy phase-run 3 --folder-id <drive_folder_id>",
+            )
+        )
+        phases.append(
+            PhaseStatus(
+                phase=4,
+                title="New trip sheet generation",
+                complete=has_sheeted_trip,
+                blockers=[] if has_sheeted_trip else ["No trip linked to a Google Sheet yet"],
+                next_step='Run: trippy phase-run 4 --trip-idea "Japan March 2027"',
+            )
+        )
+        phases.append(
+            PhaseStatus(
+                phase=5,
+                title="Gmail reconciliation in production",
+                complete=has_confirmation,
+                blockers=[] if has_confirmation else ["No parsed confirmations linked to trips yet"],
+                next_step="Run: trippy phase-run 5 --max-emails 50",
+            )
+        )
+        phases.append(
+            PhaseStatus(
+                phase=6,
+                title="Friction audit + self-improving loop",
+                complete=has_risks,
+                blockers=[] if has_risks else ["No persisted friction/risk flags on trips yet"],
+                next_step="Run: trippy phase-run 6 --trip-id <trip_id>",
+            )
+        )
+        return phases
+
+    def run_phase(self, phase: int, **kwargs: Any) -> dict[str, Any]:
+        """Execute the main workflow for one roadmap phase."""
+        if phase == 2:
+            return self._run_phase_2()
+        if phase == 3:
+            return self._run_phase_3(**kwargs)
+        if phase == 4:
+            return self._run_phase_4(**kwargs)
+        if phase == 5:
+            return self._run_phase_5(**kwargs)
+        if phase == 6:
+            return self._run_phase_6(**kwargs)
+        return {"error": f"Unsupported phase: {phase}"}
+
+    def _run_phase_2(self) -> dict[str, Any]:
+        from trippy import config
+
+        return {
+            "phase": 2,
+            "credentials_path": str(config.GMAIL_CREDENTIALS_PATH),
+            "token_path": str(config.GMAIL_TOKEN_PATH),
+            "google_token_path": str(config.GOOGLE_TOKEN_PATH),
+            "credentials_exist": config.GMAIL_CREDENTIALS_PATH.exists(),
+            "token_exists": config.GMAIL_TOKEN_PATH.exists() or config.GOOGLE_TOKEN_PATH.exists(),
+        }
+
+    def _run_phase_3(self, **kwargs: Any) -> dict[str, Any]:
+        from trippy.skills.runners.past_trip_miner import PastTripMinerRunner
+        from trippy.skills.runners.preference_extractor import PreferenceExtractorRunner
+
+        miner = PastTripMinerRunner()
+        mined = miner.run(
+            {
+                "folder_id": kwargs.get("folder_id"),
+                "query": kwargs.get("query", "trip"),
+                "max_sheets": kwargs.get("max_sheets", 50),
+            }
+        )
+        extractor = PreferenceExtractorRunner()
+        extracted = extractor.run(
+            {
+                "trip_ids": mined.get("trip_ids") or None,
+                "min_evidence_trips": kwargs.get("min_evidence_trips", 2),
+            }
+        )
+        return {"phase": 3, "mined": mined, "extracted": extracted}
+
+    def _run_phase_4(self, **kwargs: Any) -> dict[str, Any]:
+        from trippy.skills.runners.trip_sheet_creator import TripSheetCreatorRunner
+
+        runner = TripSheetCreatorRunner()
+        result = runner.run(
+            {
+                "trip_idea": kwargs.get("trip_idea", ""),
+                "folder_id": kwargs.get("folder_id"),
+                "template_sheet_id": kwargs.get("template_sheet_id"),
+            }
+        )
+        return {"phase": 4, "created": result}
+
+    def _run_phase_5(self, **kwargs: Any) -> dict[str, Any]:
+        from trippy.skills.runners.gmail_reconciler import GmailReconcilerRunner
+
+        runner = GmailReconcilerRunner()
+        result = runner.run({"max_emails": kwargs.get("max_emails", 50)})
+        return {"phase": 5, "reconciled": result}
+
+    def _run_phase_6(self, **kwargs: Any) -> dict[str, Any]:
+        from trippy import config
+        from trippy.memory.store import MemoryStore
+        from trippy.services.trip_state import TripStateService
+        from trippy.skills.runners.friction_audit import FrictionAuditRunner
+
+        trip_id = kwargs.get("trip_id")
+        if not trip_id:
+            trip_svc = TripStateService(self._trips_dir)
+            active = trip_svc.find_active()
+            trip_id = active[0].trip_id if active else ""
+            if not trip_id:
+                return {"phase": 6, "error": "No active trips found to audit"}
+
+        runner = FrictionAuditRunner()
+        audit_result = runner.run({"trip_id": trip_id, "check_preferences": True})
+
+        # Minimal self-improvement loop: store a reusable hint when high/critical
+        critical = int(audit_result.get("critical", 0))
+        high = int(audit_result.get("high", 0))
+        if critical > 0 or high > 0:
+            memory = MemoryStore(config.MEMORY_PATH)
+            memory.set(
+                key="hint:always-run-friction-audit-after-reconcile",
+                value=True,
+                category="skill_hint",
+                confidence=0.8,
+                source="phase-runner",
+                notes="High/critical risk found; enforce post-reconcile friction audit.",
+            )
+
+        return {"phase": 6, "audit": audit_result}


### PR DESCRIPTION
### Motivation
- Make the documented roadmap actionable from the repo by providing deterministic checks for readiness and a small orchestration surface to run each roadmap phase (2–6) without requiring a full interactive agent session.
- Surface clear blockers and the next actionable step so maintainers can quickly see what is missing to move the system from the Hermes-native foundation to live Google integration and higher-level workflows.

### Description
- Add `PhasePlannerService` (`trippy/services/phase_planner.py`) which computes phase `status()` (checks for Google credentials, canonical trips, extracted preferences, sheet links, confirmations, and persisted risk flags) and exposes `run_phase()` to execute phase workflows 2–6.
- Implement deterministic phase runners that wire into existing skill runners and services: Phase 3 runs the past-trip miner + preference extractor, Phase 4 runs the trip sheet creator, Phase 5 runs the Gmail reconciler, and Phase 6 runs the friction audit and writes a small `skill_hint` to memory when high/critical risks are found.
- Add CLI commands `trippy phase-status` and `trippy phase-run` (with options like `--folder-id`, `--trip-idea`, `--trip-id`, etc.) in `trippy/cli.py` so roadmap phases can be inspected and executed from the command line.
- Add unit tests `tests/unit/test_phase_planner.py` covering status detection and `run_phase(2)` behavior, and update `README.md` with usage examples for `phase-status` and `phase-run`.

### Testing
- Ran linting with `uv run ruff check trippy/cli.py trippy/services/phase_planner.py tests/unit/test_phase_planner.py README.md` and the checks passed.
- Ran unit tests with `uv run pytest tests/unit/test_phase_planner.py -q` and all 4 tests passed.
- Verified runtime output by running `uv run trippy phase-status` to ensure the CLI prints the roadmap table and next actionable phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61c6b7e1c832f8c6873cb381556d8)