### PR TITLE
Expand roadmap to phases 7–8 and add new-trip readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ CI runs all four checks on every push (GitHub Actions).
 You can inspect and run roadmap phases directly from the CLI:
 
 ```bash
-# Show phase 2-6 completion, blockers, and the next suggested action
+# Show phase 2-8 completion, blockers, and the next suggested action
 uv run trippy phase-status
 
 # Run a specific phase workflow
@@ -126,6 +126,11 @@ uv run trippy phase-run 3 --folder-id <drive_folder_id>
 uv run trippy phase-run 4 --trip-idea "Japan next March"
 uv run trippy phase-run 5 --max-emails 50
 uv run trippy phase-run 6 --trip-id japan-2027
+uv run trippy phase-run 7 --trip-id japan-2027
+uv run trippy phase-run 8 --trip-id japan-2027
+
+# Check if Trippy is ready to test by creating a new trip
+uv run trippy phase-ready-new-trip
 ```
 
 ---
@@ -170,6 +175,16 @@ them with Claude, link them to the correct trip, update both JSON state and the 
 ### Phase 6 — Self-improving skills
 After each successful workflow, have the agent assess whether a skill definition should
 be updated based on what it learned. Persist the updated `.md` and track skill versions.
+
+
+### Phase 7 — Choice intelligence (specific flight + stay recommendations)
+Persist explicit selection criteria for flights and stays (including Airbnb + boutique hotels),
+plus trip-specific overrides. This allows high-resolution recommendation ranking instead of
+generic sorting.
+
+### Phase 8 — Dual-surface concierge output
+Guarantee that recommendations and decisions stay synchronized across canonical trip state and
+the Google Sheet human view, so both the family and the agent can query the same truth.
 
 ---
 

--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -1,0 +1,78 @@
+# Trippy Delivery Phases (Execution Plan)
+
+This document expands the roadmap into concrete, testable phases with a clear
+"ready to test by creating a new trip" gate.
+
+## Phase 2 — Live Google credentials
+
+**Goal:** Trippy can authenticate safely to Gmail, Drive, and Sheets.
+
+**Definition of done:**
+- OAuth credentials and token are present and loadable.
+- MCP tools can run read + write operations without manual patching.
+
+## Phase 3 — Historical mining + durable preferences
+
+**Goal:** Build family intelligence from real prior trips.
+
+**Definition of done:**
+- Past trip sheets imported into canonical trip JSON.
+- Preference object exists in memory and is evidence-backed.
+- Global family defaults are available for planning sessions.
+
+## Phase 4 — New trip creation and human-readable sheet
+
+**Goal:** Turn a rough idea into canonical state + Google Sheet.
+
+**Definition of done:**
+- New trip can be created from a text idea.
+- Google Sheet is linked in sync metadata.
+- Checklist and baseline structure are pre-populated.
+
+## Phase 5 — Gmail reconciliation in production
+
+**Goal:** Keep bookings continuously reconciled.
+
+**Definition of done:**
+- Booking confirmations are parsed from Gmail.
+- Confirmations are linked to segments/stays.
+- Canonical trip and sheet are both updated.
+
+## Phase 6 — Friction audit and safety loop
+
+**Goal:** Catch trip risks before they hurt the family.
+
+**Definition of done:**
+- Risk flags are persisted on trips.
+- High/critical findings generate reusable skill hints.
+- Passport and timing constraints are audited on active trips.
+
+## Phase 7 — Choice intelligence (flights + stays)
+
+**Goal:** Make highly specific recommendations that match family taste.
+
+**Definition of done:**
+- Global preference keys exist for flight choice criteria.
+- Global preference keys exist for stay choice criteria (Airbnb + boutique + hotels).
+- At least one trip captures trip-specific overrides without mutating global defaults.
+
+## Phase 8 — Dual-surface concierge output
+
+**Goal:** Keep both machine state and human-facing views excellent.
+
+**Definition of done:**
+- Agent answers can reference canonical trip and preference state.
+- Google Sheet remains an up-to-date human-readable mirror.
+- Context includes both global preferences and trip-specific nuances.
+
+## New trip testing gate
+
+Trippy is considered **ready to test by building a new trip** when all are true:
+1. Phase 2 complete
+2. Phase 3 complete
+3. Phase 4 complete
+4. Phase 7 complete
+5. Phase 8 complete
+
+This ensures we are not only able to create a trip, but able to make high-quality,
+detailed recommendations and keep state usable for both humans and the concierge.

--- a/tests/unit/test_phase_planner.py
+++ b/tests/unit/test_phase_planner.py
@@ -76,3 +76,85 @@ def test_run_phase_unsupported_returns_error(tmp_path) -> None:
     planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
     result = planner.run_phase(99)
     assert "error" in result
+
+
+def test_phase_7_seeds_choice_criteria_and_trip_override(tmp_path) -> None:
+    trip_svc = TripStateService(tmp_path / "trips")
+    trip_svc.save(
+        Trip(
+            trip_id="japan-2027",
+            name="Japan 2027",
+            status=TripStatus.PLANNED,
+            start_date=date(2027, 3, 10),
+            end_date=date(2027, 3, 24),
+        )
+    )
+
+    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    result = planner.run_phase(7, trip_id="japan-2027")
+    assert result["phase"] == 7
+
+    memory = MemoryStore(tmp_path / "memory.json")
+    assert memory.get_value("pref:flight_choice_criteria") is not None
+    assert memory.get_value("pref:stay_choice_criteria") is not None
+    assert memory.get_value("trip_pref:japan-2027:stay") is not None
+
+
+def test_new_trip_readiness_requires_phases_2_3_4_7_8(tmp_path, monkeypatch) -> None:
+    from trippy import config
+
+    # Satisfy phase 2
+    creds = tmp_path / "gmail_credentials.json"
+    token = tmp_path / "gmail_token.json"
+    creds.write_text("{}", encoding="utf-8")
+    token.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(config, "GMAIL_CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(config, "GMAIL_TOKEN_PATH", token)
+    monkeypatch.setattr(config, "GOOGLE_TOKEN_PATH", tmp_path / "google_token.json")
+
+    # Satisfy phases 3/4/8 baseline with trip + preferences + sheet id
+    trip_svc = TripStateService(tmp_path / "trips")
+    trip = Trip(
+        trip_id="japan-2027",
+        name="Japan 2027",
+        status=TripStatus.BOOKED,
+        start_date=date(2027, 3, 10),
+        end_date=date(2027, 3, 24),
+    )
+    trip.sync.google_sheet_id = "sheet-123"
+    trip_svc.save(trip)
+
+    memory = MemoryStore(tmp_path / "memory.json")
+    memory.set(
+        key="pref:preferences_object",
+        value={"comfort_over_price": True},
+        category="preference",
+        confidence=0.9,
+        source="test",
+    )
+
+    # Satisfy phase 7 requirements
+    memory.set(
+        key="pref:flight_choice_criteria",
+        value={"prefer_nonstop": True},
+        category="preference",
+        source="test",
+    )
+    memory.set(
+        key="pref:stay_choice_criteria",
+        value={"allow_stay_types": ["hotel", "airbnb"]},
+        category="preference",
+        source="test",
+    )
+    memory.set(
+        key="trip_pref:japan-2027:stay",
+        value={"vibe": "walkable"},
+        category="trip_insight",
+        source="test",
+    )
+
+    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    readiness = planner.new_trip_test_readiness()
+
+    assert readiness["ready"] is True
+    assert readiness["failing"] == []

--- a/trippy/cli.py
+++ b/trippy/cli.py
@@ -333,7 +333,7 @@ def friction_audit(
 
 @app.command("phase-status")
 def phase_status() -> None:
-    """Show roadmap phases 2-6 and what is blocked next."""
+    """Show roadmap phases 2-8 and what is blocked next."""
     from trippy.services.phase_planner import PhasePlannerService
 
     planner = PhasePlannerService()
@@ -367,9 +367,29 @@ def phase_status() -> None:
         )
 
 
+
+
+@app.command("phase-ready-new-trip")
+def phase_ready_new_trip() -> None:
+    """Check if Trippy is ready for a high-quality new trip test."""
+    from trippy.services.phase_planner import PhasePlannerService
+
+    planner = PhasePlannerService()
+    readiness = planner.new_trip_test_readiness()
+    console.print(JSON.from_data(readiness))
+
+    if readiness.get("ready"):
+        console.print("\n[green]Ready: run trippy phase-run 4 --trip-idea \"<your trip idea>\"[/green]")
+    else:
+        failing = readiness.get("failing") or []
+        if failing:
+            next_phase = failing[0]
+            console.print(
+                f"\n[yellow]Not ready yet.[/yellow] Next: Phase {next_phase['phase']} — {next_phase['title']}"
+            )
 @app.command("phase-run")
 def phase_run(
-    phase: int = typer.Argument(..., help="Roadmap phase number (2-6)"),
+    phase: int = typer.Argument(..., help="Roadmap phase number (2-8)"),
     folder_id: str = typer.Option("", "--folder-id", help="Drive folder ID (phase 3/4)"),
     query: str = typer.Option("trip", "--query", help="Drive search query (phase 3)"),
     max_sheets: int = typer.Option(50, "--max-sheets", help="Max sheets to scan (phase 3)"),
@@ -384,8 +404,8 @@ def phase_run(
     """Run one roadmap phase workflow and print structured output."""
     from trippy.services.phase_planner import PhasePlannerService
 
-    if phase < 2 or phase > 6:
-        console.print("[red]Phase must be between 2 and 6.[/red]")
+    if phase < 2 or phase > 8:
+        console.print("[red]Phase must be between 2 and 8.[/red]")
         raise typer.Exit(1)
 
     planner = PhasePlannerService()

--- a/trippy/services/phase_planner.py
+++ b/trippy/services/phase_planner.py
@@ -17,7 +17,7 @@ class PhaseStatus:
 
 
 class PhasePlannerService:
-    """Determines readiness/completion of roadmap phases 2-6.
+    """Determines readiness/completion of roadmap phases 2-8.
 
     The checks are intentionally deterministic and lightweight, so teams can
     quickly see what to do next without running a full agent session.
@@ -47,6 +47,18 @@ class PhasePlannerService:
         has_sheeted_trip = any(bool(t.sync.google_sheet_id) for t in trips)
         has_confirmation = any(bool(t.confirmations) for t in trips)
         has_risks = any(bool(t.risk_flags) for t in trips)
+
+        # New intelligence checks for precise recommendation quality
+        has_flight_choice_criteria = memory.get_value("pref:flight_choice_criteria") is not None
+        has_stay_choice_criteria = memory.get_value("pref:stay_choice_criteria") is not None
+        has_trip_override = any(
+            (memory.get_value(f"trip_pref:{t.trip_id}:flight") is not None)
+            or (memory.get_value(f"trip_pref:{t.trip_id}:stay") is not None)
+            for t in trips
+        )
+
+        has_trip_and_global_context = has_preferences and has_trips
+        has_human_surface_sync = has_sheeted_trip
 
         phases: list[PhaseStatus] = []
         phases.append(
@@ -97,7 +109,69 @@ class PhasePlannerService:
                 next_step="Run: trippy phase-run 6 --trip-id <trip_id>",
             )
         )
+        phases.append(
+            PhaseStatus(
+                phase=7,
+                title="Choice intelligence (flights + stays)",
+                complete=has_flight_choice_criteria and has_stay_choice_criteria and has_trip_override,
+                blockers=[
+                    *(
+                        []
+                        if has_flight_choice_criteria
+                        else ["Missing global preference key: pref:flight_choice_criteria"]
+                    ),
+                    *(
+                        []
+                        if has_stay_choice_criteria
+                        else ["Missing global preference key: pref:stay_choice_criteria"]
+                    ),
+                    *(
+                        []
+                        if has_trip_override
+                        else ["No trip-specific override found (trip_pref:<trip_id>:flight/stay)"]
+                    ),
+                ],
+                next_step="Run: trippy phase-run 7 --trip-id <trip_id>",
+            )
+        )
+        phases.append(
+            PhaseStatus(
+                phase=8,
+                title="Dual-surface concierge output",
+                complete=has_trip_and_global_context and has_human_surface_sync,
+                blockers=[
+                    *(
+                        []
+                        if has_trip_and_global_context
+                        else ["Trip context or global preferences are incomplete"]
+                    ),
+                    *([] if has_human_surface_sync else ["Sheet sync surface is not populated"]),
+                ],
+                next_step="Run: trippy phase-run 8 --trip-id <trip_id>",
+            )
+        )
         return phases
+
+    def new_trip_test_readiness(self) -> dict[str, Any]:
+        """Return whether Trippy is ready for a realistic new-trip test."""
+        phases = self.status()
+        required = {2, 3, 4, 7, 8}
+        phase_map = {p.phase: p for p in phases}
+        failing = [phase_map[p] for p in sorted(required) if not phase_map[p].complete]
+
+        return {
+            "ready": len(failing) == 0,
+            "required_phases": sorted(required),
+            "failing": [
+                {
+                    "phase": p.phase,
+                    "title": p.title,
+                    "blockers": p.blockers,
+                    "next_step": p.next_step,
+                }
+                for p in failing
+            ],
+        }
 
     def run_phase(self, phase: int, **kwargs: Any) -> dict[str, Any]:
         """Execute the main workflow for one roadmap phase."""
@@ -111,6 +185,10 @@ class PhasePlannerService:
             return self._run_phase_5(**kwargs)
         if phase == 6:
             return self._run_phase_6(**kwargs)
+        if phase == 7:
+            return self._run_phase_7(**kwargs)
+        if phase == 8:
+            return self._run_phase_8(**kwargs)
         return {"error": f"Unsupported phase: {phase}"}
 
     def _run_phase_2(self) -> dict[str, Any]:
@@ -198,3 +276,80 @@ class PhasePlannerService:
             )
 
         return {"phase": 6, "audit": audit_result}
+
+    def _run_phase_7(self, **kwargs: Any) -> dict[str, Any]:
+        from trippy import config
+        from trippy.memory.store import MemoryStore
+
+        trip_id = kwargs.get("trip_id")
+        memory = MemoryStore(self._memory_path or config.MEMORY_PATH)
+
+        # Seed explicit recommendation criteria keys if missing.
+        if memory.get_value("pref:flight_choice_criteria") is None:
+            memory.set(
+                key="pref:flight_choice_criteria",
+                value={
+                    "prefer_nonstop": True,
+                    "avoid_departure_before": "07:00",
+                    "preferred_cabin_long_haul": "premium_economy",
+                    "connection_buffer_minutes_international": 120,
+                },
+                category="preference",
+                confidence=0.6,
+                source="phase-runner",
+                notes="Initial explicit flight choice criteria for recommendation ranking.",
+            )
+
+        if memory.get_value("pref:stay_choice_criteria") is None:
+            memory.set(
+                key="pref:stay_choice_criteria",
+                value={
+                    "allow_stay_types": ["airbnb", "hotel", "boutique_hotel"],
+                    "min_family_capacity": 5,
+                    "required_bedroom_strategy": "2_queens_or_suite",
+                    "max_transfer_minutes_from_arrival": 60,
+                },
+                category="preference",
+                confidence=0.6,
+                source="phase-runner",
+                notes="Initial explicit stay choice criteria including Airbnb/boutique filters.",
+            )
+
+        if trip_id and memory.get_value(f"trip_pref:{trip_id}:stay") is None:
+            memory.set(
+                key=f"trip_pref:{trip_id}:stay",
+                value={"neighborhood_style": "walkable", "vibe": "family-friendly"},
+                category="trip_insight",
+                confidence=0.5,
+                source="phase-runner",
+                notes="Trip-specific stay override; keep global defaults unchanged.",
+            )
+
+        return {
+            "phase": 7,
+            "flight_choice_criteria": memory.get_value("pref:flight_choice_criteria"),
+            "stay_choice_criteria": memory.get_value("pref:stay_choice_criteria"),
+            "trip_override": memory.get_value(f"trip_pref:{trip_id}:stay") if trip_id else None,
+        }
+
+    def _run_phase_8(self, **kwargs: Any) -> dict[str, Any]:
+        from trippy.memory.store import MemoryStore
+        from trippy.services.trip_state import TripStateService
+
+        memory = MemoryStore(self._memory_path)
+        trip_svc = TripStateService(self._trips_dir)
+
+        trip_id = kwargs.get("trip_id")
+        trip = trip_svc.load(trip_id) if trip_id else None
+        if trip is None:
+            active = trip_svc.find_active()
+            trip = active[0] if active else None
+
+        return {
+            "phase": 8,
+            "has_global_preferences": memory.get_value("pref:preferences_object") is not None,
+            "has_trip_specific_context": bool(trip),
+            "trip_id": trip.trip_id if trip else "",
+            "has_sheet_sync": bool(trip and trip.sync.google_sheet_id),
+            "readiness": self.new_trip_test_readiness(),
+        }


### PR DESCRIPTION
### Motivation
- Make Trippy capable of higher-resolution choice intelligence for flights and stays (Airbnb, boutique hotels) and provide a clear gate for when it is safe to test by creating a new trip.  
- Surface a deterministic, inspectable readiness signal so the team knows which phases (credentials, past-trip mining, sheet sync, choice criteria, human surface) must be satisfied before realistic end-to-end trip creation testing.

### Description
- Extend phase model from phases `2–6` to `2–8` in `PhasePlannerService` and add deterministic checks for recommendation quality and dual-surface readiness.  
- Add `new_trip_test_readiness()` which evaluates required phases `{2,3,4,7,8}` and reports failing phases, blockers, and next steps.  
- Implement phase runners `_run_phase_7` (seed explicit `pref:flight_choice_criteria` and `pref:stay_choice_criteria`, write trip-specific `trip_pref:{trip_id}:stay`) and `_run_phase_8` (surface global/trip context + sheet sync and readiness).  
- Update CLI: expand `phase-status`/`phase-run` to cover `2–8` and add `phase-ready-new-trip` which prints the `new_trip_test_readiness()` payload; add `docs/PHASES.md` and update `README.md` to document phases and the readiness command.  
- Add/extend unit tests in `tests/unit/test_phase_planner.py` to assert phase-7 seeding behavior and the readiness gate semantics.

### Testing
- Ran `uv run pytest tests/unit/test_phase_planner.py`, which executed the phase-planner unit tests and all tests passed (`6 passed`).  
- Ran the new CLI readiness check `uv run trippy phase-ready-new-trip`, which executed successfully and returned a structured readiness object indicating `ready: false` and listed blockers (first blocker: missing Google credentials / Phase 2).  
- The phase-run seeding behavior was exercised by tests that validate `pref:flight_choice_criteria`, `pref:stay_choice_criteria`, and `trip_pref:{trip_id}:stay` are created when running Phase 7, and those assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6544bdf50832fa07e116618c0e522)