### PR TITLE
Persist canonical trips after past-trip sheet imports

### DIFF
--- a/tests/unit/test_past_trip_miner.py
+++ b/tests/unit/test_past_trip_miner.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from trippy.db.models import TripStatus
+from trippy.importers.sheet_importer import ImportResult
+from trippy.skills.runners.past_trip_miner import PastTripMinerRunner
+
+
+def _fake_db_trip(name: str) -> SimpleNamespace:
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    return SimpleNamespace(
+        name=name,
+        status=TripStatus.planned,
+        destination_summary="",
+        start_date=date(2026, 3, 10),
+        end_date=date(2026, 3, 20),
+        travelers=[],
+        legs=[],
+        stays=[],
+        notes=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_import_sheet_persists_canonical_json_and_returns_trip_ids(tmp_path) -> None:
+    runner = PastTripMinerRunner(trips_dir=tmp_path, auth_manager=MagicMock(), anthropic_client=MagicMock())
+
+    import_result = ImportResult(source="sheet-id")
+    import_result.trips_created = 2
+    import_result.db_trip_ids = [101, 202]
+
+    db_trips = {
+        101: _fake_db_trip("Japan 2026"),
+        202: _fake_db_trip("Costa Rica 2027"),
+    }
+
+    session = MagicMock()
+    session.get.side_effect = lambda _model, trip_id: db_trips.get(trip_id)
+
+    @contextmanager
+    def _factory_ctx():
+        yield session
+
+    def _factory():
+        return _factory_ctx()
+
+    with (
+        patch("trippy.importers.sheet_importer.SheetImporter.import_file", return_value=import_result),
+        patch("trippy.db.make_session_factory", return_value=_factory),
+    ):
+        result = runner._import_sheet({"id": "sheet-123", "name": "Ignored Name"})
+
+    assert result["ok"] is True
+    assert result["trip_ids"] == ["japan-2026", "costa-rica-2027"]
+
+    saved_files = sorted(p.name for p in tmp_path.glob("*.json"))
+    assert saved_files == ["costa-rica-2027.json", "japan-2026.json"]

--- a/trippy/importers/sheet_importer.py
+++ b/trippy/importers/sheet_importer.py
@@ -99,6 +99,7 @@ class ImportResult:
     source: str = ""
     trips_created: int = 0
     trips_updated: int = 0
+    db_trip_ids: list[int] = field(default_factory=list)
     flagged_fields: list[FlaggedField] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     parsing_notes: str = ""
@@ -558,7 +559,8 @@ class SheetImporter:
                     result.errors.append("Skipped a trip with no name")
                     continue
                 try:
-                    _, created = _upsert_trip(session, parsed_trip)
+                    trip, created = _upsert_trip(session, parsed_trip)
+                    result.db_trip_ids.append(trip.id)
                     if created:
                         result.trips_created += 1
                     else:

--- a/trippy/skills/runners/past_trip_miner.py
+++ b/trippy/skills/runners/past_trip_miner.py
@@ -113,6 +113,8 @@ class PastTripMinerRunner:
         return cast(list[dict[str, Any]], resp.get("files", []))
 
     def _import_sheet(self, sheet: dict[str, Any]) -> dict[str, Any]:
+        from trippy.db import make_session_factory
+        from trippy.db.models import Trip as DbTrip
         from trippy.importers.sheet_importer import SheetImporter
         from trippy.ingest.google_auth import GoogleAuthManager
         from trippy.services.trip_state import TripStateService
@@ -124,14 +126,27 @@ class PastTripMinerRunner:
         if not result.ok:
             return {"ok": False, "error": str(result.errors)}
 
-        # Also persist as canonical JSON
+        # Persist imported DB trips as canonical JSON
         state_svc = TripStateService(trips_dir=self._trips_dir)
-        for trip_id in (t["name"] for t in cast(list[dict[str, Any]], [])):
-            state_svc.load_or_create(trip_id)
+        trip_ids: list[str] = []
+        factory = make_session_factory()
+        with factory() as session:
+            for db_trip_id in result.db_trip_ids:
+                db_trip = session.get(DbTrip, db_trip_id)
+                if db_trip is None:
+                    logger.warning(
+                        "Sheet import reported db trip id %s but it was not found",
+                        db_trip_id,
+                    )
+                    continue
+                canonical_trip = state_svc.from_db_trip(db_trip)
+                state_svc.save(canonical_trip)
+                trip_ids.append(canonical_trip.trip_id)
 
         created = result.trips_created > 0
         return {
             "ok": True,
             "created": created,
-            "trip_id": sheet["name"].lower().replace(" ", "-"),
+            "trip_id": trip_ids[0] if trip_ids else "",
+            "trip_ids": trip_ids,
         }


### PR DESCRIPTION
### Motivation
- Ensure sheet imports produce real canonical trip JSON files and expose the actual imported DB trip IDs instead of a placeholder name.
- Allow downstream consumers (skills and tools) to reliably reference the canonical trip state created from Drive/Sheet imports.

### Description
- Added `db_trip_ids` to `ImportResult` and populated it in `SheetImporter.import_file(...)` for each upserted DB trip.
- Updated `PastTripMinerRunner._import_sheet(...)` to load each DB trip via `make_session_factory()` and `DbTrip`, convert to canonical with `TripStateService.from_db_trip(...)`, save JSON with `TripStateService.save(...)`, and collect real `trip_ids` returned in the result.
- Returned both a primary `trip_id` (first imported) and the list `trip_ids` for backward compatibility.
- Added `tests/unit/test_past_trip_miner.py` which mocks importer output and DB session to assert that canonical JSON files are written and the returned `trip_ids` match the saved files.

### Testing
- Ran `pytest -q tests/unit/test_past_trip_miner.py tests/unit/test_drive_importer.py`, which completed successfully with all tests passing (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6350fc8e0832fa5409292c3ba45eb)