### PR TITLE
Add intent-driven deterministic orchestration to Trippy agent

### DIFF
--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,0 +1,156 @@
+"""Unit tests for Trippy agent orchestration and intent routing."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from trippy.agent import TrIppyAgent
+from trippy.models.trip import Trip, TripStatus
+
+
+def _mock_anthropic_client(response_text: str = "ok") -> MagicMock:
+    block = SimpleNamespace(type="text", text=response_text)
+    message = SimpleNamespace(content=[block], stop_reason="end_turn")
+    client = MagicMock()
+    client.messages.create.return_value = message
+    return client
+
+
+def _seed_trip(
+    agent: TrIppyAgent,
+    *,
+    trip_id: str,
+    name: str,
+    status: TripStatus,
+    start_offset_days: int,
+    with_sheet: bool = False,
+) -> Trip:
+    start = date.today() + timedelta(days=start_offset_days)
+    trip = Trip(
+        trip_id=trip_id,
+        name=name,
+        status=status,
+        start_date=start,
+        end_date=start + timedelta(days=7),
+    )
+    if with_sheet:
+        trip.sync.google_sheet_id = "sheet-123"
+    agent._trip_svc.save(trip)
+    return trip
+
+
+def test_reconcile_intent_auto_runs_gmail_reconciler(monkeypatch, tmp_path: Path) -> None:
+    client = _mock_anthropic_client("reconciled")
+    agent = TrIppyAgent(
+        anthropic_client=client,
+        memory_path=tmp_path / "memory.json",
+        trips_dir=tmp_path / "trips",
+    )
+    trip = _seed_trip(
+        agent,
+        trip_id="tokyo-2026",
+        name="Tokyo 2026",
+        status=TripStatus.BOOKED,
+        start_offset_days=10,
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_run_skill(skill_name: str, inputs: dict[str, object]) -> str:
+        captured["skill_name"] = skill_name
+        captured["inputs"] = inputs
+        return '{"ok": true}'
+
+    monkeypatch.setattr("trippy.agent._run_skill", _fake_run_skill)
+
+    result = agent.chat("Please reconcile Gmail confirmations for this trip.")
+
+    assert result == "reconciled"
+    assert captured["skill_name"] == "trippy-gmail-reconciler"
+    assert captured["inputs"] == {"trip_id": trip.trip_id}
+    assert client.messages.create.called
+
+
+def test_trip_selection_prefers_explicit_trip(monkeypatch, tmp_path: Path) -> None:
+    client = _mock_anthropic_client("done")
+    agent = TrIppyAgent(
+        anthropic_client=client,
+        memory_path=tmp_path / "memory.json",
+        trips_dir=tmp_path / "trips",
+    )
+    _seed_trip(
+        agent,
+        trip_id="iceland-2026",
+        name="Iceland 2026",
+        status=TripStatus.BOOKED,
+        start_offset_days=3,
+    )
+    explicit = _seed_trip(
+        agent,
+        trip_id="japan-2026",
+        name="Japan 2026",
+        status=TripStatus.BOOKED,
+        start_offset_days=30,
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_run_skill(skill_name: str, inputs: dict[str, object]) -> str:
+        captured["trip_id"] = inputs.get("trip_id")
+        return '{"ok": true}'
+
+    monkeypatch.setattr("trippy.agent._run_skill", _fake_run_skill)
+
+    agent.chat("Reconcile bookings for Japan 2026 please.")
+    assert captured["trip_id"] == explicit.trip_id
+
+
+def test_trip_scoped_intent_without_available_trip_asks_clarifying_question(tmp_path: Path) -> None:
+    client = _mock_anthropic_client("should-not-run")
+    agent = TrIppyAgent(
+        anthropic_client=client,
+        memory_path=tmp_path / "memory.json",
+        trips_dir=tmp_path / "trips",
+    )
+
+    result = agent.chat("Can you audit friction for our trip?")
+
+    assert "Which trip should I use" in result
+    client.messages.create.assert_not_called()
+
+
+def test_operations_intent_runs_deterministic_preflight(monkeypatch, tmp_path: Path) -> None:
+    client = _mock_anthropic_client("ops response")
+    agent = TrIppyAgent(
+        anthropic_client=client,
+        memory_path=tmp_path / "memory.json",
+        trips_dir=tmp_path / "trips",
+    )
+    trip = _seed_trip(
+        agent,
+        trip_id="rome-2026",
+        name="Rome 2026",
+        status=TripStatus.BOOKED,
+        start_offset_days=1,
+        with_sheet=True,
+    )
+
+    def _fake_execute_tool(name: str, *_args, **_kwargs) -> str:
+        if name == "run_friction_audit":
+            return '{"ok": true, "risks": []}'
+        return '{"ok": true}'
+
+    monkeypatch.setattr("trippy.agent._execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(agent, "_refresh_sheet_sync", lambda _trip: {"ok": True})
+
+    result = agent.chat("We landed. Need transfer and gate instructions now.")
+
+    assert result == "ops response"
+    called_system_prompt = client.messages.create.call_args.kwargs["system"]
+    assert "Operations Mode (During-Trip)" in called_system_prompt
+    assert trip.trip_id in called_system_prompt
+    assert "run_friction_audit" in called_system_prompt
+    assert "sheet_sync_refresh" in called_system_prompt

--- a/trippy/agent.py
+++ b/trippy/agent.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import date, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +30,7 @@ from rich.panel import Panel
 from trippy import config
 from trippy.memory.profile_manager import ProfileManager
 from trippy.memory.store import MemoryStore
+from trippy.models.trip import Trip, TripStatus
 from trippy.services.trip_state import TripStateService
 from trippy.skills import get_all_skill_summaries
 
@@ -37,13 +40,41 @@ console = Console()
 _MODEL = "claude-sonnet-4-6"
 _MAX_TOKENS = 4096
 
+_OPERATIONS_MODE_PROMPT = """
+## Operations Mode (During-Trip)
+
+The user is likely in-trip and needs immediate operational help.
+Prioritize practical, step-by-step guidance for:
+- gate and terminal navigation
+- transfer instructions (family-friendly, luggage-safe routes)
+- check-in/check-out timing constraints
+- today's concrete day plan and contingencies
+
+Be concise, actionable, and risk-aware. Flag any high-friction timing or transfer issue.
+"""
+
+
+class UserIntent(StrEnum):
+    PLAN_TRIP = "plan_trip"
+    RECONCILE_BOOKINGS = "reconcile_bookings"
+    AUDIT_FRICTION = "audit_friction"
+    IN_TRIP_OPS = "in_trip_ops"
+    GENERAL = "general"
+
 
 # ---------------------------------------------------------------------------
 # System prompt builder
 # ---------------------------------------------------------------------------
 
 
-def _build_system_prompt(memory: MemoryStore, trip_svc: TripStateService) -> str:
+def _build_system_prompt(
+    memory: MemoryStore,
+    trip_svc: TripStateService,
+    *,
+    operations_mode: bool = False,
+    active_trip_context: str | None = None,
+    orchestration_context: str | None = None,
+) -> str:
     parts: list[str] = []
 
     # Load AGENTS.md
@@ -68,6 +99,15 @@ def _build_system_prompt(memory: MemoryStore, trip_svc: TripStateService) -> str
 
     # Skills summary
     parts.append(get_all_skill_summaries())
+
+    if operations_mode:
+        parts.append(_OPERATIONS_MODE_PROMPT.strip())
+
+    if active_trip_context:
+        parts.append(active_trip_context)
+
+    if orchestration_context:
+        parts.append(orchestration_context)
 
     return "\n\n---\n\n".join(parts)
 
@@ -264,11 +304,150 @@ class TrIppyAgent:
         self._trip_svc = TripStateService(trips_dir=trips_dir or config.TRIPS_PATH)
         self._history: list[dict[str, Any]] = []
 
+    def _classify_intent(self, user_message: str) -> UserIntent:
+        msg = user_message.lower()
+        if any(k in msg for k in ("reconcile", "gmail", "booking email", "confirmation email")):
+            return UserIntent.RECONCILE_BOOKINGS
+        if any(k in msg for k in ("audit", "friction", "risk", "tight layover")):
+            return UserIntent.AUDIT_FRICTION
+        if any(
+            k in msg
+            for k in (
+                "gate",
+                "terminal",
+                "transfer",
+                "check in",
+                "check-in",
+                "today plan",
+                "today's plan",
+                "on the way",
+                "we landed",
+                "we are at",
+            )
+        ):
+            return UserIntent.IN_TRIP_OPS
+        if any(k in msg for k in ("plan trip", "plan a trip", "itinerary", "where should we go")):
+            return UserIntent.PLAN_TRIP
+        return UserIntent.GENERAL
+
+    def _extract_explicit_trip(self, user_message: str) -> Trip | None:
+        msg = user_message.lower()
+        for trip in self._trip_svc.load_all():
+            if trip.trip_id.lower() in msg or trip.name.lower() in msg:
+                return trip
+        return None
+
+    def _nearest_upcoming_booked_trip(self) -> Trip | None:
+        today = date.today()
+        booked = [t for t in self._trip_svc.find_by_status(TripStatus.BOOKED) if t.start_date]
+        upcoming = [t for t in booked if t.start_date and t.start_date >= today]
+        if not upcoming:
+            return None
+        return sorted(upcoming, key=lambda t: t.start_date or datetime.max.date())[0]
+
+    def _select_active_trip(self, user_message: str) -> tuple[Trip | None, str]:
+        explicit = self._extract_explicit_trip(user_message)
+        if explicit:
+            return explicit, "explicit"
+
+        upcoming = self._nearest_upcoming_booked_trip()
+        if upcoming:
+            return upcoming, "nearest_upcoming_booked"
+
+        return None, "none"
+
+    def _refresh_sheet_sync(self, trip: Trip) -> dict[str, Any]:
+        if not trip.sync.google_sheet_id:
+            return {"ok": False, "reason": "no_google_sheet_id"}
+        try:
+            from trippy.services.sheet_sync import SheetSyncService
+
+            SheetSyncService().push_trip_to_sheet(trip, trip.sync.google_sheet_id)
+            return {"ok": True, "sheet_id": trip.sync.google_sheet_id}
+        except Exception as exc:
+            logger.exception("Sheet sync refresh failed for trip %s", trip.trip_id)
+            return {"ok": False, "error": str(exc)}
+
     def chat(self, user_message: str) -> str:
         """Process a single user message and return the agent's response."""
+        intent = self._classify_intent(user_message)
+        trip_scoped_intents = {
+            UserIntent.RECONCILE_BOOKINGS,
+            UserIntent.AUDIT_FRICTION,
+            UserIntent.IN_TRIP_OPS,
+        }
+
+        active_trip = None
+        trip_selection_reason = "not_required"
+        if intent in trip_scoped_intents:
+            active_trip, trip_selection_reason = self._select_active_trip(user_message)
+            if active_trip is None:
+                return (
+                    "I need the trip first. Which trip should I use? "
+                    "Please share the trip name or trip ID."
+                )
+
+        orchestration_events: list[dict[str, Any]] = []
+        if intent == UserIntent.RECONCILE_BOOKINGS:
+            orchestration_events.append(
+                {
+                    "action": "invoke_skill",
+                    "skill_name": "trippy-gmail-reconciler",
+                    "result": json.loads(
+                        _run_skill("trippy-gmail-reconciler", {"trip_id": active_trip.trip_id})
+                    ),
+                }
+            )
+        elif intent == UserIntent.IN_TRIP_OPS and active_trip is not None:
+            orchestration_events.append(
+                {"action": "get_trip", "trip_id": active_trip.trip_id, "result": active_trip.model_dump()}
+            )
+            orchestration_events.append(
+                {
+                    "action": "run_friction_audit",
+                    "trip_id": active_trip.trip_id,
+                    "result": json.loads(
+                        _execute_tool(
+                            "run_friction_audit",
+                            {"trip_id": active_trip.trip_id, "check_preferences": True},
+                            self._memory,
+                            self._trip_svc,
+                        )
+                    ),
+                }
+            )
+            orchestration_events.append(
+                {
+                    "action": "sheet_sync_refresh",
+                    "trip_id": active_trip.trip_id,
+                    "result": self._refresh_sheet_sync(active_trip),
+                }
+            )
+
         self._history.append({"role": "user", "content": user_message})
 
-        system_prompt = _build_system_prompt(self._memory, self._trip_svc)
+        active_trip_context = None
+        if active_trip is not None:
+            active_trip_context = (
+                "## Active Trip Selection\n"
+                f"Selected trip: {active_trip.trip_id} ({active_trip.name})\n"
+                f"Selection policy result: {trip_selection_reason}"
+            )
+        orchestration_context = None
+        if orchestration_events:
+            orchestration_context = (
+                "## Deterministic Orchestration\n"
+                f"intent={intent.value}\n"
+                + json.dumps(orchestration_events, indent=2, default=str)
+            )
+
+        system_prompt = _build_system_prompt(
+            self._memory,
+            self._trip_svc,
+            operations_mode=intent == UserIntent.IN_TRIP_OPS,
+            active_trip_context=active_trip_context,
+            orchestration_context=orchestration_context,
+        )
         tools = _skill_tools()
 
         # Agentic loop — keep running until no more tool calls


### PR DESCRIPTION
### Motivation
- Make intent routing deterministic and perform essential orchestration steps before invoking the LLM to avoid unsafe or ambiguous model-driven actions.
- Ensure trip-scoped requests use a clear active-trip selection policy so operations and reconciliations run against the correct canonical state.
- Provide a concise "operations mode" for during-trip/help-on-the-go requests so the agent returns actionable, risk-aware guidance.

### Description
- Added a lightweight intent classifier (`UserIntent`) and `_classify_intent` in `trippy/agent.py` to bucket user messages into `plan_trip`, `reconcile_bookings`, `audit_friction`, `in_trip_ops`, and `general` intents.
- Implemented active-trip selection policy helpers (`_extract_explicit_trip`, `_nearest_upcoming_booked_trip`, `_select_active_trip`) that prefer an explicit trip mention, then the nearest booked trip, and otherwise ask a clarifying question.
- Introduced an operations-mode prompt (`_OPERATIONS_MODE_PROMPT`) and extended `_build_system_prompt` to inject `operations_mode`, `active_trip_context`, and `orchestration_context` into the system prompt for in-trip requests.
- Added deterministic preflight orchestration for critical intents so that `reconcile_bookings` auto-runs `trippy-gmail-reconciler`, and `in_trip_ops` auto-runs trip load + friction audit + sheet-sync refresh via `_execute_tool`, `_run_skill`, and `_refresh_sheet_sync` calls before the model call.
- Added unit tests in `tests/unit/test_agent.py` that mock Anthropic responses to verify orchestration behavior and trip-selection precedence.

### Testing
- Compiled the updated files with `python -m py_compile trippy/agent.py tests/unit/test_agent.py` which succeeded.
- Ran `pytest -q tests/unit/test_agent.py` in this environment but it failed to run due to a missing dependency (`sqlalchemy` imported by `tests/conftest.py`) causing an import error.
- The new unit tests are present and exercise mocked Anthropic interactions and deterministic orchestration behavior, but full `pytest` execution requires installing test dependencies (not performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63510bcfc832f8369e3e15869acb9)