### PR TITLE
Add deterministic sheet roundtrip sync with per-cell timestamps and conflict tracking

### DIFF
--- a/tests/fixtures/sample_sheets/sheet_edit_conflict.json
+++ b/tests/fixtures/sample_sheets/sheet_edit_conflict.json
@@ -1,0 +1,12 @@
+{
+  "overview": {},
+  "flights": [
+    {
+      "Segment ID": "seg-1",
+      "Carrier": "Old Carrier"
+    }
+  ],
+  "hotels": [],
+  "checklist": [],
+  "budget": []
+}

--- a/tests/fixtures/sample_sheets/sheet_edit_human_updates.json
+++ b/tests/fixtures/sample_sheets/sheet_edit_human_updates.json
@@ -1,0 +1,28 @@
+{
+  "overview": {
+    "Trip Name": "Japan 2027 Updated",
+    "Destinations": "Tokyo, Kyoto"
+  },
+  "flights": [
+    {
+      "Segment ID": "seg-1",
+      "Carrier": "Air Canada",
+      "Confirmation": "AC-NEW123",
+      "Notes": "Seat preference captured"
+    }
+  ],
+  "hotels": [
+    {
+      "Stay ID": "stay-1",
+      "Confirmation": "HOTEL-123",
+      "Notes": "Early check-in requested"
+    }
+  ],
+  "checklist": [
+    {
+      "ID": "chk-1",
+      "Done": "Yes"
+    }
+  ],
+  "budget": []
+}

--- a/tests/integration/test_sheet_sync_roundtrip.py
+++ b/tests/integration/test_sheet_sync_roundtrip.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from trippy.models.trip import (
+    ChecklistItem,
+    Segment,
+    SegmentType,
+    Stay,
+    StayType,
+    Traveler,
+    Trip,
+)
+from trippy.services.sheet_sync import SheetSyncService
+from trippy.services.trip_state import TripStateService
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "sample_sheets"
+
+
+class _FakeValues:
+    def __init__(self, pulls: dict[str, list[list[str]]]) -> None:
+        self._pulls = pulls
+        self.batch_updates: list[dict[str, object]] = []
+
+    def get(self, spreadsheetId: str, range: str):  # noqa: N803
+        values = self._pulls.get(range, [])
+
+        class _Call:
+            def execute(self_nonlocal) -> dict[str, list[list[str]]]:
+                return {"values": values}
+
+        return _Call()
+
+    def batchUpdate(self, spreadsheetId: str, body: dict[str, object]):  # noqa: N803
+        self.batch_updates.append({"spreadsheetId": spreadsheetId, "body": body})
+
+        class _Call:
+            def execute(self_nonlocal) -> dict[str, object]:
+                return {"updated": True}
+
+        return _Call()
+
+
+class _FakeSpreadsheets:
+    def __init__(self, values: _FakeValues) -> None:
+        self._values = values
+
+    def values(self) -> _FakeValues:
+        return self._values
+
+
+class _FakeSheetsService:
+    def __init__(self, values: _FakeValues) -> None:
+        self._spreadsheets = _FakeSpreadsheets(values)
+
+    def spreadsheets(self) -> _FakeSpreadsheets:
+        return self._spreadsheets
+
+
+class _FakeAuth:
+    def __init__(self, pulls: dict[str, list[list[str]]]) -> None:
+        self.values = _FakeValues(pulls)
+
+    def build_service(self, name: str, version: str) -> _FakeSheetsService:  # noqa: ARG002
+        return _FakeSheetsService(self.values)
+
+
+def _seed_trip() -> Trip:
+    return Trip(
+        trip_id="japan-2027",
+        name="Japan 2027",
+        destination_summary="Tokyo",
+        travelers=[Traveler(name="Ken"), Traveler(name="Sue")],
+        segments=[
+            Segment(
+                segment_id="seg-1",
+                segment_type=SegmentType.FLIGHT,
+                origin="YYZ",
+                destination="NRT",
+                carrier="Original Carrier",
+                confirmation_code="OLD-CODE",
+            )
+        ],
+        stays=[
+            Stay(
+                stay_id="stay-1",
+                stay_type=StayType.HOTEL,
+                property_name="Hotel A",
+                city="Tokyo",
+                country="Japan",
+                confirmation_code="OLD-HOTEL",
+            )
+        ],
+        checklist=[ChecklistItem(item_id="chk-1", category="booking", title="Check passports")],
+    )
+
+
+def _pulls_from_fixture(path: Path) -> dict[str, list[list[str]]]:
+    payload = json.loads(path.read_text())
+
+    overview_rows = [["Field", "Value"]] + [[k, v] for k, v in payload.get("overview", {}).items()]
+
+    flight_rows = [
+        [
+            "Segment ID",
+            "Type",
+            "Carrier",
+            "Flight #",
+            "From",
+            "To",
+            "Departs",
+            "Arrives",
+            "Cabin",
+            "Cost (CAD)",
+            "Confirmation",
+            "Notes",
+        ]
+    ]
+    for row in payload.get("flights", []):
+        flight_rows.append(
+            [
+                row.get("Segment ID", ""),
+                row.get("Type", ""),
+                row.get("Carrier", ""),
+                row.get("Flight #", ""),
+                row.get("From", ""),
+                row.get("To", ""),
+                row.get("Departs", ""),
+                row.get("Arrives", ""),
+                row.get("Cabin", ""),
+                row.get("Cost (CAD)", ""),
+                row.get("Confirmation", ""),
+                row.get("Notes", ""),
+            ]
+        )
+
+    hotel_rows = [["Stay ID", "Type", "Property", "City", "Country", "Check-in", "Check-out", "Nights", "Cost (CAD)", "Confirmation", "Notes"]]
+    for row in payload.get("hotels", []):
+        hotel_rows.append(
+            [
+                row.get("Stay ID", ""),
+                row.get("Type", ""),
+                row.get("Property", ""),
+                row.get("City", ""),
+                row.get("Country", ""),
+                row.get("Check-in", ""),
+                row.get("Check-out", ""),
+                row.get("Nights", ""),
+                row.get("Cost (CAD)", ""),
+                row.get("Confirmation", ""),
+                row.get("Notes", ""),
+            ]
+        )
+
+    checklist_rows = [["ID", "Category", "Task", "Due", "Assigned", "Done"]]
+    for row in payload.get("checklist", []):
+        checklist_rows.append(
+            [
+                row.get("ID", ""),
+                row.get("Category", ""),
+                row.get("Task", ""),
+                row.get("Due", ""),
+                row.get("Assigned", ""),
+                row.get("Done", ""),
+            ]
+        )
+
+    return {
+        "Overview!A:B": overview_rows,
+        "Flights!A:L": flight_rows,
+        "Hotels!A:L": hotel_rows,
+        "Checklist!A:F": checklist_rows,
+        "Budget!A:E": [["Category", "Budgeted", "Booked", "Actual", "Variance"]],
+    }
+
+
+def test_sync_roundtrip_human_edit_propagates_to_json(tmp_path: Path) -> None:
+    state = TripStateService(trips_dir=tmp_path)
+    trip = _seed_trip()
+    trip.sync.google_sheet_id = "sheet-123"
+    state.save(trip)
+
+    pulls = _pulls_from_fixture(FIXTURES / "sheet_edit_human_updates.json")
+    auth = _FakeAuth(pulls)
+    sync = SheetSyncService(auth_manager=auth, state_service=state)
+
+    merged = sync.sync_roundtrip("japan-2027")
+
+    assert merged.name == "Japan 2027 Updated"
+    assert merged.destination_summary == "Tokyo, Kyoto"
+    assert merged.get_segment("seg-1") is not None
+    assert merged.get_segment("seg-1").confirmation_code == "AC-NEW123"  # type: ignore[union-attr]
+    assert merged.get_stay("stay-1") is not None
+    assert merged.get_stay("stay-1").confirmation_code == "HOTEL-123"  # type: ignore[union-attr]
+    assert merged.checklist[0].completed is True
+
+    reloaded = state.load("japan-2027")
+    assert reloaded is not None
+    assert reloaded.name == "Japan 2027 Updated"
+    assert reloaded.sync.last_synced_by == "agent"
+    assert auth.values.batch_updates, "Expected normalized push back to sheet"
+
+
+def test_sync_roundtrip_conflict_is_flagged(tmp_path: Path) -> None:
+    state = TripStateService(trips_dir=tmp_path)
+    trip = _seed_trip()
+    trip.sync.google_sheet_id = "sheet-123"
+    trip.sync.last_synced_at = datetime(2026, 3, 1, 0, 0, 0)
+    trip.sync.cell_updated_at["flights.seg-1.carrier"] = "2026-03-10T12:00:00"
+    state.save(trip)
+
+    pulls = _pulls_from_fixture(FIXTURES / "sheet_edit_conflict.json")
+    auth = _FakeAuth(pulls)
+    sync = SheetSyncService(auth_manager=auth, state_service=state)
+
+    merged = sync.sync_roundtrip("japan-2027")
+
+    assert merged.get_segment("seg-1") is not None
+    assert merged.get_segment("seg-1").carrier == "Original Carrier"  # type: ignore[union-attr]
+    assert merged.sync.sync_conflicts
+    assert any("flights.seg-1.carrier" in c for c in merged.sync.sync_conflicts)

--- a/trippy/models/trip.py
+++ b/trippy/models/trip.py
@@ -235,6 +235,7 @@ class SyncMetadata(BaseModel):
     google_sheet_url: str | None = None
     last_synced_at: datetime | None = None
     last_synced_by: str | None = None  # "agent" | "human"
+    cell_updated_at: dict[str, str] = Field(default_factory=dict)
     sync_conflicts: list[str] = Field(default_factory=list)
 
     @field_validator("google_sheet_url", mode="before")

--- a/trippy/services/sheet_sync.py
+++ b/trippy/services/sheet_sync.py
@@ -1,19 +1,11 @@
-"""Bidirectional sync between canonical trip state and Google Sheets.
-
-Direction 1: trip state → sheet (write current state to sheet)
-Direction 2: sheet → trip state (import human edits back to state)
-
-The sheet is the HUMAN-FACING VIEW. Canonical state is the source of truth.
-Conflicts are logged and surfaced, not silently overwritten.
-"""
-
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
-from trippy.models.trip import Trip
+from trippy.models.trip import ChecklistItem, Segment, Stay, Trip
+from trippy.services.trip_state import TripStateService
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +45,9 @@ _BUDGET_COLS = ["Category", "Budgeted", "Booked", "Actual", "Variance"]
 class SheetSyncService:
     """Manages the Trippy trip sheet ↔ canonical state sync."""
 
-    def __init__(self, auth_manager: Any | None = None) -> None:
+    def __init__(self, auth_manager: Any | None = None, state_service: TripStateService | None = None) -> None:
         self._auth = auth_manager
+        self._state = state_service or TripStateService()
 
     def _sheets_service(self) -> Any:
         if self._auth is None:
@@ -258,3 +251,343 @@ class SheetSyncService:
         if len(rows) > 1:
             return [{"range": "Budget!A1", "values": rows}]
         return []
+
+    # ------------------------------------------------------------------
+    # Pull: sheet → trip state
+    # ------------------------------------------------------------------
+
+    def pull_overview(self, sheet_id: str) -> dict[str, str]:
+        rows = self._pull_range(sheet_id, "Overview!A:B")
+        out: dict[str, str] = {}
+        for row in rows[1:]:
+            if len(row) >= 2 and str(row[0]).strip():
+                out[str(row[0]).strip()] = str(row[1]).strip()
+        return out
+
+    def pull_flights(self, sheet_id: str) -> list[dict[str, str]]:
+        rows = self._pull_range(sheet_id, "Flights!A:L")
+        return self._rows_to_dicts(rows, _FLIGHTS_COLS)
+
+    def pull_hotels(self, sheet_id: str) -> list[dict[str, str]]:
+        rows = self._pull_range(sheet_id, "Hotels!A:L")
+        return self._rows_to_dicts(rows, _HOTELS_COLS)
+
+    def pull_checklist(self, sheet_id: str) -> list[dict[str, str]]:
+        rows = self._pull_range(sheet_id, "Checklist!A:F")
+        return self._rows_to_dicts(rows, _CHECKLIST_COLS)
+
+    def pull_budget(self, sheet_id: str) -> list[dict[str, str]]:
+        rows = self._pull_range(sheet_id, "Budget!A:E")
+        return self._rows_to_dicts(rows, _BUDGET_COLS)
+
+    def pull_sheet_edits(self, sheet_id: str) -> dict[str, Any]:
+        return {
+            "overview": self.pull_overview(sheet_id),
+            "flights": self.pull_flights(sheet_id),
+            "hotels": self.pull_hotels(sheet_id),
+            "checklist": self.pull_checklist(sheet_id),
+            "budget": self.pull_budget(sheet_id),
+        }
+
+    def _pull_range(self, sheet_id: str, range_name: str) -> list[list[str]]:
+        service = self._sheets_service()
+        try:
+            resp = (
+                service.spreadsheets()
+                .values()
+                .get(spreadsheetId=sheet_id, range=range_name)
+                .execute()
+            )
+            return resp.get("values", [])
+        except Exception as exc:
+            logger.warning("pull range failed sheet=%s range=%s err=%s", sheet_id, range_name, exc)
+            return []
+
+    def _rows_to_dicts(self, rows: list[list[str]], cols: list[str]) -> list[dict[str, str]]:
+        data: list[dict[str, str]] = []
+        for row in rows[1:]:
+            if not row:
+                continue
+            mapped = {
+                col: str(row[idx]).strip() if idx < len(row) else ""
+                for idx, col in enumerate(cols)
+            }
+            if any(mapped.values()):
+                data.append(mapped)
+        return data
+
+    # ------------------------------------------------------------------
+    # Merge + roundtrip
+    # ------------------------------------------------------------------
+
+    def merge_sheet_edits(
+        self,
+        trip: Trip,
+        pulled: dict[str, Any],
+        pulled_at: datetime | None = None,
+    ) -> Trip:
+        ts = pulled_at or datetime.utcnow()
+
+        overview = pulled.get("overview", {})
+        if isinstance(overview, dict):
+            self._merge_trip_field(trip, "overview.name", "name", overview.get("Trip Name"), ts)
+            self._merge_trip_field(
+                trip,
+                "overview.destination_summary",
+                "destination_summary",
+                overview.get("Destinations"),
+                ts,
+            )
+            self._merge_trip_field(
+                trip,
+                "overview.start_date",
+                "start_date",
+                _parse_date(overview.get("Start Date")),
+                ts,
+            )
+            self._merge_trip_field(
+                trip,
+                "overview.end_date",
+                "end_date",
+                _parse_date(overview.get("End Date")),
+                ts,
+            )
+            sheet_trip_id = (overview.get("Trip ID") or "").strip()
+            if sheet_trip_id and sheet_trip_id != trip.trip_id:
+                self._record_conflict(
+                    trip,
+                    "overview.trip_id",
+                    sheet_trip_id,
+                    trip.trip_id,
+                    ts,
+                    "Trip ID is immutable; canonical ID preserved.",
+                )
+
+        by_segment_id = {seg.segment_id: seg for seg in trip.segments}
+        for row in pulled.get("flights", []):
+            seg_id = (row.get("Segment ID") or "").strip()
+            if not seg_id:
+                continue
+            seg = by_segment_id.get(seg_id)
+            if seg is None:
+                self._record_conflict(
+                    trip,
+                    f"flights.{seg_id}",
+                    "new row",
+                    "missing segment",
+                    ts,
+                    "Segment ID not found in canonical trip; row ignored.",
+                )
+                continue
+            self._merge_model_field(trip, seg, f"flights.{seg_id}.carrier", "carrier", row.get("Carrier"), ts)
+            self._merge_model_field(
+                trip,
+                seg,
+                f"flights.{seg_id}.confirmation_code",
+                "confirmation_code",
+                row.get("Confirmation"),
+                ts,
+            )
+            self._merge_model_field(trip, seg, f"flights.{seg_id}.notes", "notes", row.get("Notes"), ts)
+
+        by_stay_id = {stay.stay_id: stay for stay in trip.stays}
+        for row in pulled.get("hotels", []):
+            stay_id = (row.get("Stay ID") or "").strip()
+            if not stay_id:
+                continue
+            stay = by_stay_id.get(stay_id)
+            if stay is None:
+                self._record_conflict(
+                    trip,
+                    f"hotels.{stay_id}",
+                    "new row",
+                    "missing stay",
+                    ts,
+                    "Stay ID not found in canonical trip; row ignored.",
+                )
+                continue
+            self._merge_model_field(
+                trip,
+                stay,
+                f"hotels.{stay_id}.confirmation_code",
+                "confirmation_code",
+                row.get("Confirmation"),
+                ts,
+            )
+            self._merge_model_field(
+                trip,
+                stay,
+                f"hotels.{stay_id}.notes",
+                "notes",
+                row.get("Notes"),
+                ts,
+            )
+
+        by_item_id = {item.item_id: item for item in trip.checklist}
+        for row in pulled.get("checklist", []):
+            item_id = (row.get("ID") or "").strip()
+            if not item_id:
+                continue
+            item = by_item_id.get(item_id)
+            if item is None:
+                self._record_conflict(
+                    trip,
+                    f"checklist.{item_id}",
+                    "new row",
+                    "missing item",
+                    ts,
+                    "Checklist ID not found in canonical trip; row ignored.",
+                )
+                continue
+            done_raw = (row.get("Done") or "").strip().lower()
+            self._merge_model_field(
+                trip,
+                item,
+                f"checklist.{item_id}.completed",
+                "completed",
+                done_raw in {"yes", "true", "1", "done"},
+                ts,
+            )
+
+        return trip
+
+    def sync_roundtrip(self, trip_id: str) -> Trip:
+        trip = self._state.load(trip_id)
+        if trip is None:
+            raise ValueError(f"Trip {trip_id!r} not found")
+        if not trip.sync.google_sheet_id:
+            raise ValueError(f"Trip {trip_id!r} has no google_sheet_id configured")
+
+        pulled_at = datetime.utcnow()
+        pulled = self.pull_sheet_edits(trip.sync.google_sheet_id)
+        merged = self.merge_sheet_edits(trip, pulled, pulled_at=pulled_at)
+        self._state.save(merged)
+
+        self.push_trip_to_sheet(merged, trip.sync.google_sheet_id)
+        merged.sync.last_synced_at = datetime.utcnow()
+        merged.sync.last_synced_by = "agent"
+        self._state.save(merged)
+        return merged
+
+    def _merge_trip_field(
+        self,
+        trip: Trip,
+        field_key: str,
+        attr: str,
+        incoming: Any,
+        incoming_ts: datetime,
+    ) -> None:
+        if incoming in (None, ""):
+            return
+        canonical = getattr(trip, attr)
+        self._merge_with_timestamp(
+            trip=trip,
+            field_key=field_key,
+            canonical_value=canonical,
+            incoming_value=incoming,
+            incoming_ts=incoming_ts,
+            apply=lambda value: setattr(trip, attr, value),
+        )
+
+    def _merge_model_field(
+        self,
+        trip: Trip,
+        obj: Segment | Stay | ChecklistItem,
+        field_key: str,
+        attr: str,
+        incoming: Any,
+        incoming_ts: datetime,
+    ) -> None:
+        if incoming in (None, ""):
+            return
+        canonical = getattr(obj, attr)
+        self._merge_with_timestamp(
+            trip=trip,
+            field_key=field_key,
+            canonical_value=canonical,
+            incoming_value=incoming,
+            incoming_ts=incoming_ts,
+            apply=lambda value: setattr(obj, attr, value),
+        )
+
+    def _merge_with_timestamp(
+        self,
+        trip: Trip,
+        field_key: str,
+        canonical_value: Any,
+        incoming_value: Any,
+        incoming_ts: datetime,
+        apply: Any,
+    ) -> None:
+        if canonical_value == incoming_value:
+            return
+
+        cell_map = trip.sync.cell_updated_at
+        field_ts_raw = cell_map.get(field_key)
+        field_ts = _parse_datetime(field_ts_raw)
+
+        if field_ts is not None and field_ts > incoming_ts:
+            self._record_conflict(
+                trip,
+                field_key,
+                incoming_value,
+                canonical_value,
+                incoming_ts,
+                "Canonical field is newer than sheet edit; keeping canonical value.",
+            )
+            return
+
+        last_sync = trip.sync.last_synced_at
+        if field_ts is not None and last_sync is not None and field_ts > last_sync:
+            self._record_conflict(
+                trip,
+                field_key,
+                incoming_value,
+                canonical_value,
+                incoming_ts,
+                "Field changed since last sync; edit requires review.",
+            )
+            return
+
+        apply(incoming_value)
+        cell_map[field_key] = incoming_ts.isoformat()
+
+    def _record_conflict(
+        self,
+        trip: Trip,
+        field_key: str,
+        sheet_value: Any,
+        canonical_value: Any,
+        ts: datetime,
+        reason: str,
+    ) -> None:
+        trip.sync.sync_conflicts.append(
+            (
+                f"{ts.isoformat()} field={field_key} sheet={sheet_value!r} "
+                f"canonical={canonical_value!r} reason={reason}"
+            )
+        )
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _parse_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None


### PR DESCRIPTION
### Motivation
- Ensure human edits in Google Sheets are deterministically merged into canonical trip JSON instead of being silently overwritten.
- Preserve immutable identifiers (trip/segment/stay/checklist IDs) as canonical source-of-truth while allowing safe, auditable updates to mutable fields.
- Provide a simple roundtrip workflow that pulls sheet edits, merges with canonical state, persists, and pushes a normalized sheet back.

### Description
- Added explicit per-tab pull APIs in `SheetSyncService`: `pull_overview`, `pull_flights`, `pull_hotels`, `pull_checklist`, `pull_budget`, and a `pull_sheet_edits` aggregator so sheet reads are tab-specific and deterministic (`trippy/services/sheet_sync.py`).
- Implemented deterministic merge logic that treats immutable IDs as canonical, merges mutable fields using per-cell last-updated timestamps stored in `trip.sync.cell_updated_at`, and records conflicts on field-level in `trip.sync.sync_conflicts` (`trippy/services/sheet_sync.py` and `trippy/models/trip.py`).
- Added `sync_roundtrip(trip_id)` workflow to load the canonical trip, pull sheet edits, merge, save canonical state, and push the normalized state back to the sheet (`trippy/services/sheet_sync.py`).
- Extended `SyncMetadata` to include `cell_updated_at: dict[str, str]` for per-cell ISO timestamps and kept `sync_conflicts` for conflict recording (`trippy/models/trip.py`).
- Added fixtures `tests/fixtures/sample_sheets/sheet_edit_human_updates.json` and `sheet_edit_conflict.json` and an integration test `tests/integration/test_sheet_sync_roundtrip.py` demonstrating propagation of human edits and flagging of conflicting edits.

### Testing
- Added integration tests and fixtures compile successfully; files compile with `python -m compileall` for `trippy/services/sheet_sync.py`, `trippy/models/trip.py`, and the new test file (success).
- Ran `pytest` in this environment but test collection failed due to missing runtime dependency `sqlalchemy`, so integration tests were not executed here (collection failure reported).
- New code paths covered by the integration tests include: human edit → canonical JSON propagation, and conflicting edit → conflict recorded in `trip.sync.sync_conflicts` (tests added but not run due to the environment dependency issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6350bb358832faa31f8ce3ffa6786)