### PR TITLE
Add operational Segment/Stay fields and Transfer model with backwards compatibility

### DIFF
--- a/tests/unit/test_canonical_models.py
+++ b/tests/unit/test_canonical_models.py
@@ -19,6 +19,7 @@ from trippy.models.trip import (
     Segment,
     SegmentType,
     Stay,
+    Transfer,
     Traveler,
     Trip,
     TripStatus,
@@ -143,6 +144,25 @@ class TestSegment:
         seg = Segment(segment_id="s1", origin="YYZ", destination="NRT")
         assert not seg.is_confirmed
 
+    def test_operational_fields(self) -> None:
+        seg = Segment(
+            segment_id="s1",
+            origin="YYZ",
+            destination="NRT",
+            terminal_depart="1",
+            gate_depart="E77",
+            terminal_arrive="2",
+            gate_arrive="22",
+            boarding_time=datetime(2026, 3, 10, 8, 15),
+            boarding_group="3",
+            seat_map_url="https://example.com/seat-map",
+            baggage_claim_belt="B12",
+            pnr="PNR123",
+        )
+        assert seg.terminal_depart == "1"
+        assert seg.gate_arrive == "22"
+        assert seg.pnr == "PNR123"
+
 
 class TestStay:
     def test_nights(self) -> None:
@@ -165,6 +185,77 @@ class TestStay:
             confirmation_code="HT-12345",
         )
         assert stay.is_confirmed
+
+    def test_operational_fields(self) -> None:
+        stay = Stay(
+            stay_id="stay-1",
+            property_name="Family Apartment",
+            city="Tokyo",
+            country="Japan",
+            host_name="Aiko",
+            host_contact="+81-111-2222",
+            access_code="7788#",
+            check_in_instructions="Use side entrance after 10pm",
+            wifi_name="Apt-Wifi",
+            wifi_password="secret-pass",
+            parking_instructions="Level P2 spot 15",
+            late_checkin_confirmed=True,
+            late_checkin_notes="Host approved in-app",
+        )
+        assert stay.host_name == "Aiko"
+        assert stay.late_checkin_confirmed is True
+
+
+class TestTransfer:
+    def test_transfer_fields(self) -> None:
+        transfer = Transfer(
+            transfer_id="t1",
+            provider="Klook",
+            driver_contact="WhatsApp +81-123",
+            pickup_point="NRT Terminal 1 Exit C",
+            pickup_window="18:00-18:30",
+            vehicle_details="Toyota Alphard, black",
+        )
+        assert transfer.provider == "Klook"
+        assert transfer.pickup_window == "18:00-18:30"
+
+
+class TestBackwardsCompatibility:
+    def test_existing_json_loads_with_defaults(self) -> None:
+        legacy_payload = {
+            "trip_id": "legacy-trip",
+            "name": "Legacy Trip",
+            "segments": [{"segment_id": "s1", "origin": "YYZ", "destination": "NRT"}],
+            "stays": [
+                {
+                    "stay_id": "stay-1",
+                    "property_name": "Old Hotel",
+                    "city": "Tokyo",
+                    "country": "Japan",
+                }
+            ],
+        }
+        trip = Trip.model_validate(legacy_payload)
+        assert trip.transfers == []
+        assert trip.segments[0].terminal_depart is None
+        assert trip.stays[0].late_checkin_confirmed is False
+
+    def test_legacy_import_aliases_are_migrated(self) -> None:
+        legacy_payload = {
+            "name": "Alias Trip",
+            "legs": [{"segment_id": "s1", "origin": "YYZ", "destination": "YVR"}],
+            "hotels": [
+                {
+                    "stay_id": "stay-1",
+                    "property_name": "Alias Hotel",
+                    "city": "Vancouver",
+                    "country": "Canada",
+                }
+            ],
+        }
+        trip = Trip.model_validate(legacy_payload)
+        assert len(trip.segments) == 1
+        assert len(trip.stays) == 1
 
 
 class TestBudget:

--- a/trippy/models/trip.py
+++ b/trippy/models/trip.py
@@ -103,6 +103,15 @@ class Segment(BaseModel):
     seat_assignments: dict[str, str] = Field(default_factory=dict)  # traveler → seat
     baggage_included: bool | None = None
     check_in_opens_at: datetime | None = None
+    terminal_depart: str | None = None
+    terminal_arrive: str | None = None
+    gate_depart: str | None = None
+    gate_arrive: str | None = None
+    boarding_time: datetime | None = None
+    boarding_group: str | None = None
+    seat_map_url: str | None = None
+    baggage_claim_belt: str | None = None
+    pnr: str | None = None
     notes: str | None = None
 
     @property
@@ -138,7 +147,25 @@ class Stay(BaseModel):
     confirmation_code: str | None = None
     num_rooms: int | None = None
     room_type: str | None = None
+    host_name: str | None = None
+    host_contact: str | None = None
+    access_code: str | None = None
+    check_in_instructions: str | None = None
+    wifi_name: str | None = None
+    wifi_password: str | None = None
+    parking_instructions: str | None = None
+    late_checkin_confirmed: bool = False
+    late_checkin_notes: str | None = None
     notes: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_defaults(cls, values: dict[str, Any] | Any) -> dict[str, Any] | Any:
+        if not isinstance(values, dict):
+            return values
+        if values.get("late_checkin_confirmed") is None:
+            values["late_checkin_confirmed"] = False
+        return values
 
     @property
     def nights(self) -> int | None:
@@ -174,6 +201,21 @@ class Confirmation(BaseModel):
     @property
     def is_linked(self) -> bool:
         return bool(self.linked_segment_id or self.linked_stay_id)
+
+
+# ---------------------------------------------------------------------------
+# Transfer (airport pickup/drop logistics)
+# ---------------------------------------------------------------------------
+
+
+class Transfer(BaseModel):
+    transfer_id: str
+    provider: str | None = None
+    driver_contact: str | None = None
+    pickup_point: str | None = None
+    pickup_window: str | None = None
+    vehicle_details: str | None = None
+    notes: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +306,7 @@ class Trip(BaseModel):
     travelers: list[Traveler] = Field(default_factory=list)
     segments: list[Segment] = Field(default_factory=list)
     stays: list[Stay] = Field(default_factory=list)
+    transfers: list[Transfer] = Field(default_factory=list)
     confirmations: list[Confirmation] = Field(default_factory=list)
     risk_flags: list[RiskFlag] = Field(default_factory=list)
     checklist: list[ChecklistItem] = Field(default_factory=list)
@@ -276,6 +319,12 @@ class Trip(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _auto_trip_id(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if values.get("segments") is None and values.get("legs") is not None:
+            values["segments"] = values.pop("legs")
+        if values.get("stays") is None and values.get("hotels") is not None:
+            values["stays"] = values.pop("hotels")
+        if values.get("transfers") is None:
+            values["transfers"] = []
         if not values.get("trip_id") and values.get("name"):
             values["trip_id"] = _make_trip_id(str(values["name"]))
         return values

--- a/trippy/services/sheet_sync.py
+++ b/trippy/services/sheet_sync.py
@@ -48,6 +48,15 @@ _HOTELS_COLS = [
 ]
 _CHECKLIST_COLS = ["ID", "Category", "Task", "Due", "Assigned", "Done"]
 _BUDGET_COLS = ["Category", "Budgeted", "Booked", "Actual", "Variance"]
+_TRANSFERS_COLS = [
+    "Transfer ID",
+    "Provider",
+    "Driver Contact",
+    "Pickup Point",
+    "Pickup Window",
+    "Vehicle Details",
+    "Notes",
+]
 
 
 class SheetSyncService:
@@ -87,7 +96,14 @@ class SheetSyncService:
                         "properties": {"title": title},
                         "sheets": [
                             {"properties": {"title": tab}}
-                            for tab in ["Overview", "Flights", "Hotels", "Checklist", "Budget"]
+                            for tab in [
+                                "Overview",
+                                "Flights",
+                                "Hotels",
+                                "Transfers",
+                                "Checklist",
+                                "Budget",
+                            ]
                         ],
                     }
                 )
@@ -149,6 +165,7 @@ class SheetSyncService:
         updates.extend(self._build_overview_update(trip))
         updates.extend(self._build_flights_update(trip))
         updates.extend(self._build_hotels_update(trip))
+        updates.extend(self._build_transfers_update(trip))
         updates.extend(self._build_checklist_update(trip))
         updates.extend(self._build_budget_update(trip))
 
@@ -241,6 +258,24 @@ class SheetSyncService:
             )
         if len(rows) > 1:
             return [{"range": "Checklist!A1", "values": rows}]
+        return []
+
+    def _build_transfers_update(self, trip: Trip) -> list[dict[str, Any]]:
+        rows: list[list[Any]] = [_TRANSFERS_COLS]
+        for transfer in trip.transfers:
+            rows.append(
+                [
+                    transfer.transfer_id,
+                    transfer.provider or "",
+                    transfer.driver_contact or "",
+                    transfer.pickup_point or "",
+                    transfer.pickup_window or "",
+                    transfer.vehicle_details or "",
+                    transfer.notes or "",
+                ]
+            )
+        if len(rows) > 1:
+            return [{"range": "Transfers!A1", "values": rows}]
         return []
 
     def _build_budget_update(self, trip: Trip) -> list[dict[str, Any]]:

--- a/trippy/services/trip_state.py
+++ b/trippy/services/trip_state.py
@@ -129,6 +129,7 @@ class TripStateService:
             SegmentType,
             Stay,
             StayType,
+            Transfer,
             Traveler,
             TripStatus,
         )
@@ -177,6 +178,19 @@ class TripStateService:
             for i, stay in enumerate(getattr(db_trip, "stays", []))
         ]
 
+        transfers = [
+            Transfer(
+                transfer_id=f"transfer-{i + 1}",
+                provider=getattr(transfer, "provider", None),
+                driver_contact=getattr(transfer, "driver_contact", None),
+                pickup_point=getattr(transfer, "pickup_point", None),
+                pickup_window=getattr(transfer, "pickup_window", None),
+                vehicle_details=getattr(transfer, "vehicle_details", None),
+                notes=getattr(transfer, "notes", None),
+            )
+            for i, transfer in enumerate(getattr(db_trip, "transfers", []))
+        ]
+
         return Trip(
             trip_id=db_trip.name.lower().replace(" ", "-"),
             name=db_trip.name,
@@ -187,6 +201,7 @@ class TripStateService:
             travelers=travelers,
             segments=segments,
             stays=stays,
+            transfers=transfers,
             notes=db_trip.notes,
             created_at=db_trip.created_at,
             updated_at=db_trip.updated_at,


### PR DESCRIPTION
### Motivation
- Capture real-world operational details for flights and stays so the agent can surface boarding/gate/host/access info. 
- Represent airport pickup/drop logistics as first-class canonical objects for reconciliation and sheet sync. 
- Preserve backwards compatibility so existing canonical JSON and DB imports continue to load without breaking.

### Description
- Extended `Segment` with operational fields: `terminal_depart`, `terminal_arrive`, `gate_depart`, `gate_arrive`, `boarding_time`, `boarding_group`, `seat_map_url`, `baggage_claim_belt`, and `pnr` (file: `trippy/models/trip.py`).
- Extended `Stay` with operational fields: `host_name`, `host_contact`, `access_code`, `check_in_instructions`, `wifi_name`, `wifi_password`, `parking_instructions`, `late_checkin_confirmed`, and `late_checkin_notes`, plus a `@model_validator` to default `late_checkin_confirmed` safely (file: `trippy/models/trip.py`).
- Added a new `Transfer` model for airport pickup/drop logistics and wired `Trip.transfers: list[Transfer]` into the root `Trip` model (file: `trippy/models/trip.py`).
- Added migration logic in `Trip` validator to support legacy payload shapes by mapping `legs` → `segments`, `hotels` → `stays`, and defaulting missing `transfers` to an empty list (file: `trippy/models/trip.py`).
- Updated sheet sync to create/write a `Transfers` tab and added `_build_transfers_update` to push transfers to Google Sheets (file: `trippy/services/sheet_sync.py`).
- Updated DB-import mapping to convert DB transfer rows into canonical `Transfer` objects when present (file: `trippy/services/trip_state.py`).
- Added unit tests in `tests/unit/test_canonical_models.py` covering new `Segment` and `Stay` operational fields, the new `Transfer` model, and backwards-compatibility behavior for legacy JSON and alias migration.

### Testing
- Added unit tests under `tests/unit/test_canonical_models.py` and ran static compilation with `python -m compileall trippy/models/trip.py trippy/services/trip_state.py trippy/services/sheet_sync.py tests/unit/test_canonical_models.py`, which completed successfully. 
- Attempted to run `pytest -q tests/unit/test_canonical_models.py`, but the run failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'sqlalchemy'` reported from `tests/conftest.py`).
- The new tests validate model construction, operational field presence, and migration behavior when loading legacy payload shapes (see added tests in `tests/unit/test_canonical_models.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6350a4010832f874fc79d76a9c5e2)