### PR TITLE
Sync Gmail confirmations into canonical trip state and trigger sheet sync

### DIFF
--- a/tests/integration/test_ingest.py
+++ b/tests/integration/test_ingest.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy import create_engine, select
 
 from trippy.db.models import Base, Confirmation, Leg, Stay, Trip
+from trippy.models.trip import Segment, SegmentType, SyncMetadata
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 EMAILS_DIR = FIXTURES_DIR / "emails"
@@ -226,3 +227,107 @@ class TestUnlinkedConfirmation:
             ).fetchall()
         engine.dispose()
         assert len(rows) >= 1
+
+
+class TestGmailReconcilerCanonicalSync:
+    def test_runner_updates_canonical_and_pushes_sheet(
+        self, file_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_trip(file_db)
+
+        from trippy import config
+        from trippy.ingest.gmail_watcher import EmailContent
+        from trippy.models.trip import Trip as CanonicalTrip
+        from trippy.models.trip import TripStatus
+        from trippy.services.trip_state import TripStateService
+        from trippy.skills.runners.gmail_reconciler import GmailReconcilerRunner
+
+        trips_dir = tmp_path / "trips"
+        vault_dir = tmp_path / "vault"
+        monkeypatch.setattr(config, "DATABASE_URL", file_db)
+        monkeypatch.setattr(config, "TRIPS_PATH", trips_dir)
+        monkeypatch.setattr(config, "VAULT_PATH", vault_dir)
+
+        trip_state = TripStateService(trips_dir=trips_dir)
+        canonical_trip = CanonicalTrip(
+            trip_id="japan-2026",
+            name="Japan 2026",
+            status=TripStatus.BOOKED,
+            sync=SyncMetadata(google_sheet_id="sheet-abc-123"),
+            segments=[
+                Segment(
+                    segment_id="leg-1",
+                    segment_type=SegmentType.FLIGHT,
+                    carrier="Air Canada",
+                    flight_number="AC003",
+                    origin="YYZ",
+                    destination="NRT",
+                )
+            ],
+        )
+        trip_state.save(canonical_trip)
+
+        email_text = (EMAILS_DIR / "aircanada_flight.txt").read_text()
+        fixture_email = EmailContent(
+            message_id="m-1",
+            sender="bookings@aircanada.com",
+            subject="Your Air Canada booking confirmation",
+            date=canonical_trip.created_at,
+            body_text=email_text,
+            body_html="",
+            attachments=[],
+            raw_bytes=b"raw-email",
+        )
+
+        class FakeWatcher:
+            def __init__(self, auth_manager: object | None = None) -> None:
+                self._auth_manager = auth_manager
+
+            def authenticate(self) -> None:
+                return None
+
+            def fetch_new_messages(self, max_results: int = 50) -> list[EmailContent]:
+                return [fixture_email]
+
+            def save_to_vault(self, email_content: EmailContent, vault_path: Path) -> Path:
+                vault_path.mkdir(parents=True, exist_ok=True)
+                p = vault_path / "email-1.eml"
+                p.write_bytes(email_content.raw_bytes)
+                return p
+
+        pushes: list[tuple[str, str]] = []
+
+        class FakeSheetSyncService:
+            def __init__(self, auth_manager: object | None = None) -> None:
+                self._auth_manager = auth_manager
+
+            def push_trip_to_sheet(self, trip: CanonicalTrip, sheet_id: str) -> None:
+                pushes.append((trip.trip_id, sheet_id))
+
+        class FakeAuthManager:
+            pass
+
+        from trippy.ingest import gmail_watcher as watcher_mod
+        from trippy.ingest import google_auth as google_auth_mod
+        from trippy.services import sheet_sync as sheet_sync_mod
+
+        monkeypatch.setattr(watcher_mod, "GmailWatcher", FakeWatcher)
+        monkeypatch.setattr(google_auth_mod, "GoogleAuthManager", FakeAuthManager)
+        monkeypatch.setattr(sheet_sync_mod, "SheetSyncService", FakeSheetSyncService)
+
+        runner = GmailReconcilerRunner(
+            trips_dir=trips_dir,
+            anthropic_client=_make_parser_client("aircanada_flight"),
+        )
+        result = runner.run({"max_emails": 5})
+
+        updated = trip_state.load("japan-2026")
+        assert updated is not None
+        assert result["confirmations_linked"] == 1
+        assert result["confirmations_unlinked"] == 0
+        assert len(updated.confirmations) == 1
+        assert updated.confirmations[0].confirmation_code == "ABC123"
+        assert updated.confirmations[0].linked_segment_id == "leg-1"
+        assert updated.segments[0].confirmation_code == "ABC123"
+        assert pushes == [("japan-2026", "sheet-abc-123")]
+        assert result["ambiguities"] == []

--- a/trippy/skills/runners/gmail_reconciler.py
+++ b/trippy/skills/runners/gmail_reconciler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -25,10 +26,13 @@ class GmailReconcilerRunner:
     def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
         from trippy import config
         from trippy.db import make_session_factory
+        from trippy.db.models import Trip as DbTrip
         from trippy.ingest.gmail_watcher import GmailWatcher
         from trippy.ingest.google_auth import GoogleAuthManager
         from trippy.ingest.linker import ingest_email
         from trippy.ingest.parser import ConfirmationParser
+        from trippy.services.sheet_sync import SheetSyncService
+        from trippy.services.trip_state import TripStateService
 
         max_emails: int = inputs.get("max_emails", 50)
 
@@ -49,6 +53,9 @@ class GmailReconcilerRunner:
         unlinked: list[dict[str, Any]] = []
 
         vault_path = config.VAULT_PATH
+        trip_state = TripStateService(trips_dir=self._trips_dir)
+        sheet_sync = SheetSyncService(auth_manager=auth)
+        ambiguities: list[dict[str, Any]] = []
 
         for email_content in emails:
             eml_path = watcher.save_to_vault(email_content, vault_path)
@@ -67,19 +74,61 @@ class GmailReconcilerRunner:
             conf = parse_result.confirmation
             with factory() as session:
                 link = ingest_email(conf, session, raw_email_path=str(eml_path))
+                db_trip = session.get(DbTrip, link.trip_id) if link.trip_id is not None else None
 
             if link.linked:
                 linked_count += 1
+                if db_trip is None:
+                    ambiguities.append(
+                        {
+                            "type": "linked_trip_missing",
+                            "confirmation_code": conf.confirmation_code,
+                            "vendor": conf.vendor,
+                            "trip_db_id": link.trip_id,
+                            "reason": "Linked trip ID not found in SQL state",
+                        }
+                    )
+                    continue
+
+                trip = trip_state.load(db_trip.name.lower().replace(" ", "-"))
+                if trip is None:
+                    trip = trip_state.from_db_trip(db_trip)
+
+                canonical_confirmation = _to_canonical_confirmation(
+                    confirmation=conf,
+                    subject=email_content.subject,
+                    eml_path=eml_path,
+                )
+                match_info = _attach_confirmation_to_trip(trip, canonical_confirmation, conf)
+                trip_state.save(trip)
+
+                if trip.sync.google_sheet_id:
+                    sheet_sync.push_trip_to_sheet(trip, trip.sync.google_sheet_id)
+
                 updates.append(
                     {
                         "trip_id": link.trip_id,
+                        "trip_canonical_id": trip.trip_id,
                         "confirmation_code": conf.confirmation_code,
                         "vendor": conf.vendor,
                         "method": link.method,
+                        "linked_segment_id": match_info.get("linked_segment_id"),
+                        "linked_stay_id": match_info.get("linked_stay_id"),
                     }
                 )
+                if match_info["ambiguity"] is not None:
+                    ambiguities.append(match_info["ambiguity"])
             else:
                 unlinked_count += 1
+                ambiguity = {
+                    "type": "unlinked_confirmation",
+                    "vendor": conf.vendor,
+                    "code": conf.confirmation_code,
+                    "confirmation_type": conf.confirmation_type,
+                    "reason": "No matching trip found",
+                    "email_subject": email_content.subject,
+                }
+                ambiguities.append(ambiguity)
                 unlinked.append(
                     {
                         "vendor": conf.vendor,
@@ -97,4 +146,98 @@ class GmailReconcilerRunner:
             "parse_failures": failed_count,
             "updates": updates,
             "unlinked": unlinked,
+            "ambiguities": ambiguities,
         }
+
+
+def _to_canonical_confirmation(confirmation: Any, subject: str, eml_path: Path) -> Any:
+    from trippy.models.trip import Confirmation, ConfirmationType
+
+    return Confirmation(
+        confirmation_id=f"{confirmation.vendor}-{confirmation.confirmation_code}-{int(datetime.utcnow().timestamp())}",
+        confirmation_type=ConfirmationType(confirmation.confirmation_type),
+        confirmation_code=confirmation.confirmation_code,
+        vendor=confirmation.vendor,
+        raw_email_subject=subject,
+        raw_email_path=str(eml_path),
+        received_at=datetime.utcnow(),
+        parsed_at=datetime.utcnow(),
+        extracted_data=confirmation.model_dump(),
+    )
+
+
+def _attach_confirmation_to_trip(trip: Any, canonical_confirmation: Any, parsed: Any) -> dict[str, Any]:
+    """Attach confirmation to canonical trip and enrich a matching segment/stay."""
+    trip.confirmations.append(canonical_confirmation)
+
+    ambiguity: dict[str, Any] | None = None
+    linked_segment_id: str | None = None
+    linked_stay_id: str | None = None
+
+    if parsed.confirmation_type == "flight":
+        for segment in trip.segments:
+            if segment.segment_type.value != "flight":
+                continue
+            if (
+                parsed.origin
+                and parsed.destination
+                and segment.origin.upper() == parsed.origin.upper()
+                and segment.destination.upper() == parsed.destination.upper()
+            ) or (
+                parsed.flight_number
+                and segment.flight_number
+                and segment.flight_number.upper() == parsed.flight_number.upper()
+            ):
+                segment.confirmation_code = parsed.confirmation_code
+                segment.carrier = parsed.vendor or segment.carrier
+                if parsed.depart_at:
+                    segment.depart_at = datetime.fromisoformat(parsed.depart_at)
+                if parsed.arrive_at:
+                    segment.arrive_at = datetime.fromisoformat(parsed.arrive_at)
+                linked_segment_id = segment.segment_id
+                canonical_confirmation.linked_segment_id = segment.segment_id
+                break
+
+        if linked_segment_id is None:
+            ambiguity = {
+                "type": "segment_unresolved",
+                "trip_id": trip.trip_id,
+                "confirmation_code": parsed.confirmation_code,
+                "vendor": parsed.vendor,
+                "reason": "Trip linked but no matching segment found",
+            }
+
+    elif parsed.confirmation_type in {"hotel", "rental"}:
+        for stay in trip.stays:
+            city_match = bool(parsed.city and stay.city.lower() == parsed.city.lower())
+            property_match = bool(
+                parsed.property_name and stay.property_name.lower() == parsed.property_name.lower()
+            )
+            date_match = bool(
+                parsed.check_in and stay.check_in and stay.check_in.isoformat() == parsed.check_in[:10]
+            )
+            if city_match or property_match or date_match:
+                stay.confirmation_code = parsed.confirmation_code
+                stay.property_name = parsed.property_name or stay.property_name
+                if parsed.city:
+                    stay.city = parsed.city
+                if parsed.country:
+                    stay.country = parsed.country
+                linked_stay_id = stay.stay_id
+                canonical_confirmation.linked_stay_id = stay.stay_id
+                break
+
+        if linked_stay_id is None:
+            ambiguity = {
+                "type": "stay_unresolved",
+                "trip_id": trip.trip_id,
+                "confirmation_code": parsed.confirmation_code,
+                "vendor": parsed.vendor,
+                "reason": "Trip linked but no matching stay found",
+            }
+
+    return {
+        "linked_segment_id": linked_segment_id,
+        "linked_stay_id": linked_stay_id,
+        "ambiguity": ambiguity,
+    }


### PR DESCRIPTION
### Motivation

- Keep the canonical JSON trip state in sync with SQL confirmation links so parsed booking confirmations update the user-facing trip record and Google Sheet automatically.
- Surface structured ambiguity objects for unresolved matches so downstream UIs/workflows can surface human review items.

### Description

- Extend `GmailReconcilerRunner.run()` to load the matched SQL trip, convert/load the canonical trip via `TripStateService`, append a canonical `Confirmation` to `trip.confirmations`, and persist the canonical JSON with `TripStateService.save()`.
- Enrich the matching segment or stay in the canonical trip with confirmation metadata (confirmation code, carrier/property, and ISO times) and set `linked_segment_id` / `linked_stay_id` on the canonical confirmation when a match is found.
- Trigger `SheetSyncService.push_trip_to_sheet(trip, trip.sync.google_sheet_id)` when the canonical trip has a `google_sheet_id`, and emit a structured `ambiguities` list for cases like unlinked confirmations, missing DB trip, or linked trip but no matching segment/stay.
- Add helper functions `_to_canonical_confirmation()` and `_attach_confirmation_to_trip()` and extend the runner output updates with `trip_canonical_id`, `linked_segment_id`, `linked_stay_id`; include an integration test `TestGmailReconcilerCanonicalSync::test_runner_updates_canonical_and_pushes_sheet` that mocks watcher/auth/sheet sync and validates the end-to-end path.

### Testing

- Ran `python -m ruff check trippy/skills/runners/gmail_reconciler.py tests/integration/test_ingest.py` and fixed import ordering issues reported by ruff.
- Ran `pytest -q tests/integration/test_ingest.py::TestGmailReconcilerCanonicalSync::test_runner_updates_canonical_and_pushes_sheet` which passed.
- Ran the full integration file with `pytest -q tests/integration/test_ingest.py` (7 tests) and all tests passed.
- Installed project dependencies with `python -m pip install -q '.[dev]'` successfully (non-blocking pip warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6350ea3bc832fb7398a4b4328f3ee)