### PR TITLE
[codex] Build Trippy next-phase foundations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,14 @@
 # Copy to .env and fill in values — never commit .env
 ANTHROPIC_API_KEY=sk-ant-...
-HERMES_DB_PATH=~/.hermes_trip/state.db
-HERMES_VAULT_PATH=~/.hermes_trip/vault
-GMAIL_CREDENTIALS_PATH=~/.hermes_trip/gmail_credentials.json
-GMAIL_TOKEN_PATH=~/.hermes_trip/gmail_token.json
+TRIPPY_DB_PATH=~/.trippy/state.db
+TRIPPY_MEMORY_PATH=~/.trippy/memory.json
+TRIPPY_TRIPS_PATH=~/.trippy/trips
+TRIPPY_VAULT_PATH=~/.trippy/vault
+TRIPPY_EXPORT_PATH=~/.trippy/export
+TRIPPY_LEARNING_PATH=~/.trippy/learning
+GMAIL_CREDENTIALS_PATH=~/.trippy/gmail_credentials.json
+GOOGLE_TOKEN_PATH=~/.trippy/google_token.json
+TRIPPY_SHEET_TEMPLATE_ID=
 SHERPA_API_KEY=
 DUFFEL_ACCESS_TOKEN=
-TELEGRAM_BOT_TOKEN=
 GOOGLE_SHEETS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ access, and a learning loop that persists lessons across trips.
 | Capability | Description |
 |---|---|
 | **Mine past trips** | Scans Google Drive for prior travel sheets, parses them into canonical trip records, and proposes durable planning intelligence |
+| **Use country priors** | Applies historical country ratings and notes as directional priors for destination fit, cautions, and ranking |
 | **Compare trip ideas** | Turns loose constraints into ranked family-fit concepts with comfort, food, crowd, travel-burden, and friction tradeoffs |
 | **Plan new trips** | Turns a selected trip idea into a structured trip record + Google Sheet, pre-filled with itinerary structure and known preferences |
 | **Route travel sources** | Uses an explicit source registry for flights, lodging, tours, cars, validation, and deal inspiration |
@@ -35,6 +36,7 @@ trippy/
   models/               Canonical Pydantic schemas (source of truth)
     trip.py             Trip, Segment, Stay, Confirmation, RiskFlag, ...
     preferences.py      FamilyTravelPreferences
+    country_priors.py   Historical country-level planning priors
     intelligence.py     Extracted travel intelligence signals
     ideas.py            Trip idea requests, concepts, comparisons
     maps.py             Map pins, routes, and trip map artifacts
@@ -57,6 +59,7 @@ trippy/
   services/             Core business logic
     trip_state.py       Canonical trip CRUD + JSON persistence
     learning.py         Workflow outcomes, feedback, review-gated proposals
+    country_priors.py   Country prior lookup, scoring, and learning proposals
     travel_intelligence.py Past-trip intelligence extraction
     trip_ideation.py    Family-fit trip concept scoring
     source_registry.py  Deterministic travel source routing
@@ -99,6 +102,9 @@ uv run trippy learn review
 
 # Generate ranked family-fit trip concepts
 uv run trippy trip-ideas --time "March break" --days 9 --goal food --goal culture --avoid crowds
+
+# Inspect country-level historical priors
+uv run trippy country-priors Japan
 
 # Inspect source routing, generate maps, and build the dashboard
 uv run trippy sources --category flights
@@ -212,6 +218,7 @@ The full architecture is in place and all CI checks pass:
 - [x] SQLite persistence with Alembic migrations
 - [x] Setup doctor and Google OAuth validator
 - [x] Review-gated workflow feedback and learning proposals
+- [x] Country-level priors from historical ratings and notes
 - [x] Past-trip intelligence mining and trip idea comparison
 - [x] Source registry, map artifact generation, dashboard export, and retrospective proposals
 - [x] 235 passing tests, 5 skipped, mypy clean, ruff clean

--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ access, and a learning loop that persists lessons across trips.
 
 | Capability | Description |
 |---|---|
-| **Mine past trips** | Scans Google Drive for prior travel sheets, parses them into canonical trip records, extracts durable family preferences |
-| **Plan new trips** | Turns a rough idea ("Japan next March") into a structured trip record + Google Sheet, pre-filled with itinerary structure and known preferences |
+| **Mine past trips** | Scans Google Drive for prior travel sheets, parses them into canonical trip records, and proposes durable planning intelligence |
+| **Compare trip ideas** | Turns loose constraints into ranked family-fit concepts with comfort, food, crowd, travel-burden, and friction tradeoffs |
+| **Plan new trips** | Turns a selected trip idea into a structured trip record + Google Sheet, pre-filled with itinerary structure and known preferences |
+| **Route travel sources** | Uses an explicit source registry for flights, lodging, tours, cars, validation, and deal inspiration |
+| **Generate maps** | Creates practical Google Maps links plus JSON, GeoJSON, and KML artifacts for trip navigation |
+| **Show dashboard** | Builds a static Past Trips / Planned Trips / Ideas dashboard from canonical state |
 | **Reconcile Gmail** | Reads booking confirmations, matches them to the correct trip, updates canonical state, pushes to Google Sheets |
-| **Audit for friction** | Proactively flags tight layovers, hotel check-in mismatches, missing confirmations, passport expiry, missing seats/bags |
-| **Self-improve** | Persists durable lessons to memory after successful workflows; updates Hermes skills so future planning is sharper |
+| **Audit for friction** | Proactively flags tight layovers, hotel check-in mismatches, family bed fit, city lodging burden, crowded tours, pacing issues, and missing entry/health/cash research |
+| **Self-improve** | Records workflow outcomes, retrospectives, and user feedback, then creates review-gated memory and skill proposals |
 
 ---
 
@@ -31,10 +35,16 @@ trippy/
   models/               Canonical Pydantic schemas (source of truth)
     trip.py             Trip, Segment, Stay, Confirmation, RiskFlag, ...
     preferences.py      FamilyTravelPreferences
+    intelligence.py     Extracted travel intelligence signals
+    ideas.py            Trip idea requests, concepts, comparisons
+    maps.py             Map pins, routes, and trip map artifacts
+    sources.py          Travel source registry models
+    dashboard.py        Dashboard tiles and export models
+    retrospective.py    Post-trip retrospective models
     profile.py          FamilyProfile, TravelerProfile
   memory/               Hermes memory management
     store.py            JSON-backed MemoryStore (versioned, categorized)
-    preference_writer.py  Extract + write durable preferences from trip evidence
+    preference_writer.py  Extract durable preference candidates from trip evidence
     profile_manager.py  Family profile CRUD
   mcp/                  MCP server — Google API boundary
     server.py           FastMCP entry point
@@ -46,6 +56,13 @@ trippy/
     runners/            Python skill execution modules
   services/             Core business logic
     trip_state.py       Canonical trip CRUD + JSON persistence
+    learning.py         Workflow outcomes, feedback, review-gated proposals
+    travel_intelligence.py Past-trip intelligence extraction
+    trip_ideation.py    Family-fit trip concept scoring
+    source_registry.py  Deterministic travel source routing
+    map_outputs.py      Google Maps links + JSON/GeoJSON/KML artifacts
+    dashboard.py        Static dashboard JSON + HTML generation
+    retrospective.py    Post-trip retrospective proposal workflow
     sheet_sync.py       Trip state ↔ Google Sheets bidirectional sync
     friction_detector.py  Deterministic rule-based risk auditing
   db/                   SQLite persistence (SQLAlchemy 2.x + Alembic)
@@ -59,7 +76,8 @@ trippy/
 - Canonical state lives in `~/.trippy/trips/{trip_id}.json` + SQLite. The LLM reasons about state; it does not store it.
 - All Google API calls go through the MCP server in `trippy/mcp/`. Services never call Google directly.
 - Memory holds durable truths (preferences, profile). Trip-specific facts stay in trip state.
-- Skills are the self-improvement surface — the agent patches them after successful workflows.
+- Learning is review-gated: workflows and feedback create proposals; only `trippy learn approve` mutates memory or skill files.
+- Skills are the self-improvement surface, but skill edits remain human-approved.
 
 ---
 
@@ -68,6 +86,27 @@ trippy/
 ```bash
 # Install dependencies
 uv sync
+
+# Check local/live readiness
+uv run trippy doctor
+
+# Run Google OAuth and validate Gmail, Sheets write, and Drive access
+uv run trippy auth-google
+
+# Mine past trip intelligence and review proposed learning
+uv run trippy mine-intelligence
+uv run trippy learn review
+
+# Generate ranked family-fit trip concepts
+uv run trippy trip-ideas --time "March break" --days 9 --goal food --goal culture --avoid crowds
+
+# Inspect source routing, generate maps, and build the dashboard
+uv run trippy sources --category flights
+uv run trippy maps <trip-id>
+uv run trippy dashboard
+
+# Capture post-trip lessons as review-gated proposals
+uv run trippy retro <trip-id> --worked "..." --friction "..." --hard-rule "..."
 
 # Run the end-to-end demo (no credentials required)
 uv run python -m trippy.thin_slice
@@ -82,6 +121,19 @@ uv run python -m trippy.mcp.server
 uv run trippy db-init
 ```
 
+Copy `.env.example` to `.env` for live use. Trippy stores runtime state under
+`~/.trippy` by default:
+
+```bash
+TRIPPY_DB_PATH=~/.trippy/state.db
+TRIPPY_MEMORY_PATH=~/.trippy/memory.json
+TRIPPY_TRIPS_PATH=~/.trippy/trips
+TRIPPY_VAULT_PATH=~/.trippy/vault
+TRIPPY_LEARNING_PATH=~/.trippy/learning
+GMAIL_CREDENTIALS_PATH=~/.trippy/gmail_credentials.json
+GOOGLE_TOKEN_PATH=~/.trippy/google_token.json
+```
+
 ---
 
 ## Skills
@@ -91,7 +143,7 @@ Six Hermes skills are registered and callable by the agent:
 | Skill | Purpose |
 |---|---|
 | `trippy-past-trip-miner` | Scan Drive, import prior trip sheets into canonical records |
-| `trippy-preference-extractor` | Extract durable preferences from lived trip history |
+| `trippy-preference-extractor` | Propose durable preferences from lived trip history |
 | `trippy-trip-sheet-creator` | Create a new Google Sheet from a trip idea |
 | `trippy-gmail-reconciler` | Fetch Gmail confirmations and link them to trips |
 | `trippy-flight-friction-audit` | Audit a trip for risks (layovers, passports, timing) |
@@ -102,7 +154,7 @@ Six Hermes skills are registered and callable by the agent:
 ## Development
 
 ```bash
-uv run pytest            # 186 tests
+uv run pytest            # 235 passing tests, 5 skipped
 uv run mypy trippy/      # type checking
 uv run ruff check .      # lint
 uv run ruff format .     # format
@@ -124,9 +176,23 @@ uv run trippy phase-status
 uv run trippy phase-run 2
 uv run trippy phase-run 3 --folder-id <drive_folder_id>
 uv run trippy phase-run 4 --trip-idea "Japan next March"
-uv run trippy phase-run 5 --max-emails 50
+uv run trippy phase-run 5 --max-emails 50 --dry-run
 uv run trippy phase-run 6 --trip-id japan-2027
 ```
+
+Every meaningful CLI workflow records a workflow ID under
+`~/.trippy/learning/events.jsonl`. Attach explicit feedback and review learning proposals:
+
+```bash
+uv run trippy feedback <workflow-id> --rating needs-work --notes "..." --correction "..." --future-learning
+uv run trippy learn review
+uv run trippy learn approve <proposal-id>
+uv run trippy learn reject <proposal-id>
+```
+
+No preference, profile, memory, or skill learning is applied silently. Past-trip mining,
+agent memory updates, user feedback, and friction-derived hints all create pending proposals
+first.
 
 ---
 
@@ -138,13 +204,17 @@ The full architecture is in place and all CI checks pass:
 
 - [x] Canonical Pydantic models (`Trip`, `Segment`, `Stay`, `Confirmation`, `RiskFlag`, ...)
 - [x] JSON-backed MemoryStore with versioning, categories, and confidence scoring
-- [x] Deterministic `FrictionDetector` (passport expiry, tight connections, missing confirmations, check-in gaps)
+- [x] Deterministic `FrictionDetector` (passport expiry, tight connections, missing confirmations, check-in gaps, family bed fit, city/rental fit, pacing, tours, entry/health/cash readiness)
 - [x] All 6 Hermes skills defined and runnable
 - [x] MCP server with Gmail, Sheets, and Drive tools
 - [x] Hermes agent loop (streaming, tool-calling, memory-injection)
 - [x] Full Typer CLI (`trippy agent`, `trippy db-init`, `trippy import-drive`, ...)
 - [x] SQLite persistence with Alembic migrations
-- [x] 186 passing tests, mypy clean, ruff clean
+- [x] Setup doctor and Google OAuth validator
+- [x] Review-gated workflow feedback and learning proposals
+- [x] Past-trip intelligence mining and trip idea comparison
+- [x] Source registry, map artifact generation, dashboard export, and retrospective proposals
+- [x] 235 passing tests, 5 skipped, mypy clean, ruff clean
 
 ---
 
@@ -157,7 +227,7 @@ Drive. Validate the Gmail → confirmation → trip linking pipeline end-to-end 
 ### Phase 3 — Past trip mining
 Run `trippy-past-trip-miner` against the family's Google Drive to import all historical
 trip sheets into canonical records. Extract durable preferences from that history and
-write them into the MemoryStore.
+review the proposed MemoryStore updates before approving them.
 
 ### Phase 4 — New trip sheet creation
 Wire up `trippy-trip-sheet-creator` to create real Google Sheets from the template,
@@ -169,7 +239,8 @@ them with Claude, link them to the correct trip, update both JSON state and the 
 
 ### Phase 6 — Self-improving skills
 After each successful workflow, have the agent assess whether a skill definition should
-be updated based on what it learned. Persist the updated `.md` and track skill versions.
+be updated based on what it learned. Persist the updated `.md` only after review approval
+and track skill versions.
 
 ---
 

--- a/docs/NEXT_PHASE_ARCHITECTURE.md
+++ b/docs/NEXT_PHASE_ARCHITECTURE.md
@@ -1,0 +1,182 @@
+# Trippy Next-Phase Architecture
+
+## Goal
+
+Trippy should become a family-specific travel intelligence system, not a generic destination
+recommender. The next build should strengthen three foundations before deeper booking
+automation:
+
+1. Past-trip evidence becomes structured planning intelligence.
+2. Comfort and convenience risks are deterministic checks, not vibes.
+3. Trip ideas are compared as actual family-fit concepts, with clear tradeoffs.
+4. Source routing is explicit, inspectable, and learnable.
+5. Maps and dashboard artifacts make trip state usable by the family, not just the agent.
+
+## Recommended Path
+
+### Phase 1: Memory Mining And Preference Intelligence
+
+Use existing Google Sheet, Gmail, and canonical trip import flows as evidence collectors. Convert
+the imported trips into durable, reviewable memory signals:
+
+- lodging fit by context: city hotel, city rental, rural rental, bed setup
+- travel burden: total travel time, directness, connection tolerance
+- pacing: nights per stop, transitions per week, activity/chill balance
+- vendor and loyalty patterns: airlines, hotel groups, platforms, Aeroplan usage
+- friction lessons: missed risks, avoided risks, user corrections
+
+Implementation rule: the extractor may propose and summarize memory, but memory writes remain
+review-gated through the existing learning proposal flow.
+
+### Phase 2: Comfort/Friction Engine
+
+Keep this deterministic. The engine should run before recommendations, before booking, after
+Gmail reconciliation, and during concierge mode.
+
+Core checks:
+
+- layover length, airport mismatches, terminal/airport changes
+- arrival/check-in friction and prior-night lodging needs
+- family-of-5 sleeping fit and minimum 3-bed validation
+- king-bed preference and queen-bed compromise warnings
+- city lodging location burden and city rental suitability
+- rental access, parking, safety, and late-arrival complexity
+- overcompressed trip pacing and risky same-day transitions
+- missing cash, visa, entry, health, and vaccination research
+- mass-market/crowded/weak-safety tour signals when activity data exists
+
+Implementation rule: if data is missing for a reliability-critical check, flag the missing data
+explicitly rather than pretending the option is safe.
+
+### Phase 3: Trip Ideation And Comparison
+
+Start with a small deterministic concept scorer. It should accept loose constraints and produce
+2-5 trip concepts ranked by family fit.
+
+Required concept output:
+
+- estimated cost band
+- estimated travel burden
+- direct-flight friendliness
+- family-fit score
+- comfort/convenience score
+- food score
+- crowd risk
+- rationale grounded in family preferences and memory
+- why it might not fit
+- research required before booking
+
+Implementation rule: do not claim live prices, current entry rules, or current availability unless
+the workflow explicitly uses live research tools.
+
+### Phase 4: Planning Workspace
+
+Once a concept is selected, create or update a Google Sheet as the operational workspace:
+
+- canonical itinerary
+- flight, lodging, car, and activity options considered
+- recommendation rationale and rejected alternatives
+- day-by-day plan
+- booking status and confirmations
+- costs and loyalty details
+- transport, buffers, map links, risk notes, and entry/health/cash checklist
+
+Implementation rule: the canonical JSON remains source of truth; the sheet is the family-facing
+workspace and should be syncable.
+
+### Phase 5: Source Registry And Booking Copilot
+
+Before live automation, every booking/research workflow should ask the source registry for a route:
+
+- flights: Google Flights first, Kayak.ca/Expedia/Flighthub cross-check
+- city lodging: Booking.com first, Tripadvisor/Trivago/Expedia validation
+- private lodging: Airbnb/VRBO first, Booking.com/Tripadvisor validation
+- tours: GetYourGuide first, Airbnb Experiences secondary, Tripadvisor validation
+- cars: Booking.com first, Expedia/Kayak.ca comparison
+- deals: Travelzoo for inspiration only
+
+Source records include platform, categories, strengths, weaknesses, confidence, access modes,
+prefer/avoid rules, and whether the site is currently better for discovery, validation, browser
+automation, or manual handoff.
+
+Implementation rule: source effectiveness is a learning target, but source ranking changes remain
+review-gated like other memory/rule changes.
+
+### Phase 6: Maps Output Layer
+
+Maps are operational artifacts, not decoration. Generate:
+
+- master trip map pins for airports, lodging, transfers, food, activities, and logistics
+- airport-to-lodging and stay-to-stay direction links
+- day-grouped map references
+- JSON, GeoJSON, and KML-style exports for My Maps or future geocoding
+
+Implementation rule: do not guess coordinates. Until geocoding is explicit, use address/search
+queries and Google Maps links.
+
+### Phase 7: Timeline Dashboard
+
+The dashboard should expose:
+
+- Past Trips timeline
+- Planned Trips timeline
+- Ideas Bucket
+- quick links to sheets, maps, confirmations, and notes
+- family-fit score, comfort score, completeness, budget band, risks, and next actions
+
+Implementation rule: start with generated static HTML + JSON. Move to a richer app only after the
+data model stabilizes.
+
+### Phase 8: Booking Copilot
+
+Stage this deliberately:
+
+1. structured comparison of exact fares/listings
+2. ready-to-click navigation and context handoff
+3. human-reviewed booking assist
+4. deeper automation only after repeated reliable runs
+
+Implementation rule: avoid brittle site automation until the recommendation and friction checks are
+solid enough to make automation worth trusting.
+
+### Phase 9: Concierge Mode
+
+Concierge mode should answer exact operational questions quickly from canonical state and attached
+evidence. It should prioritize retrieval and risk awareness over creative planning.
+
+Required behavior:
+
+- confirmation numbers, addresses, check-in times, access instructions
+- what is paid/unpaid, booked/unbooked, confirmed/unconfirmed
+- tomorrow's logistics and backup plans
+- transfer timing and luggage/kids burden
+- proactive warnings as risk windows approach
+
+### Phase 10: Post-Trip Retrospective
+
+After each trip, capture:
+
+- what worked
+- what was worth the money
+- what created friction
+- hard rules for next time
+- never-repeat items
+- favorite food, hotel, activity, and place moments
+- whether pace and destination fit expectations
+
+Implementation rule: retrospective output creates workflow records and pending learning proposals.
+It does not directly write memory.
+
+## Risks
+
+- **Overbroad live automation too early:** defer autonomous booking until exact-comparison workflows
+  are reliable.
+- **Unreviewed learning drift:** keep all memory and skill changes behind proposals.
+- **Generic recommendation leakage:** score all ideas against Chapman-specific preferences and
+  friction rules.
+- **False certainty on current rules:** visa, entry, vaccine, and live fare/listing details require
+  explicit current-source research before final recommendation.
+- **Map false precision:** do not create fake coordinates or route certainty; use explicit links and
+  unresolved map data until geocoded.
+- **Dashboard as vanity UI:** keep the dashboard focused on operational readiness, risks, links, and
+  decisions.

--- a/docs/NEXT_PHASE_ARCHITECTURE.md
+++ b/docs/NEXT_PHASE_ARCHITECTURE.md
@@ -20,6 +20,7 @@ Use existing Google Sheet, Gmail, and canonical trip import flows as evidence co
 the imported trips into durable, reviewable memory signals:
 
 - lodging fit by context: city hotel, city rental, rural rental, bed setup
+- country-level priors from historical ratings and notes
 - travel burden: total travel time, directness, connection tolerance
 - pacing: nights per stop, transitions per week, activity/chill balance
 - vendor and loyalty patterns: airlines, hotel groups, platforms, Aeroplan usage
@@ -27,6 +28,10 @@ the imported trips into durable, reviewable memory signals:
 
 Implementation rule: the extractor may propose and summarize memory, but memory writes remain
 review-gated through the existing learning proposal flow.
+
+Country priors are a first planning layer, not a rule engine. Strong countries still need
+sub-region, season, logistics, and trip-style checks. Weak or mixed countries can still be
+recommended when the exact concept resolves the historical friction.
 
 ### Phase 2: Comfort/Friction Engine
 
@@ -43,6 +48,7 @@ Core checks:
 - rental access, parking, safety, and late-arrival complexity
 - overcompressed trip pacing and risky same-day transitions
 - missing cash, visa, entry, health, and vaccination research
+- country-prior cautions such as historical crowd, safety, food, sickness, road, cost, or travel-burden friction
 - mass-market/crowded/weak-safety tour signals when activity data exists
 
 Implementation rule: if data is missing for a reliability-critical check, flag the missing data
@@ -63,6 +69,7 @@ Required concept output:
 - food score
 - crowd risk
 - rationale grounded in family preferences and memory
+- fit based on past country-level history
 - why it might not fit
 - research required before booking
 

--- a/tests/integration/test_ingest.py
+++ b/tests/integration/test_ingest.py
@@ -331,3 +331,112 @@ class TestGmailReconcilerCanonicalSync:
         assert updated.segments[0].confirmation_code == "ABC123"
         assert pushes == [("japan-2026", "sheet-abc-123")]
         assert result["ambiguities"] == []
+
+    def test_runner_dry_run_does_not_update_canonical_or_push_sheet(
+        self, file_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_trip(file_db)
+
+        from trippy import config
+        from trippy.ingest.gmail_watcher import EmailContent
+        from trippy.models.trip import Trip as CanonicalTrip
+        from trippy.models.trip import TripStatus
+        from trippy.services.trip_state import TripStateService
+        from trippy.skills.runners.gmail_reconciler import GmailReconcilerRunner
+
+        trips_dir = tmp_path / "trips"
+        monkeypatch.setattr(config, "DATABASE_URL", file_db)
+        monkeypatch.setattr(config, "TRIPS_PATH", trips_dir)
+        monkeypatch.setattr(config, "VAULT_PATH", tmp_path / "vault")
+
+        trip_state = TripStateService(trips_dir=trips_dir)
+        canonical_trip = CanonicalTrip(
+            trip_id="japan-2026",
+            name="Japan 2026",
+            status=TripStatus.BOOKED,
+            sync=SyncMetadata(google_sheet_id="sheet-abc-123"),
+            segments=[
+                Segment(
+                    segment_id="leg-1",
+                    segment_type=SegmentType.FLIGHT,
+                    carrier="Air Canada",
+                    flight_number="AC003",
+                    origin="YYZ",
+                    destination="NRT",
+                )
+            ],
+        )
+        trip_state.save(canonical_trip)
+
+        fixture_email = EmailContent(
+            message_id="m-1",
+            sender="bookings@aircanada.com",
+            subject="Your Air Canada booking confirmation",
+            date=canonical_trip.created_at,
+            body_text=(EMAILS_DIR / "aircanada_flight.txt").read_text(),
+            body_html="",
+            attachments=[],
+            raw_bytes=b"raw-email",
+        )
+
+        class FakeWatcher:
+            def __init__(self, auth_manager: object | None = None) -> None:
+                self._auth_manager = auth_manager
+
+            def authenticate(self) -> None:
+                return None
+
+            def fetch_new_messages(
+                self,
+                label: str = "INBOX",
+                max_results: int = 50,
+                query: str | None = None,
+            ) -> list[EmailContent]:
+                assert label == "INBOX"
+                assert max_results == 5
+                assert query == "from:aircanada.com"
+                return [fixture_email]
+
+            def save_to_vault(self, email_content: EmailContent, vault_path: Path) -> Path:
+                raise AssertionError("dry-run should not save email to vault")
+
+        pushes: list[tuple[str, str]] = []
+
+        class FakeSheetSyncService:
+            def __init__(self, auth_manager: object | None = None) -> None:
+                self._auth_manager = auth_manager
+
+            def push_trip_to_sheet(self, trip: CanonicalTrip, sheet_id: str) -> None:
+                pushes.append((trip.trip_id, sheet_id))
+
+        class FakeAuthManager:
+            pass
+
+        from trippy.ingest import gmail_watcher as watcher_mod
+        from trippy.ingest import google_auth as google_auth_mod
+        from trippy.services import sheet_sync as sheet_sync_mod
+
+        monkeypatch.setattr(watcher_mod, "GmailWatcher", FakeWatcher)
+        monkeypatch.setattr(google_auth_mod, "GoogleAuthManager", FakeAuthManager)
+        monkeypatch.setattr(sheet_sync_mod, "SheetSyncService", FakeSheetSyncService)
+
+        runner = GmailReconcilerRunner(
+            trips_dir=trips_dir,
+            anthropic_client=_make_parser_client("aircanada_flight"),
+        )
+        result = runner.run(
+            {
+                "max_emails": 5,
+                "trip_id": "japan-2026",
+                "query": "from:aircanada.com",
+                "dry_run": True,
+            }
+        )
+
+        updated = trip_state.load("japan-2026")
+        assert updated is not None
+        assert result["dry_run"] is True
+        assert result["confirmations_linked"] == 1
+        assert len(updated.confirmations) == 0
+        assert updated.segments[0].confirmation_code is None
+        assert pushes == []

--- a/tests/integration/test_sheet_sync_roundtrip.py
+++ b/tests/integration/test_sheet_sync_roundtrip.py
@@ -136,7 +136,21 @@ def _pulls_from_fixture(path: Path) -> dict[str, list[list[str]]]:
             ]
         )
 
-    hotel_rows = [["Stay ID", "Type", "Property", "City", "Country", "Check-in", "Check-out", "Nights", "Cost (CAD)", "Confirmation", "Notes"]]
+    hotel_rows = [
+        [
+            "Stay ID",
+            "Type",
+            "Property",
+            "City",
+            "Country",
+            "Check-in",
+            "Check-out",
+            "Nights",
+            "Cost (CAD)",
+            "Confirmation",
+            "Notes",
+        ]
+    ]
     for row in payload.get("hotels", []):
         hotel_rows.append(
             [

--- a/tests/unit/test_country_priors.py
+++ b/tests/unit/test_country_priors.py
@@ -1,0 +1,44 @@
+"""Tests for historical country-level travel priors."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from trippy.memory.store import MemoryStore
+from trippy.models.country_priors import CountryPriorBand
+from trippy.services.country_priors import CountryPriorService
+
+
+def test_country_priors_capture_high_and_caution_examples() -> None:
+    service = CountryPriorService()
+
+    greece = service.fit_for_country("Greece")
+    usa = service.fit_for_country("United States")
+    mexico = service.fit_for_country("Mexico")
+
+    assert greece is not None
+    assert greece.band == CountryPriorBand.STRONG_POSITIVE
+    assert "food" in greece.positive_signals
+    assert usa is not None
+    assert usa.band == CountryPriorBand.CAUTION
+    assert "safety/comfort concern" in usa.caution_signals
+    assert mexico is not None
+    assert mexico.band == CountryPriorBand.MIXED
+    assert "safety varies by region" in mexico.caution_signals
+
+
+def test_country_prior_text_matching_and_review_gated_proposals(tmp_path: Path) -> None:
+    memory_path = tmp_path / "memory.json"
+    service = CountryPriorService()
+
+    matches = service.fit_for_text("Japan and Thailand food trip")
+    proposals = service.propose_memory_updates(
+        learning_dir=tmp_path / "learning",
+        memory_path=memory_path,
+        countries=["Japan"],
+    )
+
+    assert {match.country for match in matches} == {"Japan", "Thailand"}
+    assert len(proposals) == 1
+    assert proposals[0].after["key"] == "country_prior:japan"
+    assert not MemoryStore(memory_path).all_entries()

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,0 +1,55 @@
+"""Tests for static dashboard generation."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from trippy.models.trip import RiskFlag, RiskSeverity, Trip, TripStatus
+from trippy.services.dashboard import DashboardService
+from trippy.services.trip_state import TripStateService
+
+
+def test_dashboard_builds_past_planned_and_idea_tiles(tmp_path: Path) -> None:
+    trip_state = TripStateService(trips_dir=tmp_path / "trips")
+    trip_state.save(
+        Trip(
+            trip_id="japan-2026",
+            name="Japan 2026",
+            status=TripStatus.LIVED,
+            destination_summary="Tokyo and Kyoto",
+            start_date=date(2026, 3, 1),
+            end_date=date(2026, 3, 14),
+            notes="Food and rail pacing worked well.",
+        )
+    )
+    trip_state.save(
+        Trip(
+            trip_id="portugal-2027",
+            name="Portugal 2027",
+            status=TripStatus.PLANNED,
+            destination_summary="Lisbon and Porto",
+            start_date=date(2027, 4, 1),
+            end_date=date(2027, 4, 10),
+            risk_flags=[
+                RiskFlag(
+                    risk_id="risk-1",
+                    severity=RiskSeverity.HIGH,
+                    category="lodging",
+                    description="Bed setup missing for family of 5.",
+                )
+            ],
+        )
+    )
+
+    dashboard = DashboardService(trip_state=trip_state).write_dashboard(tmp_path / "dashboard")
+
+    assert len(dashboard.past_trips) == 1
+    assert len(dashboard.planned_trips) == 1
+    assert dashboard.ideas
+    assert Path(dashboard.exports["html"]).exists()
+    assert "Trippy" in Path(dashboard.exports["html"]).read_text(encoding="utf-8")
+    assert json.loads(Path(dashboard.exports["json"]).read_text(encoding="utf-8"))["planned_trips"][
+        0
+    ]["key_risks"]

--- a/tests/unit/test_friction_detector.py
+++ b/tests/unit/test_friction_detector.py
@@ -371,6 +371,27 @@ class TestFamilyComfortChecks:
         assert [r for r in risks if r.risk_id == "missing-health-precautions"]
         assert [r for r in risks if r.risk_id == "tour-quality-tour-1"]
 
+    def test_country_prior_cautions_are_visible_but_not_trip_blocking(self) -> None:
+        trip = _make_trip(
+            destination_summary="Italy family food and history trip",
+            stays=[
+                Stay(
+                    stay_id="stay-1",
+                    property_name="Central Rome Hotel",
+                    city="Rome",
+                    country="Italy",
+                    room_type="king suite with 3 beds",
+                )
+            ],
+        )
+
+        risks = _detector().audit(trip)
+
+        country_risks = [r for r in risks if r.risk_id == "country-prior-italy"]
+        assert country_risks
+        assert country_risks[0].severity == RiskSeverity.LOW
+        assert "directional priors" in country_risks[0].description
+
 
 class TestNoRisks:
     def test_clean_trip_no_risks(self) -> None:

--- a/tests/unit/test_friction_detector.py
+++ b/tests/unit/test_friction_detector.py
@@ -6,9 +6,12 @@ from datetime import date, datetime
 
 from trippy.models.preferences import FamilyTravelPreferences
 from trippy.models.trip import (
+    ChecklistItem,
     RiskSeverity,
     Segment,
+    SegmentType,
     Stay,
+    StayType,
     Traveler,
     Trip,
     TripStatus,
@@ -279,6 +282,94 @@ class TestUnconfirmedBookings:
         unbooked = [r for r in risks if "unbooked-seg" in r.risk_id]
         assert len(unbooked) == 1
         assert unbooked[0].severity == RiskSeverity.MEDIUM
+
+
+class TestFamilyComfortChecks:
+    def test_family_stay_requires_explicit_three_bed_fit(self) -> None:
+        trip = _make_trip(
+            travelers=[Traveler(name=f"Traveler {i}") for i in range(5)],
+            stays=[
+                Stay(
+                    stay_id="stay-1",
+                    stay_type=StayType.HOTEL,
+                    property_name="Nice Hotel",
+                    city="Lisbon",
+                    country="Portugal",
+                    room_type="standard queen room",
+                )
+            ],
+        )
+
+        risks = _detector().audit(trip)
+
+        assert [r for r in risks if r.risk_id == "bed-fit-short-stay-1"]
+        assert [r for r in risks if r.risk_id == "queen-compromise-stay-1"]
+
+    def test_city_rental_without_exceptional_upside_is_flagged(self) -> None:
+        trip = _make_trip(
+            stays=[
+                Stay(
+                    stay_id="stay-1",
+                    stay_type=StayType.AIRBNB,
+                    property_name="Apartment",
+                    city="Rome",
+                    country="Italy",
+                    notes="basic apartment",
+                )
+            ],
+        )
+
+        risks = _detector().audit(trip)
+
+        assert [r for r in risks if r.risk_id == "city-rental-fit-stay-1"]
+
+    def test_driving_and_pacing_friction_are_flagged(self) -> None:
+        trip = _make_trip(
+            segments=[
+                Segment(
+                    segment_id="drive-1",
+                    segment_type=SegmentType.CAR,
+                    origin="Florence",
+                    destination="Hill Town",
+                    notes="narrow roads and difficult parking",
+                )
+            ],
+            stays=[
+                Stay(
+                    stay_id="stay-1",
+                    property_name="Transit Stop",
+                    city="Siena",
+                    country="Italy",
+                    check_in=date(2027, 3, 10),
+                    check_out=date(2027, 3, 11),
+                    room_type="king suite with 3 beds",
+                )
+            ],
+        )
+
+        risks = _detector().audit(trip)
+
+        assert [r for r in risks if r.risk_id == "driving-friction-drive-1"]
+        assert [r for r in risks if r.risk_id == "one-night-stop-stay-1"]
+
+    def test_missing_destination_readiness_and_tour_quality_are_flagged(self) -> None:
+        trip = _make_trip(
+            checklist=[
+                ChecklistItem(
+                    item_id="tour-1",
+                    category="activity",
+                    title="Large group food tour",
+                    notes="crowded mass market safety unknown",
+                )
+            ]
+        )
+
+        risks = _detector().audit(trip)
+
+        assert [r for r in risks if r.risk_id == "missing-cash-currency-guidance"]
+        assert [r for r in risks if r.risk_id == "missing-entry-requirements"]
+        assert [r for r in risks if r.risk_id == "missing-health-precautions"]
+        assert [r for r in risks if r.risk_id == "tour-quality-tour-1"]
 
 
 class TestNoRisks:

--- a/tests/unit/test_google_auth.py
+++ b/tests/unit/test_google_auth.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from trippy.ingest.google_auth import ALL_SCOPES, GoogleAuthManager
+from trippy.ingest.google_auth import ALL_SCOPES, GoogleAuthManager, missing_required_scopes
 
 
 def _manager(tmp_path: Path, credentials: object | None = None) -> GoogleAuthManager:
@@ -132,3 +132,22 @@ class TestScopes:
             scopes=scopes,
         )
         assert list(mgr._scopes) == scopes
+
+    def test_default_scopes_include_write_capable_sheets_and_drive(self) -> None:
+        assert "https://www.googleapis.com/auth/gmail.readonly" in ALL_SCOPES
+        assert "https://www.googleapis.com/auth/spreadsheets" in ALL_SCOPES
+        assert "https://www.googleapis.com/auth/drive" in ALL_SCOPES
+        assert "https://www.googleapis.com/auth/spreadsheets.readonly" not in ALL_SCOPES
+        assert "https://www.googleapis.com/auth/drive.readonly" not in ALL_SCOPES
+
+    def test_missing_required_scopes_detects_stale_token(self, tmp_path: Path) -> None:
+        token = tmp_path / "token.json"
+        token.write_text(
+            '{"scopes": ["https://www.googleapis.com/auth/gmail.readonly"]}',
+            encoding="utf-8",
+        )
+
+        missing = missing_required_scopes(token)
+
+        assert "https://www.googleapis.com/auth/spreadsheets" in missing
+        assert "https://www.googleapis.com/auth/drive" in missing

--- a/tests/unit/test_learning_store.py
+++ b/tests/unit/test_learning_store.py
@@ -1,0 +1,107 @@
+"""Tests for workflow feedback and review-gated learning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from trippy.memory.store import MemoryStore
+from trippy.services.learning import (
+    FeedbackRating,
+    LearningEventStore,
+    ProposalStatus,
+    ProposalType,
+    UserFeedback,
+    WorkflowOutcome,
+    WorkflowStatus,
+)
+
+
+def test_records_workflow_outcomes_deterministically(tmp_path: Path) -> None:
+    store = LearningEventStore(tmp_path / "learning")
+    outcome = WorkflowOutcome(
+        workflow_name="friction-audit",
+        skill_name="trippy-flight-friction-audit",
+        trip_id="japan-2027",
+        status=WorkflowStatus.SUCCESS,
+        summary="Found one tight connection",
+        metrics={"total_risks": 1},
+    )
+
+    store.record_workflow(outcome)
+
+    loaded = store.list_workflows()
+    assert [item.id for item in loaded] == [outcome.id]
+    assert store.events_path.exists()
+
+
+def test_feedback_creates_reviewable_memory_proposal_without_mutating_memory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trippy import config
+
+    memory_path = tmp_path / "memory.json"
+    monkeypatch.setattr(config, "MEMORY_PATH", memory_path)
+
+    store = LearningEventStore(tmp_path / "learning")
+    outcome = store.record_workflow(
+        WorkflowOutcome(
+            workflow_name="gmail-reconciler",
+            skill_name=None,
+            trip_id="japan-2027",
+            status=WorkflowStatus.SUCCESS,
+            summary="Reconciled Gmail",
+        )
+    )
+
+    proposals = store.add_feedback(
+        UserFeedback(
+            workflow_id=outcome.id,
+            rating=FeedbackRating.NEEDS_WORK,
+            notes="Prefer direct transfers when arriving late with luggage.",
+            future_learning=True,
+        )
+    )
+
+    assert len(proposals) == 1
+    assert proposals[0].proposal_type == ProposalType.MEMORY
+    assert proposals[0].status == ProposalStatus.PENDING
+    assert not memory_path.exists()
+
+
+def test_approving_memory_proposal_writes_memory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trippy import config
+
+    memory_path = tmp_path / "memory.json"
+    monkeypatch.setattr(config, "MEMORY_PATH", memory_path)
+
+    store = LearningEventStore(tmp_path / "learning")
+    outcome = store.record_workflow(
+        WorkflowOutcome(
+            workflow_name="trip-sheet-creator",
+            skill_name=None,
+            trip_id="japan-2027",
+            status=WorkflowStatus.SUCCESS,
+            summary="Created sheet",
+        )
+    )
+    proposals = store.add_feedback(
+        UserFeedback(
+            workflow_id=outcome.id,
+            rating=FeedbackRating.HELPFUL,
+            notes="Always add a JR Pass checklist item for Japan rail-heavy trips.",
+            future_learning=True,
+        )
+    )
+
+    approved = store.approve(proposals[0].id)
+
+    assert approved.status == ProposalStatus.APPROVED
+    entries = MemoryStore(memory_path).all_entries()
+    assert len(entries) == 1
+    assert "JR Pass" in str(entries[0].value)

--- a/tests/unit/test_map_outputs.py
+++ b/tests/unit/test_map_outputs.py
@@ -1,0 +1,76 @@
+"""Tests for Google Maps output artifacts."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+from trippy.models.maps import MapPinCategory
+from trippy.models.trip import Segment, SegmentType, Stay, StayType, Trip, TripStatus
+from trippy.services.map_outputs import MapOutputService
+
+
+def test_map_artifact_builds_pins_routes_and_links() -> None:
+    trip = _map_trip()
+    artifact = MapOutputService().build_trip_map(trip)
+
+    assert artifact.trip_id == "lisbon-2027"
+    assert any(pin.category == MapPinCategory.LODGING for pin in artifact.pins)
+    assert any("google.com/maps/search" in pin.google_maps_url for pin in artifact.pins)
+    assert artifact.routes
+    assert "google.com/maps/dir" in artifact.routes[0].google_maps_url
+    assert artifact.to_geojson()["features"][0]["geometry"] is None
+
+
+def test_map_artifact_writes_json_geojson_and_kml(tmp_path: Path) -> None:
+    trip = _map_trip()
+    artifact = MapOutputService().write_artifacts(trip, tmp_path)
+
+    json_path = Path(artifact.exports["json"])
+    geojson_path = Path(artifact.exports["geojson"])
+    kml_path = Path(artifact.exports["kml"])
+
+    assert json_path.exists()
+    assert geojson_path.exists()
+    assert kml_path.exists()
+    assert json.loads(geojson_path.read_text(encoding="utf-8"))["type"] == "FeatureCollection"
+    assert "<address>Rua Central 1, Lisbon, Portugal</address>" in kml_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def _map_trip() -> Trip:
+    start = date(2027, 3, 10)
+    depart = datetime(2027, 3, 10, 9, 30)
+    return Trip(
+        trip_id="lisbon-2027",
+        name="Lisbon 2027",
+        status=TripStatus.PLANNED,
+        destination_summary="Lisbon, Portugal",
+        start_date=start,
+        end_date=start + timedelta(days=7),
+        segments=[
+            Segment(
+                segment_id="seg-1",
+                segment_type=SegmentType.FLIGHT,
+                origin="YYZ",
+                destination="LIS",
+                depart_at=depart,
+                arrive_at=depart + timedelta(hours=7),
+            )
+        ],
+        stays=[
+            Stay(
+                stay_id="stay-1",
+                stay_type=StayType.HOTEL,
+                property_name="Central Lisbon Hotel",
+                city="Lisbon",
+                country="Portugal",
+                address="Rua Central 1, Lisbon, Portugal",
+                check_in=start,
+                check_out=start + timedelta(days=4),
+                room_type="king plus two twins",
+            )
+        ],
+    )

--- a/tests/unit/test_past_trip_miner.py
+++ b/tests/unit/test_past_trip_miner.py
@@ -28,7 +28,9 @@ def _fake_db_trip(name: str) -> SimpleNamespace:
 
 
 def test_import_sheet_persists_canonical_json_and_returns_trip_ids(tmp_path) -> None:
-    runner = PastTripMinerRunner(trips_dir=tmp_path, auth_manager=MagicMock(), anthropic_client=MagicMock())
+    runner = PastTripMinerRunner(
+        trips_dir=tmp_path, auth_manager=MagicMock(), anthropic_client=MagicMock()
+    )
 
     import_result = ImportResult(source="sheet-id")
     import_result.trips_created = 2
@@ -50,7 +52,9 @@ def test_import_sheet_persists_canonical_json_and_returns_trip_ids(tmp_path) -> 
         return _factory_ctx()
 
     with (
-        patch("trippy.importers.sheet_importer.SheetImporter.import_file", return_value=import_result),
+        patch(
+            "trippy.importers.sheet_importer.SheetImporter.import_file", return_value=import_result
+        ),
         patch("trippy.db.make_session_factory", return_value=_factory),
     ):
         result = runner._import_sheet({"id": "sheet-123", "name": "Ignored Name"})

--- a/tests/unit/test_phase_planner.py
+++ b/tests/unit/test_phase_planner.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from datetime import date
 
+from trippy.ingest.google_auth import ALL_SCOPES
 from trippy.memory.store import MemoryStore
 from trippy.models.trip import Trip, TripStatus
 from trippy.services.phase_planner import PhasePlannerService
@@ -16,13 +18,15 @@ def test_status_shows_phase_2_complete_when_google_files_exist(tmp_path, monkeyp
     creds = tmp_path / "gmail_credentials.json"
     token = tmp_path / "gmail_token.json"
     creds.write_text("{}", encoding="utf-8")
-    token.write_text("{}", encoding="utf-8")
+    token.write_text(json.dumps({"scopes": list(ALL_SCOPES)}), encoding="utf-8")
 
     monkeypatch.setattr(config, "GMAIL_CREDENTIALS_PATH", creds)
     monkeypatch.setattr(config, "GMAIL_TOKEN_PATH", token)
     monkeypatch.setattr(config, "GOOGLE_TOKEN_PATH", tmp_path / "google_token.json")
 
-    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    planner = PhasePlannerService(
+        memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips"
+    )
     phases = planner.status()
     phase2 = next(p for p in phases if p.phase == 2)
     assert phase2.complete
@@ -50,7 +54,9 @@ def test_status_marks_phase_3_complete_with_trips_and_preferences(tmp_path) -> N
         )
     )
 
-    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    planner = PhasePlannerService(
+        memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips"
+    )
     phases = planner.status()
     phase3 = next(p for p in phases if p.phase == 3)
     assert phase3.complete
@@ -65,7 +71,9 @@ def test_run_phase_2_reports_file_existence(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(config, "GMAIL_TOKEN_PATH", tmp_path / "gmail_token.json")
     monkeypatch.setattr(config, "GOOGLE_TOKEN_PATH", tmp_path / "google_token.json")
 
-    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    planner = PhasePlannerService(
+        memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips"
+    )
     result = planner.run_phase(2)
     assert result["phase"] == 2
     assert result["credentials_exist"] is True
@@ -73,6 +81,8 @@ def test_run_phase_2_reports_file_existence(tmp_path, monkeypatch) -> None:
 
 
 def test_run_phase_unsupported_returns_error(tmp_path) -> None:
-    planner = PhasePlannerService(memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips")
+    planner = PhasePlannerService(
+        memory_path=tmp_path / "memory.json", trips_dir=tmp_path / "trips"
+    )
     result = planner.run_phase(99)
     assert "error" in result

--- a/tests/unit/test_retrospective.py
+++ b/tests/unit/test_retrospective.py
@@ -1,0 +1,50 @@
+"""Tests for post-trip retrospective learning proposals."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+from trippy.memory.store import MemoryStore
+from trippy.models.retrospective import TripRetrospectiveInput
+from trippy.models.trip import Trip, TripStatus
+from trippy.services.learning import LearningEventStore
+from trippy.services.retrospective import RetrospectiveService
+from trippy.services.trip_state import TripStateService
+
+
+def test_retrospective_creates_reviewable_proposals_without_mutating_memory(
+    tmp_path: Path,
+) -> None:
+    memory_path = tmp_path / "memory.json"
+    learning = LearningEventStore(tmp_path / "learning", memory_path=memory_path)
+    trip_state = TripStateService(trips_dir=tmp_path / "trips")
+    trip_state.save(
+        Trip(
+            trip_id="japan-2026",
+            name="Japan 2026",
+            status=TripStatus.LIVED,
+            start_date=date(2026, 3, 1),
+            end_date=date(2026, 3, 1) + timedelta(days=14),
+        )
+    )
+
+    result = RetrospectiveService(trip_state=trip_state, learning_store=learning).record(
+        TripRetrospectiveInput(
+            trip_id="japan-2026",
+            worked=["Central hotels near rail stations were worth it."],
+            friction=["One transfer day was too compressed."],
+            hard_rules=["Never book a family city stay without explicit 3-bed confirmation."],
+            never_repeat=["Do not schedule luggage-heavy transfers before breakfast."],
+            favorites=["Small ramen tour was a highlight."],
+            pace="Two major activities per day was the upper limit.",
+        )
+    )
+
+    assert result.workflow_id
+    assert len(result.proposal_ids) == 5
+    assert not memory_path.exists()
+
+    approved = learning.approve(result.proposal_ids[0])
+    assert approved.status.value == "approved"
+    assert MemoryStore(memory_path).all_entries()

--- a/tests/unit/test_review_gated_learning_paths.py
+++ b/tests/unit/test_review_gated_learning_paths.py
@@ -1,0 +1,118 @@
+"""Tests that learning paths create proposals instead of mutating memory."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from trippy.agent import _execute_tool
+from trippy.memory.preference_writer import PreferenceWriter
+from trippy.memory.store import MemoryStore
+from trippy.models.trip import Segment, Stay, StayType, Traveler, Trip, TripStatus
+from trippy.services.learning import LearningEventStore
+from trippy.services.trip_state import TripStateService
+from trippy.skills.runners.preference_extractor import PreferenceExtractorRunner
+
+
+def test_preference_extractor_proposes_without_mutating_memory(tmp_path: Path) -> None:
+    memory = MemoryStore(tmp_path / "memory.json")
+    trips_dir = tmp_path / "trips"
+    learning_dir = tmp_path / "learning"
+    trip_svc = TripStateService(trips_dir=trips_dir)
+    trip_svc.save(_lived_trip("portugal-2025", date(2025, 3, 1)))
+
+    result = PreferenceExtractorRunner(memory_store=memory, trips_dir=trips_dir).run(
+        {
+            "min_evidence_trips": 1,
+            "learning_dir": learning_dir,
+        }
+    )
+
+    assert result["preferences_written"] == {}
+    assert result["preferences_proposed"]
+    assert result["learning_proposals"]
+    assert memory.all_entries() == []
+
+    store = LearningEventStore(learning_dir, memory_path=memory.path)
+    proposal = store.approve(result["learning_proposals"][0])
+    assert proposal.status.value == "approved"
+    assert MemoryStore(memory.path).all_entries()
+
+
+def test_agent_memory_tool_creates_reviewable_proposal(tmp_path: Path) -> None:
+    memory = MemoryStore(tmp_path / "memory.json")
+    trip_svc = TripStateService(trips_dir=tmp_path / "trips")
+    learning_dir = tmp_path / "learning"
+
+    result = _execute_tool(
+        "update_memory",
+        {
+            "key": "pref:test",
+            "value": "Prefer central boutique hotels in cities.",
+            "category": "preference",
+            "confidence": 0.8,
+        },
+        memory,
+        trip_svc,
+        learning_dir,
+    )
+
+    assert '"review_required": true' in result
+    assert memory.all_entries() == []
+    assert LearningEventStore(learning_dir, memory_path=memory.path).list_proposals()
+
+
+def test_preference_writer_direct_write_requires_approval(tmp_path: Path) -> None:
+    memory = MemoryStore(tmp_path / "memory.json")
+
+    with pytest.raises(PermissionError):
+        PreferenceWriter(memory).extract_and_write(
+            [_lived_trip("italy-2025", date(2025, 5, 1))],
+            min_trips=1,
+        )
+
+    assert memory.all_entries() == []
+
+
+def _lived_trip(trip_id: str, start: date) -> Trip:
+    depart = datetime.combine(start, datetime.min.time()).replace(hour=9)
+    arrive = depart + timedelta(hours=7)
+    return Trip(
+        trip_id=trip_id,
+        name="Portugal 2025",
+        status=TripStatus.LIVED,
+        destination_summary="Lisbon and Porto",
+        start_date=start,
+        end_date=start + timedelta(days=8),
+        travelers=[
+            Traveler(name="Ken", passport_country="CAN"),
+            Traveler(name="Traveler 2"),
+            Traveler(name="Traveler 3"),
+            Traveler(name="Traveler 4"),
+            Traveler(name="Traveler 5"),
+        ],
+        segments=[
+            Segment(
+                segment_id="flight-1",
+                carrier="Air Canada",
+                origin="YYZ",
+                destination="LIS",
+                depart_at=depart,
+                arrive_at=arrive,
+            )
+        ],
+        stays=[
+            Stay(
+                stay_id="stay-1",
+                stay_type=StayType.HOTEL,
+                property_name="Central Lisbon Hotel",
+                city="Lisbon",
+                country="Portugal",
+                check_in=start,
+                check_out=start + timedelta(days=4),
+                notes="central walkable boutique hotel; king bed plus 2 twins",
+            )
+        ],
+    )

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1,0 +1,77 @@
+"""Tests for first-run setup diagnostics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from trippy.ingest.google_auth import ALL_SCOPES
+from trippy.services.setup import CheckStatus, SetupDoctor
+
+
+def _patch_config_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from trippy import config
+
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "state.db")
+    monkeypatch.setattr(config, "MEMORY_PATH", tmp_path / "memory.json")
+    monkeypatch.setattr(config, "TRIPS_PATH", tmp_path / "trips")
+    monkeypatch.setattr(config, "VAULT_PATH", tmp_path / "vault")
+    monkeypatch.setattr(config, "EXPORT_PATH", tmp_path / "export")
+    monkeypatch.setattr(config, "LEARNING_PATH", tmp_path / "learning")
+    monkeypatch.setattr(config, "GMAIL_CREDENTIALS_PATH", tmp_path / "gmail_credentials.json")
+    monkeypatch.setattr(config, "GMAIL_TOKEN_PATH", tmp_path / "gmail_token.json")
+    monkeypatch.setattr(config, "GOOGLE_TOKEN_PATH", tmp_path / "google_token.json")
+    monkeypatch.setattr(config, "ANTHROPIC_API_KEY", "sk-ant-test")
+
+
+def test_doctor_reports_missing_google_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config_paths(tmp_path, monkeypatch)
+    (tmp_path / "gmail_credentials.json").write_text("{}", encoding="utf-8")
+
+    report = SetupDoctor(project_root=tmp_path).run()
+
+    token_check = report.check("google_token")
+    assert token_check is not None
+    assert token_check.status == CheckStatus.FAIL
+
+
+def test_doctor_reports_stale_google_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config_paths(tmp_path, monkeypatch)
+    (tmp_path / "gmail_credentials.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "google_token.json").write_text(
+        json.dumps({"scopes": ["https://www.googleapis.com/auth/gmail.readonly"]}),
+        encoding="utf-8",
+    )
+
+    report = SetupDoctor(project_root=tmp_path).run()
+
+    scopes_check = report.check("google_scopes")
+    assert scopes_check is not None
+    assert scopes_check.status == CheckStatus.FAIL
+    assert "spreadsheets" in (scopes_check.detail or "")
+
+
+def test_doctor_accepts_required_google_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config_paths(tmp_path, monkeypatch)
+    (tmp_path / "gmail_credentials.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "google_token.json").write_text(
+        json.dumps({"scopes": list(ALL_SCOPES)}),
+        encoding="utf-8",
+    )
+
+    report = SetupDoctor(project_root=tmp_path).run()
+
+    scopes_check = report.check("google_scopes")
+    assert scopes_check is not None
+    assert scopes_check.status == CheckStatus.PASS

--- a/tests/unit/test_skill_learning.py
+++ b/tests/unit/test_skill_learning.py
@@ -125,7 +125,9 @@ class TestRollback:
 
 
 class TestEvaluationHarness:
-    def test_replays_fixtures_and_compares_pre_post(self, skill_env: tuple[Path, Path, Path]) -> None:
+    def test_replays_fixtures_and_compares_pre_post(
+        self, skill_env: tuple[Path, Path, Path]
+    ) -> None:
         defs_dir, metadata, _ = skill_env
         svc = SkillLearningService(definitions_dir=defs_dir, metadata_path=metadata)
 

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -1,0 +1,41 @@
+"""Tests for deterministic travel source routing."""
+
+from __future__ import annotations
+
+from trippy.models.sources import TravelSourceCategory
+from trippy.services.source_registry import TravelSourceRegistry
+
+
+def test_source_registry_contains_required_platforms() -> None:
+    registry = TravelSourceRegistry()
+    names = {source.platform_name for source in registry.list_sources()}
+
+    assert {
+        "Expedia",
+        "Booking.com",
+        "Kayak.ca",
+        "Google Flights",
+        "Airbnb",
+        "GetYourGuide",
+        "Airbnb Experiences",
+        "VRBO",
+        "Trivago",
+        "Hertz",
+        "Flighthub",
+        "Travelzoo",
+        "Tripadvisor",
+    }.issubset(names)
+
+
+def test_default_routing_matches_booking_priorities() -> None:
+    registry = TravelSourceRegistry()
+
+    flights = registry.plan_for(TravelSourceCategory.FLIGHTS)
+    cars = registry.plan_for(TravelSourceCategory.CAR_RENTALS)
+    tours = registry.plan_for(TravelSourceCategory.TOURS)
+
+    assert [source.platform_name for source in flights.primary] == ["Google Flights"]
+    assert flights.primary[0].model_dump()["supports_browser_automation"] is True
+    assert "Kayak.ca" in [source.platform_name for source in flights.secondary]
+    assert [source.platform_name for source in cars.primary] == ["Booking.com"]
+    assert [source.platform_name for source in tours.primary] == ["GetYourGuide"]

--- a/tests/unit/test_travel_intelligence.py
+++ b/tests/unit/test_travel_intelligence.py
@@ -1,0 +1,77 @@
+"""Tests for extracting reusable travel intelligence from trip history."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from trippy.memory.store import MemoryStore
+from trippy.models.trip import RiskFlag, RiskSeverity, Stay, StayType, Traveler, Trip, TripStatus
+from trippy.services.learning import LearningEventStore, ProposalType
+from trippy.services.travel_intelligence import TravelIntelligenceService
+
+
+def test_extracts_family_lodging_and_pacing_signals() -> None:
+    trip = Trip(
+        trip_id="tokyo-2026",
+        name="Tokyo 2026",
+        status=TripStatus.LIVED,
+        destination_summary="Tokyo",
+        travelers=[Traveler(name=f"Traveler {i}") for i in range(5)],
+        stays=[
+            Stay(
+                stay_id="stay-1",
+                stay_type=StayType.HOTEL,
+                property_name="Central Boutique Hotel",
+                city="Tokyo",
+                country="Japan",
+                check_in=date(2026, 3, 10),
+                check_out=date(2026, 3, 14),
+                room_type="king suite with 3 beds",
+                notes="central walkable near transit",
+            )
+        ],
+    )
+
+    report = TravelIntelligenceService().analyze([trip])
+
+    keys = {signal.key for signal in report.all_signals}
+    assert "family_requires_three_bed_validation" in keys
+    assert "city_core_hotel_pattern" in keys
+    assert "average_nights_per_stop" in keys
+
+
+def test_proposes_memory_without_applying_until_approved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trippy import config
+
+    memory_path = tmp_path / "memory.json"
+    monkeypatch.setattr(config, "MEMORY_PATH", memory_path)
+    trip = Trip(
+        trip_id="rome-2026",
+        name="Rome 2026",
+        status=TripStatus.LIVED,
+        travelers=[Traveler(name=f"Traveler {i}") for i in range(5)],
+        risk_flags=[
+            RiskFlag(
+                risk_id="risk-1",
+                severity=RiskSeverity.MEDIUM,
+                category="pacing",
+                description="Too many stops",
+            )
+        ],
+    )
+    service = TravelIntelligenceService()
+    report = service.analyze([trip])
+
+    proposals = service.propose_memory_updates(report, learning_dir=tmp_path / "learning")
+
+    assert proposals
+    assert all(proposal.proposal_type == ProposalType.MEMORY for proposal in proposals)
+    assert not memory_path.exists()
+    LearningEventStore(tmp_path / "learning").approve(proposals[0].id)
+    assert MemoryStore(memory_path).all_entries()

--- a/tests/unit/test_trip_ideation.py
+++ b/tests/unit/test_trip_ideation.py
@@ -1,0 +1,37 @@
+"""Tests for family-fit trip concept comparison."""
+
+from __future__ import annotations
+
+from trippy.models.ideas import TripIdeaRequest
+from trippy.services.trip_ideation import TripIdeationService
+
+
+def test_trip_ideas_rank_food_focused_options() -> None:
+    comparison = TripIdeationService().compare(
+        TripIdeaRequest(
+            duration_days=10,
+            max_flight_hours=8,
+            goals=["food", "culture"],
+            avoid=["crowds"],
+        )
+    )
+
+    assert comparison.concepts
+    top = comparison.concepts[0]
+    assert top.food_score >= 88
+    assert top.required_research
+    assert comparison.recommended_concept_id == top.concept_id
+
+
+def test_trip_ideas_penalize_long_flights_for_short_max() -> None:
+    comparison = TripIdeationService().compare(
+        TripIdeaRequest(
+            duration_days=7,
+            max_flight_hours=6,
+            goals=["food"],
+            avoid=["crowds"],
+        )
+    )
+
+    japan = next(c for c in comparison.concepts if c.concept_id == "japan-food-rail-cities")
+    assert any("exceeds requested max" in reason for reason in japan.why_it_may_not_fit)

--- a/tests/unit/test_trip_ideation.py
+++ b/tests/unit/test_trip_ideation.py
@@ -30,8 +30,24 @@ def test_trip_ideas_penalize_long_flights_for_short_max() -> None:
             max_flight_hours=6,
             goals=["food"],
             avoid=["crowds"],
-        )
+        ),
+        limit=10,
     )
 
     japan = next(c for c in comparison.concepts if c.concept_id == "japan-food-rail-cities")
     assert any("exceeds requested max" in reason for reason in japan.why_it_may_not_fit)
+
+
+def test_trip_ideas_include_country_prior_rationale() -> None:
+    comparison = TripIdeationService().compare(
+        TripIdeaRequest(duration_days=14, goals=["food", "culture"]),
+        limit=10,
+    )
+
+    japan = next(c for c in comparison.concepts if c.concept_id == "japan-food-rail-cities")
+    italy = next(c for c in comparison.concepts if c.concept_id == "italy-food-culture-rail")
+
+    assert japan.country_prior_signals
+    assert any("past country-level history" in item for item in japan.rationale)
+    assert any("expense" in item for item in japan.why_it_may_not_fit)
+    assert any("summer heat" in item for item in italy.why_it_may_not_fit)

--- a/trippy/agent.py
+++ b/trippy/agent.py
@@ -74,6 +74,7 @@ def _build_system_prompt(
     operations_mode: bool = False,
     active_trip_context: str | None = None,
     orchestration_context: str | None = None,
+    setup_context: str | None = None,
 ) -> str:
     parts: list[str] = []
 
@@ -108,6 +109,9 @@ def _build_system_prompt(
 
     if orchestration_context:
         parts.append(orchestration_context)
+
+    if setup_context:
+        parts.append(setup_context)
 
     return "\n\n---\n\n".join(parts)
 
@@ -170,8 +174,9 @@ def _skill_tools() -> list[dict[str, Any]]:
         {
             "name": "update_memory",
             "description": (
-                "Write a durable preference or insight to agent memory. "
-                "Use this only for genuinely reusable, non-trip-specific facts."
+                "Create a reviewable proposal for a durable preference or insight. "
+                "Use this only for genuinely reusable, non-trip-specific facts; "
+                "approval is required before memory changes."
             ),
             "input_schema": {
                 "type": "object",
@@ -213,6 +218,7 @@ def _execute_tool(
     inputs: dict[str, Any],
     memory: MemoryStore,
     trip_svc: TripStateService,
+    learning_dir: Path | None = None,
 ) -> str:
     if name == "invoke_skill":
         return _run_skill(inputs.get("skill_name", ""), inputs.get("inputs", {}))
@@ -228,15 +234,35 @@ def _execute_tool(
         return json.dumps({"trips": [t.summary() for t in trips]})
 
     if name == "update_memory":
-        entry = memory.set(
-            key=inputs["key"],
-            value=inputs["value"],
-            category=inputs["category"],
-            confidence=inputs.get("confidence", 1.0),
-            source="agent",
-            notes=inputs.get("notes"),
+        from trippy.services.learning import LearningEventStore, LearningProposal, ProposalType
+
+        key = str(inputs["key"])
+        existing = memory.get(key)
+        proposals = LearningEventStore(learning_dir, memory_path=memory.path).add_proposals(
+            [
+                LearningProposal(
+                    proposal_type=ProposalType.MEMORY,
+                    summary=f"Review agent-proposed memory update: {key}",
+                    before=existing.model_dump(mode="json") if existing else None,
+                    after={
+                        "key": key,
+                        "value": inputs["value"],
+                        "category": inputs["category"],
+                        "confidence": inputs.get("confidence", 1.0),
+                        "source": "agent",
+                        "notes": inputs.get("notes"),
+                    },
+                )
+            ]
         )
-        return json.dumps({"ok": True, "key": entry.key, "version": entry.version})
+        return json.dumps(
+            {
+                "ok": True,
+                "review_required": True,
+                "proposal_id": proposals[0].id,
+                "key": key,
+            }
+        )
 
     if name == "run_friction_audit":
         from trippy.skills.runners.friction_audit import FrictionAuditRunner
@@ -298,11 +324,16 @@ class TrIppyAgent:
         anthropic_client: anthropic.Anthropic | None = None,
         memory_path: Path | None = None,
         trips_dir: Path | None = None,
+        learning_dir: Path | None = None,
     ) -> None:
         self._client = anthropic_client or anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
         self._memory = MemoryStore(memory_path or config.MEMORY_PATH)
         self._trip_svc = TripStateService(trips_dir=trips_dir or config.TRIPS_PATH)
+        self._learning_dir = learning_dir or (
+            memory_path.parent / "learning" if memory_path is not None else config.LEARNING_PATH
+        )
         self._history: list[dict[str, Any]] = []
+        self._last_workflow_id: str | None = None
 
     def _classify_intent(self, user_message: str) -> UserIntent:
         msg = user_message.lower()
@@ -368,6 +399,61 @@ class TrIppyAgent:
             logger.exception("Sheet sync refresh failed for trip %s", trip.trip_id)
             return {"ok": False, "error": str(exc)}
 
+    def _setup_context(self) -> str | None:
+        from trippy.services.setup import CheckStatus, SetupDoctor
+
+        report = SetupDoctor(project_root=Path.cwd()).run(create_paths=False)
+        blockers = [
+            check
+            for check in report.checks
+            if check.status == CheckStatus.FAIL
+            and check.name
+            in {"anthropic_key", "google_credentials", "google_token", "google_scopes"}
+        ]
+        if not blockers:
+            return None
+        lines = [
+            "## Setup Blockers",
+            "Explain these blockers before attempting live Google workflows:",
+        ]
+        lines.extend(f"- {check.summary}" for check in blockers)
+        if report.next_actions:
+            lines.append("Next actions:")
+            lines.extend(f"- {action}" for action in report.next_actions)
+        return "\n".join(lines)
+
+    def _record_agent_workflow(
+        self,
+        *,
+        intent: UserIntent,
+        active_trip: Trip | None,
+        events: list[dict[str, Any]],
+    ) -> None:
+        if not events:
+            self._last_workflow_id = None
+            return
+
+        from trippy.services.learning import LearningEventStore, WorkflowOutcome, WorkflowStatus
+
+        skill_name = None
+        for event in events:
+            if event.get("skill_name"):
+                skill_name = str(event["skill_name"])
+                break
+
+        outcome = WorkflowOutcome(
+            workflow_name=f"agent:{intent.value}",
+            skill_name=skill_name,
+            trip_id=active_trip.trip_id if active_trip else None,
+            status=WorkflowStatus.SUCCESS,
+            summary=f"Agent handled {intent.value} with {len(events)} tool/orchestration event(s)",
+            metrics={"events": len(events)},
+            artifacts={"events": events},
+            evidence_refs=[f"agent-intent:{intent.value}"],
+        )
+        LearningEventStore(self._learning_dir).record_workflow(outcome)
+        self._last_workflow_id = outcome.id
+
     def chat(self, user_message: str) -> str:
         """Process a single user message and return the agent's response."""
         intent = self._classify_intent(user_message)
@@ -389,6 +475,7 @@ class TrIppyAgent:
 
         orchestration_events: list[dict[str, Any]] = []
         if intent == UserIntent.RECONCILE_BOOKINGS:
+            assert active_trip is not None
             orchestration_events.append(
                 {
                     "action": "invoke_skill",
@@ -400,7 +487,11 @@ class TrIppyAgent:
             )
         elif intent == UserIntent.IN_TRIP_OPS and active_trip is not None:
             orchestration_events.append(
-                {"action": "get_trip", "trip_id": active_trip.trip_id, "result": active_trip.model_dump()}
+                {
+                    "action": "get_trip",
+                    "trip_id": active_trip.trip_id,
+                    "result": active_trip.model_dump(),
+                }
             )
             orchestration_events.append(
                 {
@@ -412,6 +503,7 @@ class TrIppyAgent:
                             {"trip_id": active_trip.trip_id, "check_preferences": True},
                             self._memory,
                             self._trip_svc,
+                            self._learning_dir,
                         )
                     ),
                 }
@@ -437,9 +529,9 @@ class TrIppyAgent:
         if orchestration_events:
             orchestration_context = (
                 "## Deterministic Orchestration\n"
-                f"intent={intent.value}\n"
-                + json.dumps(orchestration_events, indent=2, default=str)
+                f"intent={intent.value}\n" + json.dumps(orchestration_events, indent=2, default=str)
             )
+        setup_context = self._setup_context()
 
         system_prompt = _build_system_prompt(
             self._memory,
@@ -447,8 +539,10 @@ class TrIppyAgent:
             operations_mode=intent == UserIntent.IN_TRIP_OPS,
             active_trip_context=active_trip_context,
             orchestration_context=orchestration_context,
+            setup_context=setup_context,
         )
         tools = _skill_tools()
+        workflow_events = list(orchestration_events)
 
         # Agentic loop — keep running until no more tool calls
         for _ in range(10):
@@ -473,6 +567,7 @@ class TrIppyAgent:
                         dict(block.input),
                         self._memory,
                         self._trip_svc,
+                        self._learning_dir,
                     )
                     tool_results.append(
                         {
@@ -481,17 +576,31 @@ class TrIppyAgent:
                             "content": result,
                         }
                     )
+                    workflow_events.append(
+                        {
+                            "action": "tool_use",
+                            "tool_name": block.name,
+                            "input": dict(block.input),
+                            "result": result,
+                        }
+                    )
 
             # Add assistant turn to history
             self._history.append({"role": "assistant", "content": response.content})
 
             if response.stop_reason == "end_turn" or not tool_results:
                 final_text = "\n".join(text_parts)
+                self._record_agent_workflow(
+                    intent=intent,
+                    active_trip=active_trip,
+                    events=workflow_events,
+                )
                 return final_text
 
             # Add tool results and continue
             self._history.append({"role": "user", "content": tool_results})
 
+        self._record_agent_workflow(intent=intent, active_trip=active_trip, events=workflow_events)
         return "Agent loop limit reached."
 
     def run_interactive(self) -> None:
@@ -518,6 +627,10 @@ class TrIppyAgent:
         if active_trips:
             console.print(f"[dim]Active trips: {', '.join(t.name for t in active_trips)}[/dim]\n")
 
+        setup_context = self._setup_context()
+        if setup_context:
+            console.print("[yellow]Setup has blockers. Run `trippy doctor` for details.[/yellow]\n")
+
         while True:
             try:
                 user_input = console.input("[bold green]You:[/bold green] ").strip()
@@ -535,6 +648,13 @@ class TrIppyAgent:
                     response = self.chat(user_input)
                 console.print("[bold cyan]Trippy:[/bold cyan]")
                 console.print(Markdown(response))
+                if self._last_workflow_id:
+                    console.print(
+                        f"\n[dim]Workflow ID: {self._last_workflow_id}[/dim]\n"
+                        "[dim]Share feedback with:[/dim] "
+                        f'trippy feedback {self._last_workflow_id} --rating helpful --notes "..." '
+                        "--future-learning"
+                    )
                 console.print()
             except KeyboardInterrupt:
                 console.print("\n[dim](interrupted)[/dim]\n")

--- a/trippy/cli.py
+++ b/trippy/cli.py
@@ -227,6 +227,57 @@ def sources(
     _print_sources(items)
 
 
+@app.command("country-priors")
+def country_priors(
+    country: str = typer.Argument("", help="Optional country name to inspect"),
+    propose_learning: bool = typer.Option(
+        False,
+        "--propose-learning",
+        help="Create review-gated memory proposals for the shown country priors",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Show historical country-level preference priors."""
+    from trippy.services.country_priors import CountryPriorService
+
+    service = CountryPriorService()
+    if country:
+        prior = service.get(country)
+        if prior is None:
+            console.print(f"[red]No country prior found for:[/red] {country}")
+            raise typer.Exit(1)
+        priors = [prior]
+    else:
+        priors = service.list_priors()
+
+    workflow_id = _record_cli_workflow(
+        workflow_name="country-priors",
+        summary=f"Reviewed {len(priors)} country-level travel prior(s)",
+        result={"country_priors": [prior.model_dump(mode="json") for prior in priors]},
+        status=WorkflowStatus.SUCCESS,
+    )
+    proposals = []
+    if propose_learning:
+        proposals = service.propose_memory_updates(
+            source_workflow_id=workflow_id,
+            countries=[prior.country for prior in priors],
+        )
+
+    payload = {
+        "workflow_id": workflow_id,
+        "country_priors": [prior.model_dump(mode="json") for prior in priors],
+        "learning_proposals": [proposal.id for proposal in proposals],
+    }
+    if json_output:
+        _print_json(payload)
+        return
+    _print_country_priors(priors)
+    if proposals:
+        console.print(f"\nCreated {len(proposals)} review-gated learning proposal(s).")
+        console.print("Review with: [bold]trippy learn review[/bold]")
+    _print_workflow_footer(workflow_id)
+
+
 @app.command("maps")
 def maps(
     trip_name: str = typer.Argument(..., help="Canonical trip ID or name to map"),
@@ -1121,6 +1172,28 @@ def _print_source_plan(plan: Any) -> None:
     console.print(table)
     for note in plan.notes:
         console.print(f"  · {note}")
+
+
+def _print_country_priors(priors: list[Any]) -> None:
+    table = Table(title="Historical Country Priors", show_lines=True)
+    table.add_column("Country", style="bold")
+    table.add_column("Rating")
+    table.add_column("Band")
+    table.add_column("Positive Signals")
+    table.add_column("Cautions")
+    for prior in priors:
+        table.add_row(
+            prior.country,
+            str(prior.rating) if prior.rating is not None else "",
+            prior.band.value,
+            ", ".join(prior.positive_signals[:4]),
+            ", ".join(prior.caution_signals[:4]),
+        )
+    console.print(table)
+    console.print(
+        "[dim]Country priors are directional. Trip goals, season, sub-region, logistics, "
+        "and newer evidence can override them.[/dim]"
+    )
 
 
 def _print_map_artifact(artifact: Any) -> None:

--- a/trippy/cli.py
+++ b/trippy/cli.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
+import json as json_lib
+from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import typer
 from rich.console import Console
-from rich.json import JSON
 from rich.table import Table
+
+from trippy.services.learning import FeedbackRating, WorkflowOutcome, WorkflowStatus
 
 if TYPE_CHECKING:
     from trippy.db.models import Trip as TripModel
     from trippy.importers.sheet_importer import ImportResult as ImportResultType
 
 app = typer.Typer(name="trippy", help="Chapman family travel concierge.")
+learn_app = typer.Typer(help="Review and apply Trippy learning proposals.")
+app.add_typer(learn_app, name="learn")
 console = Console()
 
 
@@ -37,6 +42,7 @@ def db_init() -> None:
     config.VAULT_PATH.mkdir(parents=True, exist_ok=True)
     config.EXPORT_PATH.mkdir(parents=True, exist_ok=True)
     config.TRIPS_PATH.mkdir(parents=True, exist_ok=True)
+    config.LEARNING_PATH.mkdir(parents=True, exist_ok=True)
     result = subprocess.run(["alembic", "upgrade", "head"], capture_output=True, text=True)
     typer.echo(result.stdout)
     if result.returncode != 0:
@@ -60,7 +66,277 @@ def thin_slice(
     """Run the end-to-end thin slice demo."""
     from trippy.thin_slice import run_thin_slice
 
-    run_thin_slice(real_google=real_google)
+    result = run_thin_slice(real_google=real_google)
+    workflow_id = _record_cli_workflow(
+        workflow_name="thin-slice",
+        summary="Ran the end-to-end thin slice demo",
+        result=result,
+        status=WorkflowStatus.SUCCESS,
+    )
+    _print_workflow_footer(workflow_id)
+
+
+@app.command("doctor")
+def doctor(
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Check local setup, credentials, scopes, storage, DB, and MCP readiness."""
+    from trippy.services.setup import SetupDoctor
+
+    report = SetupDoctor(project_root=Path.cwd()).run()
+    if json_output:
+        _print_json(report.model_dump(mode="json"))
+    else:
+        _print_setup_report(report)
+    if not report.ok:
+        raise typer.Exit(1)
+
+
+@app.command("auth-google")
+def auth_google(
+    force: bool = typer.Option(False, "--force", help="Delete existing token and re-run OAuth"),
+) -> None:
+    """Run Google OAuth and validate Gmail, Sheets write, and Drive access."""
+    from trippy.services.setup import GoogleAuthValidator
+
+    result = GoogleAuthValidator().run(force=force)
+    _print_setup_report(result)
+    if not result.ok:
+        raise typer.Exit(1)
+
+
+@app.command("mine-intelligence")
+def mine_intelligence(
+    min_support: int = typer.Option(
+        1, "--min-support", help="Evidence count required for a signal"
+    ),
+    propose_learning: bool = typer.Option(
+        True,
+        "--propose-learning/--no-propose-learning",
+        help="Create review-gated memory proposals from extracted signals",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Extract reusable planning intelligence from canonical trip history."""
+    from trippy.services.travel_intelligence import TravelIntelligenceService
+    from trippy.services.trip_state import TripStateService
+
+    trips = TripStateService().load_all()
+    service = TravelIntelligenceService()
+    report = service.analyze(trips, min_support=min_support)
+    workflow_id = _record_cli_workflow(
+        workflow_name="mine-intelligence",
+        summary=report.summary,
+        result=report.model_dump(mode="json"),
+        status=WorkflowStatus.SUCCESS if trips else WorkflowStatus.SKIPPED,
+        skill_name="trippy-preference-extractor",
+    )
+    proposals = []
+    if propose_learning:
+        proposals = service.propose_memory_updates(report, source_workflow_id=workflow_id)
+
+    payload = {
+        "workflow_id": workflow_id,
+        "report": report.model_dump(mode="json"),
+        "learning_proposals": [proposal.id for proposal in proposals],
+    }
+    if json_output:
+        _print_json(payload)
+        return
+    _print_intelligence_report(report)
+    if proposals:
+        console.print(f"\nCreated {len(proposals)} review-gated learning proposal(s).")
+        console.print("Review with: [bold]trippy learn review[/bold]")
+    _print_workflow_footer(workflow_id)
+
+
+@app.command("trip-ideas")
+def trip_ideas(
+    time_of_year: str = typer.Option("", "--time", help="Time of year or season"),
+    duration_days: int = typer.Option(0, "--days", help="Trip duration in days"),
+    budget_cad: float = typer.Option(0.0, "--budget-cad", help="Approximate total budget CAD"),
+    max_flight_hours: float = typer.Option(
+        0.0, "--max-flight-hours", help="Preferred max flight hours"
+    ),
+    direct: bool = typer.Option(True, "--direct/--connections-ok", help="Prefer direct flights"),
+    goal: list[str] | None = typer.Option(None, "--goal", help="Trip goal; repeatable"),
+    avoid: list[str] | None = typer.Option(None, "--avoid", help="Things to avoid; repeatable"),
+    vibe: str = typer.Option("", "--vibe", help="Desired trip vibe"),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Generate and rank family-fit trip concepts from loose constraints."""
+    from trippy.models.ideas import TripIdeaRequest
+    from trippy.services.trip_ideation import TripIdeationService
+
+    request = TripIdeaRequest(
+        time_of_year=time_of_year or None,
+        duration_days=duration_days or None,
+        budget_cad=budget_cad or None,
+        max_flight_hours=max_flight_hours or None,
+        direct_flight_preferred=direct,
+        goals=goal or [],
+        avoid=avoid or [],
+        desired_vibe=vibe or None,
+    )
+    comparison = TripIdeationService().compare(request)
+    workflow_id = _record_cli_workflow(
+        workflow_name="trip-ideas",
+        summary="Generated ranked family-fit trip concepts",
+        result=comparison.model_dump(mode="json"),
+        status=WorkflowStatus.SUCCESS,
+    )
+    payload = {"workflow_id": workflow_id, "comparison": comparison.model_dump(mode="json")}
+    if json_output:
+        _print_json(payload)
+        return
+    _print_trip_ideas(comparison)
+    _print_workflow_footer(workflow_id)
+
+
+@app.command("sources")
+def sources(
+    category: str = typer.Option(
+        "",
+        "--category",
+        help="Optional category: flights, city_lodging, private_lodging, tours, car_rentals, deals",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Show Trippy's travel source registry and routing plan."""
+    from trippy.models.sources import TravelSourceCategory
+    from trippy.services.source_registry import TravelSourceRegistry
+
+    registry = TravelSourceRegistry()
+    if category:
+        try:
+            selected = TravelSourceCategory(category)
+        except ValueError as exc:
+            console.print(f"[red]Unknown source category:[/red] {category}")
+            raise typer.Exit(1) from exc
+        plan = registry.plan_for(selected)
+        if json_output:
+            _print_json(plan.model_dump(mode="json"))
+            return
+        _print_source_plan(plan)
+        return
+
+    items = registry.list_sources()
+    if json_output:
+        _print_json([item.model_dump(mode="json") for item in items])
+        return
+    _print_sources(items)
+
+
+@app.command("maps")
+def maps(
+    trip_name: str = typer.Argument(..., help="Canonical trip ID or name to map"),
+    output_dir: Path = typer.Option(
+        Path(""),
+        "--output-dir",
+        help="Directory for JSON, GeoJSON, and KML outputs. Defaults to TRIPPY_EXPORT_PATH/maps.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Generate practical Google Maps artifacts for a trip."""
+    from trippy import config
+    from trippy.services.map_outputs import MapOutputService
+
+    trip = _load_canonical_trip_or_exit(trip_name)
+    destination = output_dir if str(output_dir) else config.EXPORT_PATH / "maps"
+    artifact = MapOutputService().write_artifacts(trip, destination)
+    workflow_id = _record_cli_workflow(
+        workflow_name="maps",
+        trip_id=trip.trip_id,
+        summary=f"Generated map artifacts for {trip.name}",
+        result=artifact.model_dump(mode="json"),
+        status=WorkflowStatus.SUCCESS,
+    )
+    if json_output:
+        _print_json(artifact.model_dump(mode="json"))
+        return
+    _print_map_artifact(artifact)
+    _print_workflow_footer(workflow_id)
+
+
+@app.command("dashboard")
+def dashboard(
+    output_dir: Path = typer.Option(
+        Path(""),
+        "--output-dir",
+        help="Dashboard output directory. Defaults to TRIPPY_EXPORT_PATH/dashboard.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Build the static Trippy timeline dashboard."""
+    from trippy import config
+    from trippy.services.dashboard import DashboardService
+
+    destination = output_dir if str(output_dir) else config.EXPORT_PATH / "dashboard"
+    data = DashboardService().write_dashboard(destination)
+    workflow_id = _record_cli_workflow(
+        workflow_name="dashboard",
+        summary="Built Trippy timeline dashboard",
+        result=data.model_dump(mode="json"),
+        status=WorkflowStatus.SUCCESS,
+    )
+    if json_output:
+        _print_json(data.model_dump(mode="json"))
+        return
+    _print_dashboard_summary(data)
+    _print_workflow_footer(workflow_id)
+
+
+@app.command("retro")
+def retro(
+    trip_id: str = typer.Argument(..., help="Canonical trip ID for the completed trip"),
+    worked: list[str] | None = typer.Option(None, "--worked", help="What worked; repeatable"),
+    worth_money: list[str] | None = typer.Option(
+        None, "--worth-money", help="What was worth the money; repeatable"
+    ),
+    friction: list[str] | None = typer.Option(
+        None, "--friction", help="What created friction; repeatable"
+    ),
+    hard_rule: list[str] | None = typer.Option(
+        None, "--hard-rule", help="Hard rule for future trips; repeatable"
+    ),
+    never_repeat: list[str] | None = typer.Option(
+        None, "--never-repeat", help="What not to repeat; repeatable"
+    ),
+    favorite: list[str] | None = typer.Option(
+        None, "--favorite", help="Favorite place, food, hotel, or activity; repeatable"
+    ),
+    pace: str = typer.Option("", "--pace", help="Whether the pace felt right"),
+    expectations: str = typer.Option(
+        "", "--expectations", help="Whether destination matched expectations"
+    ),
+    notes: str = typer.Option("", "--notes", help="General retrospective notes"),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Capture a post-trip retrospective and create review-gated learning proposals."""
+    from trippy.models.retrospective import TripRetrospectiveInput
+    from trippy.services.retrospective import RetrospectiveService
+
+    result = RetrospectiveService().record(
+        TripRetrospectiveInput(
+            trip_id=trip_id,
+            worked=worked or [],
+            worth_money=worth_money or [],
+            friction=friction or [],
+            hard_rules=hard_rule or [],
+            never_repeat=never_repeat or [],
+            favorites=favorite or [],
+            pace=pace or None,
+            expectations=expectations or None,
+            notes=notes or None,
+        )
+    )
+    if json_output:
+        _print_json(result.model_dump(mode="json"))
+        return
+    console.print(f"[green]{result.summary}[/green]")
+    console.print(f"Workflow ID: [dim]{result.workflow_id}[/dim]")
+    if result.proposal_ids:
+        console.print("Review with: [bold]trippy learn review[/bold]")
 
 
 @app.command("import")
@@ -75,6 +351,19 @@ def import_sheet(
     console.print(f"[bold]Importing:[/bold] {source}")
     result = importer.import_file(source)
     _print_import_result(result)
+    workflow_id = _record_cli_workflow(
+        workflow_name="import-sheet",
+        summary=f"Imported trip sheet {source}",
+        result={
+            "source": result.source,
+            "trips_created": result.trips_created,
+            "trips_updated": result.trips_updated,
+            "errors": result.errors,
+            "flagged_fields": len(result.flagged_fields),
+        },
+        status=WorkflowStatus.FAILED if result.errors else WorkflowStatus.SUCCESS,
+    )
+    _print_workflow_footer(workflow_id)
     if not result.ok:
         raise typer.Exit(1)
 
@@ -98,6 +387,13 @@ def import_folder(
 
     if not results:
         console.print("[yellow]No .xlsx or .csv files found.[/yellow]")
+        workflow_id = _record_cli_workflow(
+            workflow_name="import-folder",
+            summary=f"No importable trip sheets found in {folder}",
+            result={"folder": str(folder), "files": 0, "dry_run": dry_run},
+            status=WorkflowStatus.SKIPPED,
+        )
+        _print_workflow_footer(workflow_id)
         return
 
     total_created = total_updated = 0
@@ -110,6 +406,19 @@ def import_folder(
         f"\n[bold]Total:[/bold] {len(results)} files · "
         f"{total_created} created · {total_updated} updated"
     )
+    workflow_id = _record_cli_workflow(
+        workflow_name="import-folder",
+        summary=f"Imported trip sheets from {folder}",
+        result={
+            "folder": str(folder),
+            "files": len(results),
+            "trips_created": total_created,
+            "trips_updated": total_updated,
+            "dry_run": dry_run,
+        },
+        status=WorkflowStatus.SKIPPED if dry_run else WorkflowStatus.SUCCESS,
+    )
+    _print_workflow_footer(workflow_id)
 
 
 @app.command("import-drive-folder")
@@ -138,6 +447,14 @@ def import_drive_folder_cmd(
         for f in files:
             console.print(f"  · {f.get('name', '?')}  [dim]{f['id']}[/dim]")
         console.print(f"\nFound {len(files)} sheet(s). Run without --dry-run to import.")
+        workflow_id = _record_cli_workflow(
+            workflow_name="import-drive-folder",
+            skill_name="trippy-past-trip-miner",
+            summary=f"Previewed Google Sheets in Drive folder {folder_id}",
+            result={"folder_id": folder_id, "files_found": len(files), "dry_run": True},
+            status=WorkflowStatus.SKIPPED,
+        )
+        _print_workflow_footer(workflow_id)
         return
 
     console.print(f"[bold]Importing Drive folder:[/bold] {folder_id}")
@@ -148,6 +465,20 @@ def import_drive_folder_cmd(
     console.print(
         f"\n[bold]Total:[/bold] {result.total_created} created · {result.total_updated} updated"
     )
+    workflow_id = _record_cli_workflow(
+        workflow_name="import-drive-folder",
+        skill_name="trippy-past-trip-miner",
+        summary=f"Imported Google Sheets from Drive folder {folder_id}",
+        result={
+            "folder_id": folder_id,
+            "files_found": result.files_found,
+            "trips_created": result.total_created,
+            "trips_updated": result.total_updated,
+            "errors": result.errors,
+        },
+        status=WorkflowStatus.FAILED if result.errors else WorkflowStatus.SUCCESS,
+    )
+    _print_workflow_footer(workflow_id)
     if result.errors:
         raise typer.Exit(1)
 
@@ -228,56 +559,36 @@ def show_trip(
 def ingest_emails(
     max_results: int = typer.Option(50, "--max", help="Max emails to fetch"),
     label: str = typer.Option("INBOX", "--label", help="Gmail label to fetch from"),
+    query: str = typer.Option("", "--query", help="Optional Gmail search query override"),
+    trip_id: str = typer.Option("", "--trip-id", help="Only reconcile confirmations for this trip"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without writing state"),
 ) -> None:
     """Fetch new booking confirmation emails from Gmail and ingest them."""
-    from trippy import config
-    from trippy.db import make_session_factory
-    from trippy.ingest.gmail_watcher import GmailWatcher
-    from trippy.ingest.google_auth import GoogleAuthManager
-    from trippy.ingest.linker import ingest_email
-    from trippy.ingest.parser import ConfirmationParser
+    from trippy.skills.runners.gmail_reconciler import GmailReconcilerRunner
 
-    auth = GoogleAuthManager()
-    watcher = GmailWatcher(auth_manager=auth)
-    watcher.authenticate()
-
-    console.print(f"[bold]Fetching[/bold] up to {max_results} messages from {label}…")
-    emails = watcher.fetch_new_messages(label=label, max_results=max_results)
-    console.print(f"Found {len(emails)} message(s) from trusted senders.")
-
-    parser = ConfirmationParser()
-    factory = make_session_factory()
-    linked = unlinked = skipped = 0
-
-    for email_content in emails:
-        eml_path = watcher.save_to_vault(email_content, config.VAULT_PATH)
-        atts = [(a.filename, a.content_type, a.data) for a in email_content.attachments]
-        result = parser.parse(
-            body_text=email_content.body_text,
-            body_html=email_content.body_html,
-            attachments=atts,
-            eml_path=eml_path,
-        )
-        if not result.ok or result.confirmation is None:
-            console.print(f"  [yellow]skipped[/yellow] {email_content.subject!r}: {result.error}")
-            skipped += 1
-            continue
-
-        with factory() as session:
-            link = ingest_email(result.confirmation, session, raw_email_path=str(eml_path))
-
-        icon = "[green]✓[/green]" if link.linked else "[yellow]?[/yellow]"
-        trip_label = f"trip {link.trip_id}" if link.linked else "unlinked inbox"
-        console.print(
-            f"  {icon} {result.confirmation.confirmation_code!r} "
-            f"({result.confirmation.vendor}) → {trip_label} [{link.method}]"
-        )
-        if link.linked:
-            linked += 1
-        else:
-            unlinked += 1
-
-    console.print(f"\n[bold]Done.[/bold] {linked} linked · {unlinked} unlinked · {skipped} skipped")
+    mode = "[yellow](dry-run)[/yellow] " if dry_run else ""
+    console.print(
+        f"{mode}[bold]Reconciling[/bold] up to {max_results} Gmail messages from {label}…"
+    )
+    result = GmailReconcilerRunner().run(
+        {
+            "max_emails": max_results,
+            "label": label,
+            "query": query or None,
+            "trip_id": trip_id or None,
+            "dry_run": dry_run,
+        }
+    )
+    _print_reconcile_summary(result)
+    workflow_id = _record_cli_workflow(
+        workflow_name="gmail-reconciler",
+        skill_name="trippy-gmail-reconciler",
+        trip_id=trip_id or result.get("target_trip_id"),
+        summary="Reconciled Gmail booking confirmations",
+        result=result,
+        status=WorkflowStatus.SKIPPED if dry_run else WorkflowStatus.SUCCESS,
+    )
+    _print_workflow_footer(workflow_id)
 
 
 @app.command("friction-audit")
@@ -311,6 +622,15 @@ def friction_audit(
 
     if not risks:
         console.print(f"[green]✓ No risks found for {trip.name}[/green]")
+        workflow_id = _record_cli_workflow(
+            workflow_name="friction-audit",
+            skill_name="trippy-flight-friction-audit",
+            trip_id=trip.trip_id,
+            summary=f"No risks found for {trip.name}",
+            result={"trip_id": trip.trip_id, "total_risks": 0},
+            status=WorkflowStatus.SUCCESS,
+        )
+        _print_workflow_footer(workflow_id)
         return
 
     t = Table(title=f"Friction Audit: {trip.name}", show_lines=True)
@@ -329,6 +649,20 @@ def friction_audit(
             (r.recommended_fix or "")[:60],
         )
     console.print(t)
+    workflow_id = _record_cli_workflow(
+        workflow_name="friction-audit",
+        skill_name="trippy-flight-friction-audit",
+        trip_id=trip.trip_id,
+        summary=f"Found {len(risks)} risk(s) for {trip.name}",
+        result={
+            "trip_id": trip.trip_id,
+            "total_risks": len(risks),
+            "high": len([r for r in risks if r.severity.value == "high"]),
+            "critical": len([r for r in risks if r.severity.value == "critical"]),
+        },
+        status=WorkflowStatus.SUCCESS,
+    )
+    _print_workflow_footer(workflow_id)
 
 
 @app.command("phase-status")
@@ -371,7 +705,7 @@ def phase_status() -> None:
 def phase_run(
     phase: int = typer.Argument(..., help="Roadmap phase number (2-6)"),
     folder_id: str = typer.Option("", "--folder-id", help="Drive folder ID (phase 3/4)"),
-    query: str = typer.Option("trip", "--query", help="Drive search query (phase 3)"),
+    query: str = typer.Option("", "--query", help="Drive/Gmail query override"),
     max_sheets: int = typer.Option(50, "--max-sheets", help="Max sheets to scan (phase 3)"),
     min_evidence_trips: int = typer.Option(
         2, "--min-evidence-trips", help="Trips required for preference extraction (phase 3)"
@@ -380,6 +714,11 @@ def phase_run(
     template_sheet_id: str = typer.Option("", "--template-sheet-id", help="Sheet template ID"),
     max_emails: int = typer.Option(50, "--max-emails", help="Max emails to reconcile (phase 5)"),
     trip_id: str = typer.Option("", "--trip-id", help="Trip ID for friction audit (phase 6)"),
+    label: str = typer.Option("INBOX", "--label", help="Gmail label for phase 5"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview phase workflow without writes where supported"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
 ) -> None:
     """Run one roadmap phase workflow and print structured output."""
     from trippy.services.phase_planner import PhasePlannerService
@@ -392,25 +731,418 @@ def phase_run(
     result = planner.run_phase(
         phase=phase,
         folder_id=folder_id or None,
-        query=query,
+        query=query or ("trip" if phase == 3 else None),
         max_sheets=max_sheets,
         min_evidence_trips=min_evidence_trips,
         trip_idea=trip_idea,
         template_sheet_id=template_sheet_id or None,
         max_emails=max_emails,
         trip_id=trip_id or None,
+        label=label,
+        dry_run=dry_run,
     )
 
     if result.get("error"):
         console.print(f"[red]{result['error']}[/red]")
         raise typer.Exit(1)
 
-    console.print(JSON.from_data(result))
+    workflow_id = _record_cli_workflow(
+        workflow_name=f"phase-{phase}",
+        skill_name=_phase_skill_name(phase),
+        trip_id=trip_id or _result_trip_id(result),
+        summary=f"Ran roadmap phase {phase}",
+        result=result,
+        status=_phase_workflow_status(result, dry_run=dry_run),
+    )
+    result["workflow_id"] = workflow_id
+
+    if json_output:
+        _print_json(result)
+    else:
+        _print_phase_run_summary(result)
+        _print_workflow_footer(workflow_id)
+
+
+@app.command("feedback")
+def feedback(
+    workflow_id: str = typer.Argument(..., help="Workflow ID printed by Trippy"),
+    rating: FeedbackRating = typer.Option(..., "--rating", help="helpful, needs-work, or wrong"),
+    notes: str = typer.Option(..., "--notes", help="What was helpful or wrong"),
+    correction: str = typer.Option("", "--correction", help="Corrected behavior or preference"),
+    future_learning: bool = typer.Option(
+        False,
+        "--future-learning",
+        help="Create reviewable memory/skill proposals from this feedback",
+    ),
+) -> None:
+    """Attach explicit feedback to a workflow and optionally create learning proposals."""
+    from trippy.services.learning import LearningEventStore, UserFeedback
+
+    store = LearningEventStore()
+    fb = UserFeedback(
+        workflow_id=workflow_id,
+        rating=rating,
+        notes=notes,
+        correction=correction or None,
+        future_learning=future_learning,
+    )
+    proposals = store.add_feedback(fb)
+    console.print(f"[green]Feedback recorded:[/green] {fb.id}")
+    if future_learning:
+        if proposals:
+            console.print(f"Created {len(proposals)} reviewable learning proposal(s).")
+            console.print("Review with: [bold]trippy learn review[/bold]")
+        else:
+            console.print(
+                "[yellow]No proposals created. Check that the workflow ID exists.[/yellow]"
+            )
+
+
+@learn_app.command("review")
+def learn_review(
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Show pending memory and skill learning proposals."""
+    from trippy.services.learning import LearningEventStore
+
+    proposals = LearningEventStore().list_proposals()
+    if json_output:
+        _print_json([p.model_dump(mode="json") for p in proposals])
+        return
+    _print_learning_proposals(proposals)
+
+
+@learn_app.command("approve")
+def learn_approve(
+    proposal_id: str = typer.Argument(..., help="Learning proposal ID"),
+) -> None:
+    """Approve and apply a pending learning proposal."""
+    from trippy.services.learning import LearningEventStore
+
+    proposal = LearningEventStore().approve(proposal_id)
+    console.print(f"[green]Approved:[/green] {proposal.id} — {proposal.summary}")
+
+
+@learn_app.command("reject")
+def learn_reject(
+    proposal_id: str = typer.Argument(..., help="Learning proposal ID"),
+) -> None:
+    """Reject a pending learning proposal."""
+    from trippy.services.learning import LearningEventStore
+
+    proposal = LearningEventStore().reject(proposal_id)
+    console.print(f"[yellow]Rejected:[/yellow] {proposal.id} — {proposal.summary}")
 
 
 # ---------------------------------------------------------------------------
 # Print helpers
 # ---------------------------------------------------------------------------
+
+
+def _load_canonical_trip_or_exit(trip_name: str) -> Any:
+    from trippy.services.trip_state import TripStateService
+
+    trip_svc = TripStateService()
+    trip = trip_svc.load(trip_name.lower().replace(" ", "-"))
+    if trip is not None:
+        return trip
+    matches = [t for t in trip_svc.load_all() if trip_name.lower() in t.name.lower()]
+    if not matches:
+        console.print(f"[red]No canonical trip found matching:[/red] {trip_name}")
+        raise typer.Exit(1)
+    return matches[0]
+
+
+def _print_json(data: Any) -> None:
+    typer.echo(json_lib.dumps(data, indent=2, sort_keys=True, default=str))
+
+
+def _record_cli_workflow(
+    *,
+    workflow_name: str,
+    summary: str,
+    result: dict[str, Any],
+    status: WorkflowStatus,
+    skill_name: str | None = None,
+    trip_id: str | None = None,
+) -> str:
+    from trippy.services.learning import LearningEventStore
+
+    ended_at = datetime.utcnow()
+    safe_result = _jsonable(result)
+    metrics = _numeric_metrics(safe_result)
+    outcome = WorkflowOutcome(
+        workflow_name=workflow_name,
+        skill_name=skill_name,
+        trip_id=trip_id,
+        status=status,
+        started_at=ended_at,
+        ended_at=ended_at,
+        summary=summary,
+        metrics=metrics,
+        artifacts={"result": safe_result},
+    )
+    LearningEventStore().record_workflow(outcome)
+    return outcome.id
+
+
+def _jsonable(value: object) -> dict[str, Any]:
+    raw = json_lib.dumps(value, default=str)
+    loaded = json_lib.loads(raw)
+    return loaded if isinstance(loaded, dict) else {"value": loaded}
+
+
+def _numeric_metrics(result: dict[str, Any]) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    for key, value in result.items():
+        if isinstance(value, (int, float, bool, str)) or value is None:
+            metrics[key] = value
+    return metrics
+
+
+def _print_workflow_footer(workflow_id: str) -> None:
+    console.print(f"\n[dim]Workflow ID:[/dim] {workflow_id}")
+    console.print(
+        "[dim]Feedback:[/dim] "
+        f'trippy feedback {workflow_id} --rating helpful --notes "..." --future-learning'
+    )
+
+
+def _print_setup_report(report: Any) -> None:
+    checks = report.checks
+    table = Table(title="Trippy Setup", show_lines=True)
+    table.add_column("Check", style="bold")
+    table.add_column("Status")
+    table.add_column("Summary")
+    table.add_column("Detail")
+    colors = {"pass": "green", "warn": "yellow", "fail": "red", "skip": "dim"}
+    for check in checks:
+        status = check.status.value
+        color = colors.get(status, "white")
+        table.add_row(
+            check.name,
+            f"[{color}]{status.upper()}[/{color}]",
+            check.summary,
+            check.detail or "",
+        )
+    console.print(table)
+    next_actions = getattr(report, "next_actions", [])
+    if next_actions:
+        console.print("\n[bold]Next actions[/bold]")
+        for action in next_actions:
+            console.print(f"  · {action}")
+
+
+def _print_reconcile_summary(result: dict[str, Any]) -> None:
+    dry = " [yellow](dry-run)[/yellow]" if result.get("dry_run") else ""
+    console.print(
+        f"\n[bold]Done{dry}.[/bold] "
+        f"{result.get('confirmations_linked', 0)} linked · "
+        f"{result.get('confirmations_unlinked', 0)} unlinked · "
+        f"{result.get('parse_failures', 0)} parse failures"
+    )
+    updates = result.get("updates", [])
+    if isinstance(updates, list):
+        for update in updates[:10]:
+            if isinstance(update, dict):
+                console.print(
+                    "  [green]✓[/green] "
+                    f"{update.get('confirmation_code')} → {update.get('trip_canonical_id')}"
+                )
+    ambiguities = result.get("ambiguities", [])
+    if isinstance(ambiguities, list) and ambiguities:
+        console.print(f"  [yellow]{len(ambiguities)} item(s) need review.[/yellow]")
+
+
+def _phase_skill_name(phase: int) -> str | None:
+    return {
+        3: "trippy-past-trip-miner",
+        4: "trippy-trip-sheet-creator",
+        5: "trippy-gmail-reconciler",
+        6: "trippy-flight-friction-audit",
+    }.get(phase)
+
+
+def _phase_workflow_status(result: dict[str, Any], *, dry_run: bool) -> WorkflowStatus:
+    if dry_run:
+        return WorkflowStatus.SKIPPED
+    if result.get("error") or result.get("setup_ok") is False:
+        return WorkflowStatus.FAILED
+    return WorkflowStatus.SUCCESS
+
+
+def _result_trip_id(result: dict[str, Any]) -> str | None:
+    for key in ("created", "reconciled", "audit"):
+        value = result.get(key)
+        if isinstance(value, dict) and value.get("trip_id"):
+            return str(value["trip_id"])
+    return None
+
+
+def _print_phase_run_summary(result: dict[str, Any]) -> None:
+    phase = result.get("phase")
+    console.print(f"[bold]Phase {phase} complete.[/bold]")
+    if phase == 2:
+        checks = result.get("checks", [])
+        failed = [c for c in checks if isinstance(c, dict) and c.get("status") in {"fail", "skip"}]
+        if failed:
+            for check in failed:
+                console.print(f"  [red]✗[/red] {check.get('summary')}")
+        else:
+            console.print("  [green]✓[/green] Setup checks passed.")
+    elif phase == 3:
+        mined = result.get("mined", {})
+        extracted = result.get("extracted", {})
+        if isinstance(mined, dict):
+            console.print(
+                f"  Trips imported: {mined.get('trips_imported', 0)} · "
+                f"updated: {mined.get('trips_updated', 0)}"
+            )
+        if isinstance(extracted, dict):
+            prefs = extracted.get("preferences_proposed", {})
+            proposals = extracted.get("learning_proposals", [])
+            console.print(f"  Preferences proposed: {len(prefs) if isinstance(prefs, dict) else 0}")
+            if isinstance(proposals, list) and proposals:
+                console.print(f"  Review-gated learning proposals: {len(proposals)}")
+    elif phase == 4:
+        created = result.get("created", {})
+        if isinstance(created, dict):
+            console.print(f"  Trip: {created.get('trip_id')} — {created.get('trip_name')}")
+            if created.get("sheet_url"):
+                console.print(f"  Sheet: {created.get('sheet_url')}")
+            if created.get("sheet_error"):
+                console.print(f"  [yellow]Sheet error:[/yellow] {created.get('sheet_error')}")
+    elif phase == 5:
+        reconciled = result.get("reconciled", {})
+        if isinstance(reconciled, dict):
+            _print_reconcile_summary(reconciled)
+    elif phase == 6:
+        audit = result.get("audit", {})
+        if isinstance(audit, dict):
+            console.print(
+                f"  Risks: {audit.get('total_risks', 0)} "
+                f"({audit.get('critical', 0)} critical, {audit.get('high', 0)} high)"
+            )
+
+
+def _print_learning_proposals(proposals: list[Any]) -> None:
+    if not proposals:
+        console.print("[green]No pending learning proposals.[/green]")
+        return
+    table = Table(title="Pending Learning Proposals", show_lines=True)
+    table.add_column("ID", style="dim")
+    table.add_column("Type")
+    table.add_column("Summary")
+    table.add_column("Source")
+    for proposal in proposals:
+        table.add_row(
+            proposal.id,
+            proposal.proposal_type.value,
+            proposal.summary,
+            proposal.source_workflow_id or "",
+        )
+    console.print(table)
+    console.print("\nApprove with: [bold]trippy learn approve <proposal-id>[/bold]")
+
+
+def _print_intelligence_report(report: Any) -> None:
+    console.print(f"[bold]{report.summary}[/bold]")
+    table = Table(title="Travel Intelligence Signals", show_lines=True)
+    table.add_column("Key", style="dim")
+    table.add_column("Category")
+    table.add_column("Confidence")
+    table.add_column("Rationale")
+    for signal in report.all_signals[:20]:
+        table.add_row(
+            signal.key,
+            signal.category.value,
+            f"{signal.confidence:.0%}",
+            signal.rationale,
+        )
+    console.print(table)
+
+
+def _print_trip_ideas(comparison: Any) -> None:
+    table = Table(title="Ranked Trip Concepts", show_lines=True)
+    table.add_column("Score", justify="right")
+    table.add_column("Concept", style="bold")
+    table.add_column("Duration")
+    table.add_column("Cost Band")
+    table.add_column("Travel")
+    table.add_column("Fit Notes")
+    for concept in comparison.concepts:
+        marker = (
+            " [green]recommended[/green]"
+            if concept.concept_id == comparison.recommended_concept_id
+            else ""
+        )
+        table.add_row(
+            str(concept.total_score),
+            concept.title + marker,
+            f"{concept.recommended_duration_days} days",
+            concept.estimated_cost_band_cad,
+            concept.estimated_travel_burden,
+            "; ".join(concept.rationale[:2]),
+        )
+    console.print(table)
+    console.print("\n[bold]Required research before booking[/bold]")
+    if comparison.concepts:
+        for item in comparison.concepts[0].required_research:
+            console.print(f"  · {item}")
+    for note in comparison.scoring_notes:
+        console.print(f"[dim]{note}[/dim]")
+
+
+def _print_sources(sources: list[Any]) -> None:
+    table = Table(title="Travel Source Registry", show_lines=True)
+    table.add_column("Platform", style="bold")
+    table.add_column("Categories")
+    table.add_column("Confidence")
+    table.add_column("Access")
+    table.add_column("Prefer When")
+    for source in sources:
+        table.add_row(
+            source.platform_name,
+            ", ".join(category.value for category in source.categories),
+            source.confidence_level.value,
+            ", ".join(mode.value for mode in source.access_modes),
+            "; ".join(source.prefer_when[:2]),
+        )
+    console.print(table)
+
+
+def _print_source_plan(plan: Any) -> None:
+    table = Table(title=f"Source Routing: {plan.category.value}", show_lines=True)
+    table.add_column("Role", style="bold")
+    table.add_column("Sources")
+    for role in ("primary", "secondary", "validation"):
+        sources = getattr(plan, role)
+        table.add_row(role, ", ".join(source.platform_name for source in sources) or "None")
+    console.print(table)
+    for note in plan.notes:
+        console.print(f"  · {note}")
+
+
+def _print_map_artifact(artifact: Any) -> None:
+    console.print(f"[bold]{artifact.title}[/bold]")
+    console.print(f"Pins: {len(artifact.pins)} · Routes: {len(artifact.routes)}")
+    for pin in artifact.pins[:8]:
+        console.print(f"  · {pin.label}: {pin.google_maps_url}")
+    if artifact.exports:
+        console.print("\n[bold]Exports[/bold]")
+        for label, path in artifact.exports.items():
+            console.print(f"  · {label}: {path}")
+
+
+def _print_dashboard_summary(data: Any) -> None:
+    console.print("[bold]Dashboard built.[/bold]")
+    console.print(
+        f"Past trips: {len(data.past_trips)} · "
+        f"Planned trips: {len(data.planned_trips)} · Ideas: {len(data.ideas)}"
+    )
+    if data.exports:
+        for label, path in data.exports.items():
+            console.print(f"  · {label}: {path}")
 
 
 def _print_import_result(result: ImportResultType) -> None:

--- a/trippy/config.py
+++ b/trippy/config.py
@@ -21,6 +21,7 @@ MEMORY_PATH: Path = _expand("TRIPPY_MEMORY_PATH", "~/.trippy/memory.json")
 TRIPS_PATH: Path = _expand("TRIPPY_TRIPS_PATH", "~/.trippy/trips")
 VAULT_PATH: Path = _expand("TRIPPY_VAULT_PATH", "~/.trippy/vault")
 EXPORT_PATH: Path = _expand("TRIPPY_EXPORT_PATH", "~/.trippy/export")
+LEARNING_PATH: Path = _expand("TRIPPY_LEARNING_PATH", "~/.trippy/learning")
 
 # Google OAuth
 GMAIL_CREDENTIALS_PATH: Path = _expand("GMAIL_CREDENTIALS_PATH", "~/.trippy/gmail_credentials.json")

--- a/trippy/ingest/gmail_watcher.py
+++ b/trippy/ingest/gmail_watcher.py
@@ -239,21 +239,26 @@ class GmailWatcher:
 
         self._service = build("gmail", "v1", credentials=creds)
 
-    def fetch_new_messages(self, label: str = "INBOX", max_results: int = 50) -> list[EmailContent]:
+    def fetch_new_messages(
+        self,
+        label: str = "INBOX",
+        max_results: int = 50,
+        query: str | None = None,
+    ) -> list[EmailContent]:
         """Fetch recent messages from Gmail, filtered to allowed senders."""
         if self._service is None:
             self.authenticate()
         service: Any = self._service
 
         # Narrow to booking-confirmation-like emails to avoid wasting fetch budget
-        query = (
+        gmail_query = query or (
             "subject:(confirmation OR booking OR reservation OR itinerary OR "
             '"your trip" OR "order confirmed" OR "e-ticket")'
         )
         results: dict[str, Any] = (
             service.users()
             .messages()
-            .list(userId="me", labelIds=[label], maxResults=max_results, q=query)
+            .list(userId="me", labelIds=[label], maxResults=max_results, q=gmail_query)
             .execute()
         )
         messages_meta = results.get("messages", [])

--- a/trippy/ingest/google_auth.py
+++ b/trippy/ingest/google_auth.py
@@ -12,9 +12,32 @@ from trippy import config
 logger = logging.getLogger(__name__)
 
 GMAIL_SCOPES: tuple[str, ...] = ("https://www.googleapis.com/auth/gmail.readonly",)
-SHEETS_SCOPES: tuple[str, ...] = ("https://www.googleapis.com/auth/spreadsheets.readonly",)
-DRIVE_SCOPES: tuple[str, ...] = ("https://www.googleapis.com/auth/drive.readonly",)
+SHEETS_SCOPES: tuple[str, ...] = ("https://www.googleapis.com/auth/spreadsheets",)
+DRIVE_SCOPES: tuple[str, ...] = ("https://www.googleapis.com/auth/drive",)
 ALL_SCOPES: tuple[str, ...] = GMAIL_SCOPES + SHEETS_SCOPES + DRIVE_SCOPES
+
+
+def token_scopes(token_path: Path) -> set[str]:
+    """Return OAuth scopes recorded in a Google authorized-user token file."""
+    import json
+
+    if not token_path.exists():
+        return set()
+
+    raw = json.loads(token_path.read_text(encoding="utf-8"))
+    scopes_raw = raw.get("scopes") or raw.get("scope") or []
+    if isinstance(scopes_raw, str):
+        return set(scopes_raw.split())
+    if isinstance(scopes_raw, list):
+        return {str(scope) for scope in scopes_raw}
+    return set()
+
+
+def missing_required_scopes(token_path: Path, required: Sequence[str] | None = None) -> set[str]:
+    """Return required scopes absent from a token file."""
+    expected = set(required or ALL_SCOPES)
+    actual = token_scopes(token_path)
+    return expected - actual
 
 
 class GoogleAuthManager:

--- a/trippy/memory/preference_writer.py
+++ b/trippy/memory/preference_writer.py
@@ -40,11 +40,40 @@ class PreferenceWriter:
         self,
         trips: list[Trip],
         min_trips: int = _MIN_TRIPS_FOR_PREFERENCE,
+        *,
+        approved_by_human: bool = False,
     ) -> dict[str, str]:
-        """Analyse trips and write any new or updated durable preferences.
+        """Analyse trips and write approved durable preferences.
 
         Returns a dict of {preference_key: reason_string} for logging/display.
         """
+        if not approved_by_human:
+            raise PermissionError(
+                "Preference writes require review approval. Use extract_candidates() "
+                "and the learning proposal flow instead."
+            )
+        candidates = self.extract_candidates(trips, min_trips=min_trips)
+        written: dict[str, str] = {}
+        for name, candidate in candidates.items():
+            self._memory.set(
+                key=str(candidate["key"]),
+                value=candidate["value"],
+                category=str(candidate["category"]),
+                confidence=float(candidate["confidence"]),
+                source=str(candidate["source"]),
+                notes=str(candidate["notes"]) if candidate.get("notes") else None,
+            )
+            written[name] = str(candidate["reason"])
+
+        logger.info("PreferenceWriter wrote %d preferences", len(written))
+        return written
+
+    def extract_candidates(
+        self,
+        trips: list[Trip],
+        min_trips: int = _MIN_TRIPS_FOR_PREFERENCE,
+    ) -> dict[str, dict[str, Any]]:
+        """Analyse trips and return memory-write candidates without mutating memory."""
         if not trips:
             return {}
 
@@ -54,7 +83,7 @@ class PreferenceWriter:
             return {}
 
         trip_ids = [t.trip_id for t in lived_trips]
-        written: dict[str, str] = {}
+        candidates: dict[str, dict[str, Any]] = {}
 
         # -------------------------------------------------------
         # Departure time analysis
@@ -62,20 +91,22 @@ class PreferenceWriter:
         early_departures = self._find_early_departures(lived_trips)
         if early_departures["avoided_count"] >= min_trips:
             conf = _calc_confidence(early_departures["avoided_count"], min_trips)
-            self._memory.set(
-                key="pref:departure_time_earliest_acceptable",
-                value={
-                    "time": "07:00",
-                    "evidence": f"avoided early departures in {early_departures['avoided_count']} trips",
-                },
-                category="preference",
-                confidence=conf,
-                source=f"extracted from {len(lived_trips)} trips",
-            )
-            written["departure_time"] = (
+            reason = (
                 f"Earliest acceptable 07:00 (avoided early in "
                 f"{early_departures['avoided_count']} trips, conf={conf:.0%})"
             )
+            candidates["departure_time"] = {
+                "key": "pref:departure_time_earliest_acceptable",
+                "value": {
+                    "time": "07:00",
+                    "evidence": f"avoided early departures in {early_departures['avoided_count']} trips",
+                },
+                "category": "preference",
+                "confidence": conf,
+                "source": f"extracted from {len(lived_trips)} trips",
+                "notes": reason,
+                "reason": reason,
+            }
 
         # -------------------------------------------------------
         # Connection time analysis
@@ -85,19 +116,19 @@ class PreferenceWriter:
             min_seen = connections.get("min_minutes_seen")
             if min_seen and min_seen > 60:
                 conf = _calc_confidence(connections["sample_count"], min_trips)
-                self._memory.set(
-                    key="pref:min_connection_international",
-                    value={
+                reason = f"Min international connection {max(110, min_seen)} min (conf={conf:.0%})"
+                candidates["min_connection"] = {
+                    "key": "pref:min_connection_international",
+                    "value": {
                         "minutes": max(110, min_seen),
                         "evidence": f"min observed: {min_seen} min across {connections['sample_count']} connections",
                     },
-                    category="preference",
-                    confidence=conf,
-                    source=f"extracted from trips: {', '.join(trip_ids)}",
-                )
-                written["min_connection"] = (
-                    f"Min international connection {max(110, min_seen)} min (conf={conf:.0%})"
-                )
+                    "category": "preference",
+                    "confidence": conf,
+                    "source": f"extracted from trips: {', '.join(trip_ids)}",
+                    "notes": reason,
+                    "reason": reason,
+                }
 
         # -------------------------------------------------------
         # Stay preferences from lived trips
@@ -106,39 +137,42 @@ class PreferenceWriter:
         if stay_prefs["sample_count"] >= min_trips:
             conf = _calc_confidence(stay_prefs["sample_count"], min_trips)
             if stay_prefs.get("avg_nights_per_dest"):
-                self._memory.set(
-                    key="pref:min_nights_per_destination",
-                    value={
+                nights = max(2, int(stay_prefs["avg_nights_per_dest"]))
+                reason = f"Min {nights} nights/destination"
+                candidates["nights_per_dest"] = {
+                    "key": "pref:min_nights_per_destination",
+                    "value": {
                         "nights": max(2, int(stay_prefs["avg_nights_per_dest"])),
                         "evidence": f"avg {stay_prefs['avg_nights_per_dest']:.1f} nights/dest",
                     },
-                    category="preference",
-                    confidence=conf,
-                    source=f"extracted from trips: {', '.join(trip_ids)}",
-                )
-                written["nights_per_dest"] = (
-                    f"Min {max(2, int(stay_prefs['avg_nights_per_dest']))} nights/destination"
-                )
+                    "category": "preference",
+                    "confidence": conf,
+                    "source": f"extracted from trips: {', '.join(trip_ids)}",
+                    "notes": reason,
+                    "reason": reason,
+                }
 
         # -------------------------------------------------------
         # Source trip metadata in memory
         # -------------------------------------------------------
         existing_prefs = FamilyTravelPreferences(source_trips=trip_ids)
         existing_prefs.confidence = min(0.9, len(lived_trips) * 0.15)
-        self._memory.set(
-            key="pref:preference_source_trips",
-            value={"trip_ids": trip_ids, "count": len(lived_trips)},
-            category="preference",
-            confidence=existing_prefs.confidence,
-            source="preference_writer",
-        )
+        candidates["preference_source_trips"] = {
+            "key": "pref:preference_source_trips",
+            "value": {"trip_ids": trip_ids, "count": len(lived_trips)},
+            "category": "preference",
+            "confidence": existing_prefs.confidence,
+            "source": "preference_writer",
+            "notes": "Tracks the lived trips used as preference evidence.",
+            "reason": f"Preference evidence covers {len(lived_trips)} lived trip(s)",
+        }
 
         logger.info(
-            "PreferenceWriter wrote %d preferences from %d lived trips",
-            len(written),
+            "PreferenceWriter found %d preference candidates from %d lived trips",
+            len(candidates),
             len(lived_trips),
         )
-        return written
+        return candidates
 
     # ------------------------------------------------------------------
 
@@ -203,8 +237,14 @@ class PreferenceWriter:
         hint: str,
         source: str,
         confidence: float = 0.7,
+        *,
+        approved_by_human: bool = False,
     ) -> None:
         """Write an agent-discovered planning pattern to memory."""
+        if not approved_by_human:
+            raise PermissionError(
+                "Skill-hint writes require review approval. Use the learning proposal flow instead."
+            )
         self._memory.set(
             key=f"hint:{key}",
             value=hint,

--- a/trippy/models/__init__.py
+++ b/trippy/models/__init__.py
@@ -1,5 +1,20 @@
 """Canonical Pydantic models — source of truth for trip state."""
 
+from trippy.models.dashboard import (
+    DashboardIdeaTile,
+    DashboardLink,
+    DashboardTripTile,
+    TravelDashboard,
+)
+from trippy.models.ideas import TripComparison, TripConcept, TripIdeaRequest
+from trippy.models.intelligence import (
+    EvidenceRef,
+    EvidenceSourceType,
+    IntelligenceCategory,
+    PreferenceSignal,
+    TravelIntelligenceReport,
+)
+from trippy.models.maps import MapPin, MapPinCategory, MapRoute, MapRouteMode, TripMapArtifact
 from trippy.models.preferences import (
     DepartureTimePreference,
     FamilyTravelPreferences,
@@ -7,6 +22,15 @@ from trippy.models.preferences import (
     TransferPreference,
 )
 from trippy.models.profile import FamilyProfile, TravelerProfile
+from trippy.models.retrospective import TripRetrospectiveInput, TripRetrospectiveResult
+from trippy.models.sources import (
+    SourceAccessMode,
+    SourceConfidence,
+    SourcePlan,
+    SourceRole,
+    TravelSource,
+    TravelSourceCategory,
+)
 from trippy.models.trip import (
     Budget,
     ChecklistItem,
@@ -27,10 +51,21 @@ __all__ = [
     "Budget",
     "ChecklistItem",
     "Confirmation",
+    "DashboardIdeaTile",
+    "DashboardLink",
+    "DashboardTripTile",
     "DepartureTimePreference",
+    "EvidenceRef",
+    "EvidenceSourceType",
     "FamilyProfile",
     "FamilyTravelPreferences",
+    "IntelligenceCategory",
     "LayoverPreference",
+    "MapPin",
+    "MapPinCategory",
+    "MapRoute",
+    "MapRouteMode",
+    "PreferenceSignal",
     "RiskFlag",
     "RiskSeverity",
     "Segment",
@@ -38,9 +73,23 @@ __all__ = [
     "Stay",
     "StayType",
     "SyncMetadata",
+    "SourceAccessMode",
+    "SourceConfidence",
+    "SourcePlan",
+    "SourceRole",
     "TransferPreference",
     "Traveler",
     "TravelerProfile",
+    "TravelDashboard",
+    "TravelIntelligenceReport",
+    "TravelSource",
+    "TravelSourceCategory",
     "Trip",
+    "TripComparison",
+    "TripConcept",
+    "TripIdeaRequest",
+    "TripMapArtifact",
+    "TripRetrospectiveInput",
+    "TripRetrospectiveResult",
     "TripStatus",
 ]

--- a/trippy/models/__init__.py
+++ b/trippy/models/__init__.py
@@ -1,5 +1,6 @@
 """Canonical Pydantic models — source of truth for trip state."""
 
+from trippy.models.country_priors import CountryFitSignal, CountryPrior, CountryPriorBand
 from trippy.models.dashboard import (
     DashboardIdeaTile,
     DashboardLink,
@@ -51,6 +52,9 @@ __all__ = [
     "Budget",
     "ChecklistItem",
     "Confirmation",
+    "CountryFitSignal",
+    "CountryPrior",
+    "CountryPriorBand",
     "DashboardIdeaTile",
     "DashboardLink",
     "DashboardTripTile",

--- a/trippy/models/country_priors.py
+++ b/trippy/models/country_priors.py
@@ -1,0 +1,39 @@
+"""Country-level travel preference priors from historical family ratings."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class CountryPriorBand(StrEnum):
+    STRONG_POSITIVE = "strong_positive"
+    MIXED = "mixed"
+    CAUTION = "caution"
+    NEUTRAL = "neutral"
+
+
+class CountryPrior(BaseModel):
+    country: str
+    rating: int | None = None
+    band: CountryPriorBand
+    confidence: float
+    positive_notes: list[str] = Field(default_factory=list)
+    caution_notes: list[str] = Field(default_factory=list)
+    positive_signals: list[str] = Field(default_factory=list)
+    caution_signals: list[str] = Field(default_factory=list)
+    aliases: list[str] = Field(default_factory=list)
+    planning_rules: list[str] = Field(default_factory=list)
+
+
+class CountryFitSignal(BaseModel):
+    country: str
+    rating: int | None = None
+    band: CountryPriorBand
+    confidence: float
+    score_adjustment: int
+    rationale: str
+    positive_signals: list[str] = Field(default_factory=list)
+    caution_signals: list[str] = Field(default_factory=list)
+    planning_rules: list[str] = Field(default_factory=list)

--- a/trippy/models/dashboard.py
+++ b/trippy/models/dashboard.py
@@ -1,0 +1,51 @@
+"""Dashboard models for past trips, planned trips, and ideas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class DashboardLink(BaseModel):
+    label: str
+    url: str
+
+
+class DashboardTripTile(BaseModel):
+    trip_id: str
+    name: str
+    status: str
+    destination: str
+    date_label: str
+    family_fit_score: int
+    comfort_score: int
+    budget_band: str
+    planning_completeness: int
+    hero_label: str
+    quick_links: list[DashboardLink] = Field(default_factory=list)
+    next_actions: list[str] = Field(default_factory=list)
+    key_risks: list[str] = Field(default_factory=list)
+    lessons: list[str] = Field(default_factory=list)
+
+
+class DashboardIdeaTile(BaseModel):
+    concept_id: str
+    title: str
+    destination: str
+    why_interesting: str
+    constraints: list[str] = Field(default_factory=list)
+    estimated_cost_band: str
+    estimated_travel_burden: str
+    family_fit_score: int
+    comfort_score: int
+    comparison_notes: list[str] = Field(default_factory=list)
+    promote_to_planning_action: str
+
+
+class TravelDashboard(BaseModel):
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    past_trips: list[DashboardTripTile] = Field(default_factory=list)
+    planned_trips: list[DashboardTripTile] = Field(default_factory=list)
+    ideas: list[DashboardIdeaTile] = Field(default_factory=list)
+    exports: dict[str, str] = Field(default_factory=dict)

--- a/trippy/models/ideas.py
+++ b/trippy/models/ideas.py
@@ -34,6 +34,7 @@ class TripConcept(BaseModel):
     food_score: int
     crowd_risk: int
     total_score: int
+    country_prior_signals: list[str] = Field(default_factory=list)
     rationale: list[str]
     why_it_may_not_fit: list[str]
     major_risks: list[str]

--- a/trippy/models/ideas.py
+++ b/trippy/models/ideas.py
@@ -1,0 +1,47 @@
+"""Trip idea request and comparison models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class TripIdeaRequest(BaseModel):
+    time_of_year: str | None = None
+    duration_days: int | None = None
+    budget_cad: float | None = None
+    travelers: int = 5
+    max_flight_hours: float | None = None
+    direct_flight_preferred: bool = True
+    goals: list[str] = Field(default_factory=list)
+    avoid: list[str] = Field(default_factory=list)
+    desired_vibe: str | None = None
+    activity_level: str | None = None
+    beach_culture_food_adventure: dict[str, int] = Field(default_factory=dict)
+
+
+class TripConcept(BaseModel):
+    concept_id: str
+    title: str
+    destinations: list[str]
+    recommended_duration_days: int
+    best_season: str
+    estimated_cost_band_cad: str
+    estimated_travel_burden: str
+    estimated_flight_hours: float
+    direct_flight_friendliness: int
+    family_fit_score: int
+    comfort_convenience_score: int
+    food_score: int
+    crowd_risk: int
+    total_score: int
+    rationale: list[str]
+    why_it_may_not_fit: list[str]
+    major_risks: list[str]
+    required_research: list[str]
+
+
+class TripComparison(BaseModel):
+    request: TripIdeaRequest
+    concepts: list[TripConcept]
+    recommended_concept_id: str | None = None
+    scoring_notes: list[str] = Field(default_factory=list)

--- a/trippy/models/intelligence.py
+++ b/trippy/models/intelligence.py
@@ -1,0 +1,63 @@
+"""Structured travel intelligence extracted from family trip evidence."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class EvidenceSourceType(StrEnum):
+    TRIP = "trip"
+    SHEET = "sheet"
+    GMAIL = "gmail"
+    FEEDBACK = "feedback"
+    MANUAL = "manual"
+
+
+class IntelligenceCategory(StrEnum):
+    LODGING = "lodging"
+    FLIGHT = "flight"
+    PACING = "pacing"
+    FOOD = "food"
+    TRANSPORT = "transport"
+    VENDOR = "vendor"
+    FRICTION = "friction"
+    DESTINATION = "destination"
+
+
+class EvidenceRef(BaseModel):
+    source_type: EvidenceSourceType
+    source_id: str
+    trip_id: str | None = None
+    description: str
+
+
+class PreferenceSignal(BaseModel):
+    key: str
+    category: IntelligenceCategory
+    value: Any
+    confidence: float
+    support_count: int = 0
+    evidence: list[EvidenceRef] = Field(default_factory=list)
+    rationale: str
+
+
+class TravelIntelligenceReport(BaseModel):
+    trips_analyzed: int
+    lived_trips_analyzed: int
+    signals: list[PreferenceSignal] = Field(default_factory=list)
+    friction_patterns: list[PreferenceSignal] = Field(default_factory=list)
+    destination_affinities: list[PreferenceSignal] = Field(default_factory=list)
+    vendor_patterns: list[PreferenceSignal] = Field(default_factory=list)
+    summary: str
+
+    @property
+    def all_signals(self) -> list[PreferenceSignal]:
+        return [
+            *self.signals,
+            *self.friction_patterns,
+            *self.destination_affinities,
+            *self.vendor_patterns,
+        ]

--- a/trippy/models/maps.py
+++ b/trippy/models/maps.py
@@ -1,0 +1,72 @@
+"""Map output models for trip planning and concierge use."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class MapPinCategory(StrEnum):
+    AIRPORT = "airport"
+    LODGING = "lodging"
+    TRANSFER = "transfer"
+    FOOD = "food"
+    ACTIVITY = "activity"
+    LOGISTICS = "logistics"
+    OTHER = "other"
+
+
+class MapRouteMode(StrEnum):
+    DRIVING = "driving"
+    WALKING = "walking"
+    TRANSIT = "transit"
+
+
+class MapPin(BaseModel):
+    pin_id: str
+    label: str
+    category: MapPinCategory
+    query: str
+    google_maps_url: str
+    address: str | None = None
+    day_index: int | None = None
+    source_id: str | None = None
+    notes: str | None = None
+
+
+class MapRoute(BaseModel):
+    route_id: str
+    label: str
+    origin_query: str
+    destination_query: str
+    google_maps_url: str
+    mode: MapRouteMode = MapRouteMode.DRIVING
+    day_index: int | None = None
+    notes: str | None = None
+
+
+class TripMapArtifact(BaseModel):
+    trip_id: str
+    title: str
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    pins: list[MapPin] = Field(default_factory=list)
+    routes: list[MapRoute] = Field(default_factory=list)
+    day_groups: dict[str, list[str]] = Field(default_factory=dict)
+    exports: dict[str, str] = Field(default_factory=dict)
+    notes: list[str] = Field(default_factory=list)
+
+    def to_geojson(self) -> dict[str, Any]:
+        return {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": None,
+                    "properties": pin.model_dump(mode="json"),
+                }
+                for pin in self.pins
+            ],
+        }

--- a/trippy/models/preferences.py
+++ b/trippy/models/preferences.py
@@ -63,12 +63,54 @@ class StayPreference(BaseModel):
     preferred_checkin_hour: int = 15
     checkout_hour: int = 11
     require_family_room_setup: bool = True  # Must fit 5 people
+    min_beds_for_family: int = 3
+    prefer_king_bed_for_adults: bool = True
+    queen_requires_compelling_upside: bool = True
     preferred_room_configs: list[str] = Field(
         default_factory=lambda: ["2_queens", "2_doubles", "suite", "2_rooms"]
     )
     preferred_stay_types: list[str] = Field(default_factory=lambda: ["hotel", "house", "vrbo"])
     min_nights_per_destination: int = 2  # Avoid single-night hotel stops
     preferred_nights_per_destination: int = 3
+
+
+class LodgingContextPreference(BaseModel):
+    city_prefer_urban_core: bool = True
+    city_prefer_boutique_hotel: bool = True
+    city_airbnb_requires_exceptional_upside: bool = True
+    non_city_prefer_private_rental: bool = True
+    require_safe_location_signal: bool = True
+    require_parking_practicality_for_rentals: bool = True
+
+
+class FoodPreference(BaseModel):
+    food_is_major_objective: bool = True
+    value_street_food_to_michelin_range: bool = True
+    score_food_access_highly: bool = True
+
+
+class CrowdPreference(BaseModel):
+    avoid_huge_crowds_when_possible: bool = True
+    prefer_lower_crowd_alternatives: bool = True
+
+
+class GroundTransportPreference(BaseModel):
+    comfortable_driving_many_places: bool = True
+    avoid_cramped_roads_and_bad_parking: bool = True
+    city_public_transit_ok: bool = True
+
+
+class ActivityPreference(BaseModel):
+    prefer_safe_well_reviewed_tours: bool = True
+    prefer_small_group_experiences: bool = True
+    avoid_mass_market_crowd_experiences: bool = True
+    prefer_activity_chill_balance: bool = True
+
+
+class DestinationReadinessPreference(BaseModel):
+    require_local_currency_guidance: bool = True
+    require_entry_requirements_summary: bool = True
+    require_health_precautions_summary: bool = True
 
 
 class FlightPreference(BaseModel):
@@ -85,6 +127,14 @@ class FamilyTravelPreferences(BaseModel):
     layover: LayoverPreference = Field(default_factory=LayoverPreference)
     transfer: TransferPreference = Field(default_factory=TransferPreference)
     stay: StayPreference = Field(default_factory=StayPreference)
+    lodging_context: LodgingContextPreference = Field(default_factory=LodgingContextPreference)
+    food: FoodPreference = Field(default_factory=FoodPreference)
+    crowd: CrowdPreference = Field(default_factory=CrowdPreference)
+    ground_transport: GroundTransportPreference = Field(default_factory=GroundTransportPreference)
+    activity: ActivityPreference = Field(default_factory=ActivityPreference)
+    destination_readiness: DestinationReadinessPreference = Field(
+        default_factory=DestinationReadinessPreference
+    )
     flight: FlightPreference = Field(default_factory=FlightPreference)
 
     # Airport logistics
@@ -128,6 +178,13 @@ class FamilyTravelPreferences(BaseModel):
             f"- Cabin (long haul >{self.flight.long_haul_threshold_hours}h): {self.flight.preferred_cabin_long_haul}",
             f"- Prefer direct flights: {self.flight.prefer_direct}",
             f"- Hotel check-in expected: {self.stay.min_checkin_hour:02d}:00",
+            f"- Family sleeping fit: at least {self.stay.min_beds_for_family} beds; king bed strongly preferred",
+            f"- City lodging: central/walkable boutique hotel preferred: {self.lodging_context.city_prefer_boutique_hotel}",
+            f"- Outside major cities: private rental preferred: {self.lodging_context.non_city_prefer_private_rental}",
+            f"- Food priority: major trip objective: {self.food.food_is_major_objective}",
+            f"- Avoid huge crowds when reasonable: {self.crowd.avoid_huge_crowds_when_possible}",
+            f"- Prefer small-group safe tours: {self.activity.prefer_small_group_experiences}",
+            f"- Require cash/entry/health guidance: {self.destination_readiness.require_local_currency_guidance}",
             f"- Min nights per destination: {self.stay.min_nights_per_destination}",
             f"- Airport buffer (domestic): {self.airport_buffer_minutes_domestic} min",
             f"- Airport buffer (international): {self.airport_buffer_minutes_international} min",

--- a/trippy/models/retrospective.py
+++ b/trippy/models/retrospective.py
@@ -1,0 +1,28 @@
+"""Post-trip retrospective models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class TripRetrospectiveInput(BaseModel):
+    trip_id: str
+    worked: list[str] = Field(default_factory=list)
+    worth_money: list[str] = Field(default_factory=list)
+    friction: list[str] = Field(default_factory=list)
+    hard_rules: list[str] = Field(default_factory=list)
+    never_repeat: list[str] = Field(default_factory=list)
+    favorites: list[str] = Field(default_factory=list)
+    pace: str | None = None
+    expectations: str | None = None
+    notes: str | None = None
+
+
+class TripRetrospectiveResult(BaseModel):
+    trip_id: str
+    workflow_id: str
+    proposal_ids: list[str] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    summary: str

--- a/trippy/models/sources.py
+++ b/trippy/models/sources.py
@@ -1,0 +1,68 @@
+"""Travel source registry models."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Self
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class TravelSourceCategory(StrEnum):
+    FLIGHTS = "flights"
+    CITY_LODGING = "city_lodging"
+    PRIVATE_LODGING = "private_lodging"
+    TOURS = "tours"
+    CAR_RENTALS = "car_rentals"
+    DEALS = "deals"
+    VALIDATION = "validation"
+
+
+class SourceAccessMode(StrEnum):
+    API = "api"
+    MCP = "mcp"
+    BROWSER_AUTOMATION = "browser_automation"
+    MANUAL_HANDOFF = "manual_handoff"
+
+
+class SourceConfidence(StrEnum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class SourceRole(StrEnum):
+    PRIMARY = "primary"
+    SECONDARY = "secondary"
+    VALIDATION = "validation"
+
+
+class TravelSource(BaseModel):
+    platform_name: str
+    categories: list[TravelSourceCategory]
+    strengths: list[str] = Field(default_factory=list)
+    weaknesses: list[str] = Field(default_factory=list)
+    confidence_level: SourceConfidence = SourceConfidence.MEDIUM
+    access_modes: list[SourceAccessMode] = Field(default_factory=list)
+    supports_api: bool = False
+    supports_mcp: bool = False
+    supports_browser_automation: bool = False
+    supports_manual_handoff: bool = False
+    prefer_when: list[str] = Field(default_factory=list)
+    avoid_when: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _derive_support_flags(self) -> Self:
+        self.supports_api = SourceAccessMode.API in self.access_modes
+        self.supports_mcp = SourceAccessMode.MCP in self.access_modes
+        self.supports_browser_automation = SourceAccessMode.BROWSER_AUTOMATION in self.access_modes
+        self.supports_manual_handoff = SourceAccessMode.MANUAL_HANDOFF in self.access_modes
+        return self
+
+
+class SourcePlan(BaseModel):
+    category: TravelSourceCategory
+    primary: list[TravelSource] = Field(default_factory=list)
+    secondary: list[TravelSource] = Field(default_factory=list)
+    validation: list[TravelSource] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)

--- a/trippy/services/__init__.py
+++ b/trippy/services/__init__.py
@@ -1,5 +1,6 @@
 """Trippy core services — setup, learning, trip state, sheet sync, friction detection."""
 
+from trippy.services.country_priors import CountryPriorService
 from trippy.services.dashboard import DashboardService
 from trippy.services.learning import LearningEventStore
 from trippy.services.map_outputs import MapOutputService
@@ -11,6 +12,7 @@ from trippy.services.travel_intelligence import TravelIntelligenceService
 from trippy.services.trip_ideation import TripIdeationService
 
 __all__ = [
+    "CountryPriorService",
     "DashboardService",
     "LearningEventStore",
     "MapOutputService",

--- a/trippy/services/__init__.py
+++ b/trippy/services/__init__.py
@@ -1,5 +1,23 @@
-"""Trippy core services — trip state, sheet sync, friction detection, skill learning."""
+"""Trippy core services — setup, learning, trip state, sheet sync, friction detection."""
 
+from trippy.services.dashboard import DashboardService
+from trippy.services.learning import LearningEventStore
+from trippy.services.map_outputs import MapOutputService
+from trippy.services.retrospective import RetrospectiveService
+from trippy.services.setup import SetupDoctor
 from trippy.services.skill_learning import SkillLearningService
+from trippy.services.source_registry import TravelSourceRegistry
+from trippy.services.travel_intelligence import TravelIntelligenceService
+from trippy.services.trip_ideation import TripIdeationService
 
-__all__ = ["SkillLearningService"]
+__all__ = [
+    "DashboardService",
+    "LearningEventStore",
+    "MapOutputService",
+    "RetrospectiveService",
+    "SetupDoctor",
+    "SkillLearningService",
+    "TravelSourceRegistry",
+    "TripIdeationService",
+    "TravelIntelligenceService",
+]

--- a/trippy/services/country_priors.py
+++ b/trippy/services/country_priors.py
@@ -1,0 +1,449 @@
+"""Country-level priors from historical family ratings and notes."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from trippy.models.country_priors import CountryFitSignal, CountryPrior, CountryPriorBand
+from trippy.services.learning import LearningEventStore, LearningProposal, ProposalType
+
+
+class CountryPriorService:
+    """Country preference priors used as directional planning intelligence."""
+
+    def __init__(self, priors: list[CountryPrior] | None = None) -> None:
+        self._priors = priors or _default_country_priors()
+
+    def list_priors(self) -> list[CountryPrior]:
+        return list(self._priors)
+
+    def get(self, country: str) -> CountryPrior | None:
+        wanted = _normalize(country)
+        for prior in self._priors:
+            names = [prior.country, *prior.aliases]
+            if any(_normalize(name) == wanted for name in names):
+                return prior
+        return None
+
+    def fit_for_country(self, country: str) -> CountryFitSignal | None:
+        prior = self.get(country)
+        return _fit_signal(prior) if prior else None
+
+    def fit_for_text(self, text: str) -> list[CountryFitSignal]:
+        normalized_text = f" {_normalize(text)} "
+        matches: list[CountryFitSignal] = []
+        for prior in self._priors:
+            names = [prior.country, *prior.aliases]
+            if any(f" {_normalize(name)} " in normalized_text for name in names):
+                matches.append(_fit_signal(prior))
+        return matches
+
+    def propose_memory_updates(
+        self,
+        *,
+        learning_dir: Path | None = None,
+        memory_path: Path | None = None,
+        source_workflow_id: str | None = None,
+        countries: list[str] | None = None,
+    ) -> list[LearningProposal]:
+        selected = self._priors
+        if countries:
+            wanted = {_normalize(country) for country in countries}
+            selected = [
+                prior
+                for prior in selected
+                if _normalize(prior.country) in wanted
+                or any(_normalize(alias) in wanted for alias in prior.aliases)
+            ]
+        proposals = [
+            LearningProposal(
+                proposal_type=ProposalType.MEMORY,
+                summary=f"Review country prior for {prior.country}: {prior.band.value}",
+                source_workflow_id=source_workflow_id,
+                after={
+                    "key": f"country_prior:{_slug(prior.country)}",
+                    "value": prior.model_dump(mode="json"),
+                    "category": "preference",
+                    "confidence": prior.confidence,
+                    "source": "historical-country-ratings",
+                    "notes": "Directional country-level prior. Override with trip-specific goals, season, sub-region, or newer evidence.",
+                },
+            )
+            for prior in selected
+        ]
+        return LearningEventStore(learning_dir, memory_path=memory_path).add_proposals(proposals)
+
+
+def _fit_signal(prior: CountryPrior) -> CountryFitSignal:
+    return CountryFitSignal(
+        country=prior.country,
+        rating=prior.rating,
+        band=prior.band,
+        confidence=prior.confidence,
+        score_adjustment=_score_adjustment(prior),
+        rationale=_rationale(prior),
+        positive_signals=prior.positive_signals,
+        caution_signals=prior.caution_signals,
+        planning_rules=prior.planning_rules,
+    )
+
+
+def _score_adjustment(prior: CountryPrior) -> int:
+    if prior.band == CountryPriorBand.STRONG_POSITIVE:
+        return 8 if (prior.rating or 0) >= 9 else 5
+    if prior.band == CountryPriorBand.MIXED:
+        return 2 if (prior.rating or 0) >= 8 else 0
+    if prior.band == CountryPriorBand.CAUTION:
+        return -6
+    return 0
+
+
+def _rationale(prior: CountryPrior) -> str:
+    rating = f"{prior.rating}/10" if prior.rating is not None else "unrated"
+    positives = ", ".join(prior.positive_signals[:3]) or "no strong positive signal"
+    cautions = ", ".join(prior.caution_signals[:3])
+    suffix = f"; watch {cautions}" if cautions else ""
+    return f"Historical country prior for {prior.country}: {rating}, {prior.band.value}; positives: {positives}{suffix}."
+
+
+def _prior(
+    country: str,
+    rating: int | None,
+    positives: list[str],
+    cautions: list[str],
+    positive_signals: list[str],
+    caution_signals: list[str],
+    *,
+    aliases: list[str] | None = None,
+    rules: list[str] | None = None,
+) -> CountryPrior:
+    return CountryPrior(
+        country=country,
+        rating=rating,
+        band=_band(rating, caution_signals),
+        confidence=0.85 if rating is not None else 0.45,
+        positive_notes=positives,
+        caution_notes=cautions,
+        positive_signals=positive_signals,
+        caution_signals=caution_signals,
+        aliases=aliases or [],
+        planning_rules=[
+            "Use this as a directional prior, not a rigid rule.",
+            "Check exact sub-region, season, logistics, and trip style before recommending.",
+            *(rules or []),
+        ],
+    )
+
+
+def _band(rating: int | None, caution_signals: list[str]) -> CountryPriorBand:
+    if rating is None:
+        return CountryPriorBand.NEUTRAL
+    if rating >= 9:
+        return CountryPriorBand.STRONG_POSITIVE
+    if rating <= 6:
+        return CountryPriorBand.CAUTION
+    if rating == 7 or len(caution_signals) >= 3:
+        return CountryPriorBand.MIXED
+    return CountryPriorBand.MIXED
+
+
+def _default_country_priors() -> list[CountryPrior]:
+    return [
+        _prior(
+            "Canada",
+            10,
+            [
+                "Lots of places",
+                "Tofino felt like Canada Hawaii",
+                "East Coast and Quebec were favorite trips",
+            ],
+            ["Taxes", "Huge drives", "Poor rail"],
+            ["natural beauty", "multi-location depth", "family familiarity"],
+            ["huge drives", "poor rail", "cost/tax drag"],
+        ),
+        _prior(
+            "USA",
+            6,
+            ["Lots of places", "California coast seems awesome", "Many great spots"],
+            ["Fearful", "Awful politically right now"],
+            ["destination variety", "California coast potential"],
+            ["safety/comfort concern", "political discomfort"],
+            aliases=["United States", "United States of America"],
+        ),
+        _prior(
+            "Mexico",
+            8,
+            ["Food", "Cheap", "Nice people", "Easy weather and beaches"],
+            [
+                "Not always drivable",
+                "Seagrass can hurt waterfront by region",
+                "Not always safe feeling",
+            ],
+            ["food", "value", "easy weather", "beach potential"],
+            ["safety varies by region", "driving practicality", "beach-condition risk"],
+        ),
+        _prior(
+            "Costa Rica",
+            8,
+            ["Wildlife", "Surfing", "Feels safe", "Easy beaches and weather"],
+            ["Getting expensive", "Food not amazing"],
+            ["wildlife", "surfing", "safety", "easy beaches"],
+            ["expense creep", "food disappointment"],
+            aliases=["Costca Rica"],
+        ),
+        _prior(
+            "St Lucia",
+            7,
+            ["Great food", "Fun Airbnb vibe", "Cheaper"],
+            ["Hard roads to drive", "Mostly safe feel"],
+            ["food", "private rental upside", "value"],
+            ["hard driving", "road stress"],
+            aliases=["Saint Lucia"],
+        ),
+        _prior(
+            "St Maarten",
+            6,
+            [],
+            ["Stayed during cruise", "Touristy and full"],
+            [],
+            ["touristy/crowded"],
+            aliases=["Sint Maarten", "Saint Martin"],
+        ),
+        _prior(
+            "St Kitts",
+            6,
+            [],
+            ["Stayed during cruise", "Touristy and full"],
+            [],
+            ["touristy/crowded"],
+            aliases=["Saint Kitts"],
+        ),
+        _prior(
+            "St Thomas",
+            6,
+            [],
+            ["Stayed during cruise", "Touristy and full"],
+            [],
+            ["touristy/crowded"],
+            aliases=["Saint Thomas"],
+        ),
+        _prior(
+            "Antigua",
+            7,
+            ["All inclusive", "Stayed on resort"],
+            [],
+            ["resort ease", "beach potential"],
+            [],
+        ),
+        _prior(
+            "Trinidad and Tobago",
+            7,
+            ["Loved it", "Amazing and cheap food"],
+            ["Not safe"],
+            ["food", "value", "unique local experience"],
+            ["safety concern"],
+            aliases=["Trinadad and Tobago", "Trinidad"],
+        ),
+        _prior(
+            "Curacao",
+            8,
+            ["Super drivable", "Colorful and fun", "Good beaches"],
+            ["Food hit and miss", "Theft", "Car break-in", "Long flight", "Euro was expensive"],
+            ["drivable", "colorful atmosphere", "beaches"],
+            ["theft/safety", "cost", "flight burden", "food inconsistency"],
+            aliases=["Curaçao"],
+        ),
+        _prior(
+            "Peru",
+            10,
+            ["Amazing experiences", "Safe", "Cheap", "Multiple cool locations"],
+            ["Got sick", "Risk of shutdown of services in some places"],
+            ["adventure", "value", "multi-location depth", "safety"],
+            ["health/sickness", "service disruption risk"],
+        ),
+        _prior(
+            "France",
+            9,
+            [
+                "European feel",
+                "Safe",
+                "Great food",
+                "Family friendly",
+                "South of France and Paris are amazing",
+            ],
+            ["Expensive"],
+            ["food", "safety", "family-friendly", "urban plus south-country depth"],
+            ["expense"],
+        ),
+        _prior(
+            "Italy",
+            7,
+            ["History and culture was great"],
+            ["Expensive", "Too hot in summer", "Food was just ok", "Rome busy"],
+            ["culture/history"],
+            ["expense", "summer heat", "food-expectation risk", "crowds"],
+        ),
+        _prior(
+            "Monaco",
+            7,
+            ["Luxury", "Quick visit"],
+            ["Not to stay in"],
+            ["luxury novelty"],
+            ["not a stay base"],
+        ),
+        _prior(
+            "UK",
+            6,
+            ["Scotland is interesting", "Nice to have seen"],
+            ["Food is gross", "Expensive"],
+            ["Scotland interest"],
+            ["food disappointment", "expense"],
+            aliases=["United Kingdom", "England", "Scotland"],
+        ),
+        _prior(
+            "Finland",
+            8,
+            [
+                "Fresh feeling",
+                "Northern Ontario but Europe",
+                "Fun tangent to Europe",
+                "New foods to try",
+            ],
+            ["Expensive"],
+            ["fresh atmosphere", "new foods", "Europe tangent"],
+            ["expense"],
+        ),
+        _prior(
+            "The Netherlands",
+            8,
+            ["So fun", "Interesting", "Fun people"],
+            [],
+            ["culture", "fun atmosphere", "people"],
+            [],
+            aliases=["Netherlands", "Holland"],
+        ),
+        _prior(
+            "Egypt",
+            7,
+            ["Amazing diving", "Food was incredible", "Adventure upside"],
+            ["Pushing for tips", "Crowded", "Bags snatched", "Got sick", "Harassment/disrespect"],
+            ["diving", "food", "adventure"],
+            ["crowds", "health/sickness", "harassment", "comfort/safety"],
+        ),
+        _prior(
+            "Greece",
+            10,
+            [
+                "Santorini was extremely romantic",
+                "Food amazing",
+                "Easy and safe drive",
+                "Postcard views",
+                "Unforgettable",
+            ],
+            [],
+            ["romantic atmosphere", "food", "scenery", "safety", "easy movement"],
+            [],
+        ),
+        _prior(
+            "China",
+            7,
+            ["Loved the food", "Big culture change"],
+            ["Dirty sometimes", "Language barrier"],
+            ["food", "unique culture"],
+            ["cleanliness inconsistency", "language barrier"],
+        ),
+        _prior(
+            "New Zealand",
+            10,
+            ["Perfect natural environment", "So much to do", "Great people", "Family lives there"],
+            ["Far flight", "Food wasn't amazing"],
+            ["nature", "activities", "people", "family connection"],
+            ["long flight burden", "food disappointment"],
+        ),
+        _prior(
+            "Belize",
+            9,
+            ["Beach and snorkel feel", "Awesome food", "Biking on the beach", "Great snorkeling"],
+            ["Not easy to get to", "Second flight to the atoll"],
+            ["beach/water", "snorkeling", "food"],
+            ["extra-hop travel burden"],
+        ),
+        _prior(
+            "Morocco",
+            8,
+            ["Unique and amazing cultural experience", "Fun adventure"],
+            ["Didn't love the food"],
+            ["unique culture", "adventure"],
+            ["food disappointment"],
+            aliases=["Morroco"],
+        ),
+        _prior(
+            "Spain",
+            8,
+            ["Canary Islands and Madrid", "Great food"],
+            ["Island was traffic-y"],
+            ["food", "city plus island variety"],
+            ["traffic"],
+        ),
+        _prior(
+            "Switzerland",
+            7,
+            ["Mountains", "So much more to see"],
+            ["Crazy expensive"],
+            ["mountains", "natural beauty"],
+            ["extreme expense"],
+        ),
+        _prior(
+            "Cuba",
+            6,
+            ["Beautiful beaches"],
+            ["Terrible food"],
+            ["beaches"],
+            ["food disappointment"],
+        ),
+        _prior(
+            "The Bahamas",
+            7,
+            ["Generally ok"],
+            [],
+            ["beach potential"],
+            [],
+            aliases=["Bahamas"],
+        ),
+        _prior(
+            "Vatican",
+            None,
+            ["Small"],
+            ["Not meaningful as a country-level trip base"],
+            [],
+            ["too small as destination base"],
+            aliases=["Vatican City"],
+        ),
+        _prior(
+            "Thailand",
+            9,
+            ["Amazing culture", "Amazing food", "More to see in Chiang Mai/Chiang Rai"],
+            ["Koh Samui crowded roads", "Not good for cars", "Bad snorkeling", "Busy beaches"],
+            ["food", "culture", "north Thailand upside"],
+            ["crowded beach zones", "hard driving", "snorkeling disappointment"],
+        ),
+        _prior(
+            "Japan",
+            9,
+            ["So clean", "Great culture", "Want to see more"],
+            ["Kinda expensive"],
+            ["cleanliness", "culture", "repeat interest"],
+            ["expense"],
+        ),
+    ]
+
+
+def _normalize(value: str) -> str:
+    text = value.lower().replace("&", " and ")
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")

--- a/trippy/services/dashboard.py
+++ b/trippy/services/dashboard.py
@@ -1,0 +1,366 @@
+"""Generate the Trippy family travel dashboard artifacts."""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from urllib.parse import quote_plus
+
+from trippy.models.dashboard import (
+    DashboardIdeaTile,
+    DashboardLink,
+    DashboardTripTile,
+    TravelDashboard,
+)
+from trippy.models.ideas import TripComparison, TripConcept, TripIdeaRequest
+from trippy.models.trip import RiskSeverity, Trip, TripStatus
+from trippy.services.map_outputs import MapOutputService
+from trippy.services.trip_ideation import TripIdeationService
+from trippy.services.trip_state import TripStateService
+
+
+class DashboardService:
+    """Build a static dashboard and machine-readable dashboard data."""
+
+    def __init__(
+        self,
+        trip_state: TripStateService | None = None,
+        map_service: MapOutputService | None = None,
+    ) -> None:
+        self._trip_state = trip_state or TripStateService()
+        self._map_service = map_service or MapOutputService()
+
+    def build(self, comparison: TripComparison | None = None) -> TravelDashboard:
+        trips = self._trip_state.load_all()
+        if comparison is None:
+            comparison = TripIdeationService().compare(TripIdeaRequest(), limit=3)
+
+        return TravelDashboard(
+            past_trips=[self._trip_tile(trip) for trip in trips if trip.status == TripStatus.LIVED],
+            planned_trips=[
+                self._trip_tile(trip)
+                for trip in trips
+                if trip.status in {TripStatus.DREAM, TripStatus.PLANNED, TripStatus.BOOKED}
+            ],
+            ideas=[self._idea_tile(concept) for concept in comparison.concepts],
+        )
+
+    def write_dashboard(self, output_dir: Path) -> TravelDashboard:
+        dashboard = self.build()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        data_path = output_dir / "dashboard.json"
+        html_path = output_dir / "index.html"
+        data_path.write_text(dashboard.model_dump_json(indent=2), encoding="utf-8")
+        html_path.write_text(self.render_html(dashboard), encoding="utf-8")
+        dashboard.exports = {"json": str(data_path), "html": str(html_path)}
+        data_path.write_text(dashboard.model_dump_json(indent=2), encoding="utf-8")
+        return dashboard
+
+    def render_html(self, dashboard: TravelDashboard) -> str:
+        return "\n".join(
+            [
+                "<!doctype html>",
+                '<html lang="en">',
+                "<head>",
+                '  <meta charset="utf-8">',
+                '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+                "  <title>Trippy Dashboard</title>",
+                "  <style>",
+                _CSS,
+                "  </style>",
+                "</head>",
+                "<body>",
+                '  <header class="topbar">',
+                '    <div class="brand"><span class="mark">T</span><span>Trippy</span></div>',
+                '    <div class="stamp">Chapman family travel dashboard</div>',
+                "  </header>",
+                '  <main class="shell">',
+                _section("Planned Trips", dashboard.planned_trips),
+                _ideas_section("Ideas Bucket", dashboard.ideas),
+                _section("Past Trips", dashboard.past_trips),
+                "  </main>",
+                "</body>",
+                "</html>",
+                "",
+            ]
+        )
+
+    def _trip_tile(self, trip: Trip) -> DashboardTripTile:
+        risks = [risk for risk in trip.risk_flags if not risk.resolved]
+        high_risks = [
+            risk for risk in risks if risk.severity in {RiskSeverity.HIGH, RiskSeverity.CRITICAL}
+        ]
+        map_query = trip.destination_summary or trip.name
+        map_artifact = self._map_service.build_trip_map(trip)
+        map_url = (
+            map_artifact.pins[0].google_maps_url
+            if map_artifact.pins
+            else f"https://www.google.com/maps/search/?api=1&query={quote_plus(map_query)}"
+        )
+        quick_links = [DashboardLink(label="Map", url=map_url)]
+        if trip.sync.google_sheet_url:
+            quick_links.append(DashboardLink(label="Sheet", url=trip.sync.google_sheet_url))
+
+        return DashboardTripTile(
+            trip_id=trip.trip_id,
+            name=trip.name,
+            status=trip.status.value,
+            destination=trip.destination_summary or "Destination TBD",
+            date_label=_date_label(trip),
+            family_fit_score=max(45, 92 - len(high_risks) * 12 - len(risks) * 3),
+            comfort_score=max(40, 88 - len(high_risks) * 15 - len(risks) * 4),
+            budget_band=_budget_band(trip),
+            planning_completeness=_planning_completeness(trip),
+            hero_label=(trip.destination_summary or trip.name)[:60],
+            quick_links=quick_links,
+            next_actions=_next_actions(trip),
+            key_risks=[risk.description for risk in risks[:3]],
+            lessons=_lessons(trip),
+        )
+
+    def _idea_tile(self, concept: TripConcept) -> DashboardIdeaTile:
+        return DashboardIdeaTile(
+            concept_id=concept.concept_id,
+            title=concept.title,
+            destination=", ".join(concept.destinations),
+            why_interesting=concept.rationale[0]
+            if concept.rationale
+            else "Strong family-fit concept.",
+            constraints=concept.required_research[:3],
+            estimated_cost_band=concept.estimated_cost_band_cad,
+            estimated_travel_burden=concept.estimated_travel_burden,
+            family_fit_score=concept.family_fit_score,
+            comfort_score=concept.comfort_convenience_score,
+            comparison_notes=concept.why_it_may_not_fit[:3],
+            promote_to_planning_action=f"uv run trippy phase-run 4 --trip-idea {concept.title!r}",
+        )
+
+
+def _date_label(trip: Trip) -> str:
+    if trip.start_date and trip.end_date:
+        return f"{trip.start_date} to {trip.end_date}"
+    if trip.start_date:
+        return str(trip.start_date)
+    return "Dates TBD"
+
+
+def _budget_band(trip: Trip) -> str:
+    total = trip.total_booked_cad
+    if total <= 0:
+        return "Budget TBD"
+    if total < 15000:
+        return "Under CAD 15k booked"
+    if total < 30000:
+        return "CAD 15k-30k booked"
+    return "CAD 30k+ booked"
+
+
+def _planning_completeness(trip: Trip) -> int:
+    checks = [
+        bool(trip.segments),
+        bool(trip.stays),
+        bool(trip.travelers),
+        bool(trip.sync.google_sheet_url or trip.sync.google_sheet_id),
+        not trip.unconfirmed_segments,
+        not trip.unconfirmed_stays,
+        any(item.category in {"visa", "document", "logistics"} for item in trip.checklist),
+    ]
+    return int(sum(1 for item in checks if item) / len(checks) * 100)
+
+
+def _next_actions(trip: Trip) -> list[str]:
+    actions: list[str] = []
+    if not trip.segments:
+        actions.append("Research exact flight options and total travel burden.")
+    if trip.unconfirmed_segments:
+        actions.append("Resolve unconfirmed flights and add confirmation codes.")
+    if not trip.stays:
+        actions.append("Shortlist lodging with explicit 3-bed family fit.")
+    if trip.unconfirmed_stays:
+        actions.append("Resolve unconfirmed lodging and check-in details.")
+    if not any(item.category == "visa" for item in trip.checklist):
+        actions.append("Add visa, entry, health, and cash checklist items.")
+    return actions[:4]
+
+
+def _lessons(trip: Trip) -> list[str]:
+    lessons = []
+    for risk in trip.risk_flags:
+        if risk.resolved:
+            lessons.append(f"Resolved {risk.category}: {risk.description}")
+    if trip.notes:
+        lessons.append(trip.notes[:160])
+    return lessons[:3]
+
+
+def _section(title: str, trips: list[DashboardTripTile]) -> str:
+    cards = "\n".join(_trip_card(trip) for trip in trips) or '<p class="empty">No trips yet.</p>'
+    return f"""
+    <section>
+      <div class="section-head">
+        <h1>{html.escape(title)}</h1>
+        <span>{len(trips)} item(s)</span>
+      </div>
+      <div class="grid">{cards}</div>
+    </section>
+    """
+
+
+def _ideas_section(title: str, ideas: list[DashboardIdeaTile]) -> str:
+    cards = "\n".join(_idea_card(idea) for idea in ideas) or '<p class="empty">No ideas yet.</p>'
+    return f"""
+    <section>
+      <div class="section-head">
+        <h1>{html.escape(title)}</h1>
+        <span>{len(ideas)} item(s)</span>
+      </div>
+      <div class="grid">{cards}</div>
+    </section>
+    """
+
+
+def _trip_card(trip: DashboardTripTile) -> str:
+    links = " ".join(
+        f'<a href="{html.escape(link.url)}">{html.escape(link.label)}</a>'
+        for link in trip.quick_links
+    )
+    actions = "".join(f"<li>{html.escape(action)}</li>" for action in trip.next_actions[:3])
+    risks = "".join(f"<li>{html.escape(risk)}</li>" for risk in trip.key_risks[:2])
+    return f"""
+      <article class="card">
+        <div class="hero">{html.escape(trip.hero_label)}</div>
+        <div class="meta">{html.escape(trip.status)} · {html.escape(trip.date_label)}</div>
+        <h2>{html.escape(trip.name)}</h2>
+        <p>{html.escape(trip.destination)}</p>
+        <div class="scores">
+          <span>Family {trip.family_fit_score}</span>
+          <span>Comfort {trip.comfort_score}</span>
+          <span>{trip.planning_completeness}% planned</span>
+        </div>
+        <p class="budget">{html.escape(trip.budget_band)}</p>
+        <div class="links">{links}</div>
+        <h3>Next</h3>
+        <ul>{actions or "<li>No immediate action recorded.</li>"}</ul>
+        <h3>Risks</h3>
+        <ul>{risks or "<li>No key risks recorded.</li>"}</ul>
+      </article>
+    """
+
+
+def _idea_card(idea: DashboardIdeaTile) -> str:
+    notes = "".join(f"<li>{html.escape(note)}</li>" for note in idea.comparison_notes[:2])
+    constraints = "".join(f"<li>{html.escape(item)}</li>" for item in idea.constraints[:2])
+    return f"""
+      <article class="card idea">
+        <div class="hero">{html.escape(idea.destination)}</div>
+        <h2>{html.escape(idea.title)}</h2>
+        <p>{html.escape(idea.why_interesting)}</p>
+        <div class="scores">
+          <span>Family {idea.family_fit_score}</span>
+          <span>Comfort {idea.comfort_score}</span>
+        </div>
+        <p class="budget">{html.escape(idea.estimated_cost_band)}</p>
+        <p>{html.escape(idea.estimated_travel_burden)} travel burden</p>
+        <h3>Research</h3>
+        <ul>{constraints}</ul>
+        <h3>Watch</h3>
+        <ul>{notes or "<li>No major concern recorded.</li>"}</ul>
+      </article>
+    """
+
+
+_CSS = """
+:root {
+  color-scheme: light;
+  --ink: #15171a;
+  --muted: #667085;
+  --line: #d9dde3;
+  --paper: #f7f8fa;
+  --surface: #ffffff;
+  --accent: #146c5f;
+  --accent-2: #9a4b26;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background: var(--paper);
+}
+.topbar {
+  min-height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 18px 32px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+.brand { display: flex; align-items: center; gap: 12px; font-size: 24px; font-weight: 760; }
+.mark {
+  width: 38px;
+  height: 38px;
+  display: inline-grid;
+  place-items: center;
+  background: var(--accent);
+  color: white;
+  font-weight: 800;
+}
+.stamp { color: var(--muted); font-size: 14px; }
+.shell { max-width: 1280px; margin: 0 auto; padding: 28px; }
+section { margin-bottom: 42px; }
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 14px;
+}
+h1 { font-size: 26px; margin: 0; }
+.section-head span { color: var(--muted); }
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+}
+.hero {
+  min-height: 86px;
+  display: flex;
+  align-items: end;
+  padding: 12px;
+  margin: -16px -16px 14px;
+  background: #dfe8e2;
+  color: #12352f;
+  font-size: 18px;
+  font-weight: 720;
+}
+.idea .hero { background: #efe1d5; color: #4a2110; }
+.meta { color: var(--muted); font-size: 13px; text-transform: uppercase; }
+h2 { margin: 8px 0; font-size: 20px; }
+h3 { margin: 16px 0 6px; font-size: 13px; text-transform: uppercase; color: var(--muted); }
+p { margin: 8px 0; line-height: 1.45; }
+ul { margin: 6px 0 0; padding-left: 18px; }
+li { margin: 4px 0; }
+.scores { display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0; }
+.scores span {
+  border: 1px solid var(--line);
+  padding: 5px 8px;
+  font-size: 13px;
+  background: #fbfcfd;
+}
+.budget { font-weight: 650; }
+.links { display: flex; flex-wrap: wrap; gap: 10px; margin: 10px 0; }
+a { color: var(--accent); font-weight: 650; }
+.empty { color: var(--muted); }
+@media (max-width: 700px) {
+  .topbar { align-items: flex-start; flex-direction: column; padding: 18px; }
+  .shell { padding: 18px; }
+}
+"""

--- a/trippy/services/friction_detector.py
+++ b/trippy/services/friction_detector.py
@@ -13,10 +13,11 @@ Risk severity:
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
-from trippy.models.trip import RiskFlag, RiskSeverity, Segment, Trip
+from trippy.models.trip import RiskFlag, RiskSeverity, Segment, SegmentType, Stay, StayType, Trip
 
 if TYPE_CHECKING:
     from trippy.models.preferences import FamilyTravelPreferences
@@ -125,6 +126,12 @@ class FrictionDetector:
         risks.extend(self._check_unconfirmed_stays(trip))
         risks.extend(self._check_passport_expiry(trip))
         risks.extend(self._check_missing_bags(trip))
+        risks.extend(self._check_family_sleeping_fit(trip))
+        risks.extend(self._check_lodging_context(trip))
+        risks.extend(self._check_driving_and_parking_friction(trip))
+        risks.extend(self._check_pacing(trip))
+        risks.extend(self._check_destination_readiness(trip))
+        risks.extend(self._check_tour_quality_signals(trip))
 
         logger.info("FrictionDetector: %d risk(s) found for trip %r", len(risks), trip.trip_id)
         return risks
@@ -392,6 +399,261 @@ class FrictionDetector:
                 )
         return risks
 
+    def _check_family_sleeping_fit(self, trip: Trip) -> list[RiskFlag]:
+        risks: list[RiskFlag] = []
+        if len(trip.travelers) < 5:
+            return risks
+        min_beds = self._prefs.stay.min_beds_for_family if self._prefs else 3
+        for stay in trip.stays:
+            text = _stay_text(stay)
+            bed_count = _bed_count(text)
+            if bed_count is None:
+                risks.append(
+                    RiskFlag(
+                        risk_id=f"bed-fit-unknown-{stay.stay_id}",
+                        severity=RiskSeverity.HIGH,
+                        category="lodging",
+                        description=(
+                            f"{stay.property_name} does not clearly document bed count. "
+                            f"Family of 5 needs an explicit sleeping setup with at least {min_beds} beds."
+                        ),
+                        affected_ids=[stay.stay_id],
+                        recommended_fix=(
+                            "Confirm exact bed layout before booking; reject options that cannot verify "
+                            f"{min_beds}+ beds."
+                        ),
+                    )
+                )
+            elif bed_count < min_beds:
+                risks.append(
+                    RiskFlag(
+                        risk_id=f"bed-fit-short-{stay.stay_id}",
+                        severity=RiskSeverity.HIGH,
+                        category="lodging",
+                        description=(
+                            f"{stay.property_name} appears to have {bed_count} bed(s), below the "
+                            f"family minimum of {min_beds}."
+                        ),
+                        affected_ids=[stay.stay_id],
+                        recommended_fix=f"Find a property with at least {min_beds} beds or book two rooms.",
+                    )
+                )
+
+            if (
+                (self._prefs is None or self._prefs.stay.queen_requires_compelling_upside)
+                and "queen" in text
+                and "king" not in text
+                and not _has_compelling_lodging_upside(text)
+            ):
+                risks.append(
+                    RiskFlag(
+                        risk_id=f"queen-compromise-{stay.stay_id}",
+                        severity=RiskSeverity.MEDIUM,
+                        category="lodging",
+                        description=(
+                            f"{stay.property_name} appears to rely on queen bed(s) without a clear "
+                            "offsetting benefit. King bed is strongly preferred for the primary adults."
+                        ),
+                        affected_ids=[stay.stay_id],
+                        recommended_fix="Prefer a king-bed option unless this property has exceptional location, space, or value.",
+                    )
+                )
+        return risks
+
+    def _check_lodging_context(self, trip: Trip) -> list[RiskFlag]:
+        risks: list[RiskFlag] = []
+        for stay in trip.stays:
+            text = _stay_text(stay)
+            if _looks_like_city_stay(stay):
+                if any(
+                    term in text for term in ("suburb", "outside city", "airport hotel", "remote")
+                ):
+                    risks.append(
+                        RiskFlag(
+                            risk_id=f"non-central-city-lodging-{stay.stay_id}",
+                            severity=RiskSeverity.MEDIUM,
+                            category="lodging",
+                            description=(
+                                f"{stay.property_name} has non-central location signals. "
+                                "For city stays, the family strongly prefers walkable urban-core lodging."
+                            ),
+                            affected_ids=[stay.stay_id],
+                            recommended_fix="Compare against central boutique hotels before accepting transit burden.",
+                        )
+                    )
+                if stay.stay_type in {
+                    StayType.AIRBNB,
+                    StayType.VRBO,
+                    StayType.HOUSE,
+                } and not _has_compelling_lodging_upside(text):
+                    risks.append(
+                        RiskFlag(
+                            risk_id=f"city-rental-fit-{stay.stay_id}",
+                            severity=RiskSeverity.MEDIUM,
+                            category="lodging",
+                            description=(
+                                f"{stay.property_name} is a city rental without clear upside. "
+                                "In cities, boutique hotels usually fit the family's walkability and service needs better."
+                            ),
+                            affected_ids=[stay.stay_id],
+                            recommended_fix="Require exceptional space/location/safety value or prefer a central boutique hotel.",
+                        )
+                    )
+            if stay.stay_type in {StayType.AIRBNB, StayType.VRBO, StayType.HOUSE}:
+                missing_signals = []
+                if "safe" not in text and "well-reviewed" not in text:
+                    missing_signals.append("safety/review confidence")
+                if "parking" not in text and "walkable" not in text and "transit" not in text:
+                    missing_signals.append("access/parking practicality")
+                if missing_signals:
+                    risks.append(
+                        RiskFlag(
+                            risk_id=f"rental-access-confidence-{stay.stay_id}",
+                            severity=RiskSeverity.LOW,
+                            category="lodging",
+                            description=(
+                                f"{stay.property_name} is a private rental missing explicit "
+                                f"{', '.join(missing_signals)}."
+                            ),
+                            affected_ids=[stay.stay_id],
+                            recommended_fix="Verify location safety, parking/access, and review quality before shortlisting.",
+                        )
+                    )
+        return risks
+
+    def _check_driving_and_parking_friction(self, trip: Trip) -> list[RiskFlag]:
+        risks: list[RiskFlag] = []
+        friction_terms = (
+            "narrow road",
+            "cramped road",
+            "difficult parking",
+            "no parking",
+            "limited parking",
+        )
+        for seg in trip.segments:
+            if seg.segment_type != SegmentType.CAR:
+                continue
+            text = (seg.notes or "").lower()
+            if any(term in text for term in friction_terms):
+                risks.append(
+                    RiskFlag(
+                        risk_id=f"driving-friction-{seg.segment_id}",
+                        severity=RiskSeverity.MEDIUM,
+                        category="transfer",
+                        description=(
+                            f"Driving segment {seg.segment_id} has cramped-road or parking friction signals. "
+                            "The family is comfortable driving generally, but dislikes stressful roads and parking."
+                        ),
+                        affected_ids=[seg.segment_id],
+                        recommended_fix="Confirm route/parking practicality or use train/private transfer instead.",
+                    )
+                )
+        for stay in trip.stays:
+            text = _stay_text(stay)
+            if any(term in text for term in friction_terms):
+                risks.append(
+                    RiskFlag(
+                        risk_id=f"parking-friction-{stay.stay_id}",
+                        severity=RiskSeverity.MEDIUM,
+                        category="lodging",
+                        description=f"{stay.property_name} has parking or road-access friction signals.",
+                        affected_ids=[stay.stay_id],
+                        recommended_fix="Verify parking details and arrival route before booking.",
+                    )
+                )
+        return risks
+
+    def _check_pacing(self, trip: Trip) -> list[RiskFlag]:
+        risks: list[RiskFlag] = []
+        for stay in trip.stays:
+            if stay.nights == 1:
+                risks.append(
+                    RiskFlag(
+                        risk_id=f"one-night-stop-{stay.stay_id}",
+                        severity=RiskSeverity.MEDIUM,
+                        category="pacing",
+                        description=(
+                            f"{stay.property_name} is a one-night stop. The family dislikes frequent "
+                            "hotel changes and overcompressed pacing."
+                        ),
+                        affected_ids=[stay.stay_id],
+                        recommended_fix="Combine stops or extend to at least 2 nights unless this is a necessary transit stop.",
+                    )
+                )
+        if trip.start_date and trip.end_date and trip.stays:
+            trip_days = max(1, (trip.end_date - trip.start_date).days + 1)
+            max_destinations = max(
+                1,
+                int(
+                    (trip_days / 7) * (self._prefs.max_destinations_per_week if self._prefs else 3)
+                ),
+            )
+            distinct_stops = len({(stay.city.lower(), stay.country.lower()) for stay in trip.stays})
+            if distinct_stops > max_destinations:
+                risks.append(
+                    RiskFlag(
+                        risk_id="overcompressed-itinerary",
+                        severity=RiskSeverity.MEDIUM,
+                        category="pacing",
+                        description=(
+                            f"{distinct_stops} lodging stops across {trip_days} days is likely overcompressed "
+                            "for a family trip."
+                        ),
+                        affected_ids=[stay.stay_id for stay in trip.stays],
+                        recommended_fix="Reduce destinations or add downtime between transitions.",
+                    )
+                )
+        return risks
+
+    def _check_destination_readiness(self, trip: Trip) -> list[RiskFlag]:
+        checklist_text = " ".join(
+            f"{item.category} {item.title} {item.notes or ''}" for item in trip.checklist
+        ).lower()
+        required = {
+            "cash-currency-guidance": ("cash", "currency"),
+            "entry-requirements": ("visa", "entry", "eta", "passport"),
+            "health-precautions": ("health", "vaccine", "vaccination", "medical"),
+        }
+        risks: list[RiskFlag] = []
+        for risk_key, terms in required.items():
+            if not any(term in checklist_text for term in terms):
+                risks.append(
+                    RiskFlag(
+                        risk_id=f"missing-{risk_key}",
+                        severity=RiskSeverity.LOW,
+                        category="readiness",
+                        description=(
+                            f"Trip is missing explicit {risk_key.replace('-', ' ')}. "
+                            "Trippy should surface this before final recommendations or booking."
+                        ),
+                        affected_ids=[],
+                        recommended_fix="Add researched destination guidance to the planning sheet checklist.",
+                    )
+                )
+        return risks
+
+    def _check_tour_quality_signals(self, trip: Trip) -> list[RiskFlag]:
+        risks: list[RiskFlag] = []
+        tour_terms = ("tour", "excursion", "outing", "adventure")
+        bad_terms = ("large group", "mass market", "crowded", "weak review", "safety unknown")
+        for item in trip.checklist:
+            text = f"{item.category} {item.title} {item.notes or ''}".lower()
+            if any(term in text for term in tour_terms) and any(term in text for term in bad_terms):
+                risks.append(
+                    RiskFlag(
+                        risk_id=f"tour-quality-{item.item_id}",
+                        severity=RiskSeverity.MEDIUM,
+                        category="activity",
+                        description=(
+                            f"Activity '{item.title}' has crowd, review, or safety confidence warnings. "
+                            "The family prefers safe, well-reviewed, smaller-group outings."
+                        ),
+                        affected_ids=[item.item_id],
+                        recommended_fix="Find a smaller-group, strongly reviewed operator with clear safety signals.",
+                    )
+                )
+        return risks
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
@@ -401,3 +663,60 @@ class FrictionDetector:
             if seg.arrive_at and seg.arrive_at.date() == check_date:
                 return seg
         return None
+
+
+def _stay_text(stay: Stay) -> str:
+    return " ".join(
+        str(value or "")
+        for value in (
+            stay.property_name,
+            stay.city,
+            stay.country,
+            stay.address,
+            stay.room_type,
+            stay.parking_instructions,
+            stay.check_in_instructions,
+            stay.notes,
+        )
+    ).lower()
+
+
+def _bed_count(text: str) -> int | None:
+    if not text.strip():
+        return None
+    if "2 rooms" in text or "two rooms" in text:
+        return 3
+    explicit = re.search(r"(\d+)\s+(?:beds?|sleeping surfaces?)", text)
+    if explicit:
+        return int(explicit.group(1))
+    count = 0
+    for word in ("king", "queen", "double", "twin", "sofa bed", "bunk"):
+        if word in text:
+            multiplier = 1
+            match = re.search(rf"(\d+)\s+{re.escape(word)}", text)
+            if match:
+                multiplier = int(match.group(1))
+            count += multiplier
+    return count or None
+
+
+def _has_compelling_lodging_upside(text: str) -> bool:
+    return any(
+        term in text
+        for term in (
+            "central",
+            "walkable",
+            "suite",
+            "exceptional",
+            "spacious",
+            "safe",
+            "parking",
+            "near transit",
+            "urban core",
+        )
+    )
+
+
+def _looks_like_city_stay(stay: Stay) -> bool:
+    text = _stay_text(stay)
+    return bool(stay.city) and not any(term in text for term in ("countryside", "rural", "villa"))

--- a/trippy/services/friction_detector.py
+++ b/trippy/services/friction_detector.py
@@ -131,6 +131,7 @@ class FrictionDetector:
         risks.extend(self._check_driving_and_parking_friction(trip))
         risks.extend(self._check_pacing(trip))
         risks.extend(self._check_destination_readiness(trip))
+        risks.extend(self._check_country_priors(trip))
         risks.extend(self._check_tour_quality_signals(trip))
 
         logger.info("FrictionDetector: %d risk(s) found for trip %r", len(risks), trip.trip_id)
@@ -632,6 +633,38 @@ class FrictionDetector:
                 )
         return risks
 
+    def _check_country_priors(self, trip: Trip) -> list[RiskFlag]:
+        from trippy.models.country_priors import CountryPriorBand
+        from trippy.services.country_priors import CountryPriorService
+
+        service = CountryPriorService()
+        risks: list[RiskFlag] = []
+        for country in _countries_for_trip(trip):
+            fit = service.fit_for_country(country)
+            if fit is None or not fit.caution_signals:
+                continue
+            severity = (
+                RiskSeverity.MEDIUM if fit.band == CountryPriorBand.CAUTION else RiskSeverity.LOW
+            )
+            risks.append(
+                RiskFlag(
+                    risk_id=f"country-prior-{_risk_slug(fit.country)}",
+                    severity=severity,
+                    category="country_prior",
+                    description=(
+                        f"{fit.country} has historical country-level caution signals: "
+                        f"{', '.join(fit.caution_signals[:5])}. These are directional priors, "
+                        "not a reason to reject the trip automatically."
+                    ),
+                    affected_ids=[],
+                    recommended_fix=(
+                        "Explain why this exact sub-region, season, logistics plan, and trip style "
+                        "still fit before recommending."
+                    ),
+                )
+            )
+        return risks
+
     def _check_tour_quality_signals(self, trip: Trip) -> list[RiskFlag]:
         risks: list[RiskFlag] = []
         tour_terms = ("tour", "excursion", "outing", "adventure")
@@ -720,3 +753,24 @@ def _has_compelling_lodging_upside(text: str) -> bool:
 def _looks_like_city_stay(stay: Stay) -> bool:
     text = _stay_text(stay)
     return bool(stay.city) and not any(term in text for term in ("countryside", "rural", "villa"))
+
+
+def _countries_for_trip(trip: Trip) -> list[str]:
+    countries = []
+    seen = set()
+    for stay in trip.stays:
+        if stay.country and stay.country.lower() not in seen:
+            countries.append(stay.country)
+            seen.add(stay.country.lower())
+    if trip.destination_summary:
+        from trippy.services.country_priors import CountryPriorService
+
+        for fit in CountryPriorService().fit_for_text(trip.destination_summary):
+            if fit.country.lower() not in seen:
+                countries.append(fit.country)
+                seen.add(fit.country.lower())
+    return countries
+
+
+def _risk_slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")

--- a/trippy/services/learning.py
+++ b/trippy/services/learning.py
@@ -1,0 +1,348 @@
+"""Workflow outcome, feedback, and review-gated learning store."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from trippy import config
+
+
+class WorkflowStatus(StrEnum):
+    SUCCESS = "success"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class FeedbackRating(StrEnum):
+    HELPFUL = "helpful"
+    NEEDS_WORK = "needs-work"
+    WRONG = "wrong"
+
+
+class ProposalType(StrEnum):
+    MEMORY = "memory"
+    SKILL_PATCH = "skill_patch"
+
+
+class ProposalStatus(StrEnum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+def _new_id(prefix: str) -> str:
+    stamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    return f"{prefix}-{stamp}-{uuid.uuid4().hex[:8]}"
+
+
+class WorkflowOutcome(BaseModel):
+    id: str = Field(default_factory=lambda: _new_id("wf"))
+    workflow_name: str
+    skill_name: str | None = None
+    trip_id: str | None = None
+    status: WorkflowStatus
+    started_at: datetime = Field(default_factory=datetime.utcnow)
+    ended_at: datetime = Field(default_factory=datetime.utcnow)
+    summary: str
+    metrics: dict[str, Any] = Field(default_factory=dict)
+    artifacts: dict[str, Any] = Field(default_factory=dict)
+    evidence_refs: list[str] = Field(default_factory=list)
+    resolved_issues: list[dict[str, Any]] = Field(default_factory=list)
+    quality_notes: list[str] = Field(default_factory=list)
+
+
+class UserFeedback(BaseModel):
+    id: str = Field(default_factory=lambda: _new_id("fb"))
+    workflow_id: str
+    rating: FeedbackRating
+    notes: str
+    correction: str | None = None
+    future_learning: bool = False
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class LearningProposal(BaseModel):
+    id: str = Field(default_factory=lambda: _new_id("lp"))
+    proposal_type: ProposalType
+    status: ProposalStatus = ProposalStatus.PENDING
+    summary: str
+    source_workflow_id: str | None = None
+    source_feedback_id: str | None = None
+    before: Any = None
+    after: Any = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    resolved_at: datetime | None = None
+
+
+class _ProposalFile(BaseModel):
+    version: str = "1.0"
+    proposals: list[LearningProposal] = Field(default_factory=list)
+
+
+class LearningEventStore:
+    """Append-only workflow event log plus reviewable learning proposals."""
+
+    def __init__(self, learning_dir: Path | None = None, memory_path: Path | None = None) -> None:
+        self._dir = learning_dir or config.LEARNING_PATH
+        self._events_path = self._dir / "events.jsonl"
+        self._proposals_path = self._dir / "proposals.json"
+        self._memory_path = memory_path or config.MEMORY_PATH
+
+    @property
+    def events_path(self) -> Path:
+        return self._events_path
+
+    @property
+    def proposals_path(self) -> Path:
+        return self._proposals_path
+
+    def record_workflow(self, outcome: WorkflowOutcome) -> WorkflowOutcome:
+        self._append_event("workflow_outcome", outcome.model_dump(mode="json"))
+        return outcome
+
+    def add_feedback(self, feedback: UserFeedback) -> list[LearningProposal]:
+        self._append_event("user_feedback", feedback.model_dump(mode="json"))
+        proposals = self._proposals_from_feedback(feedback)
+        self.add_proposals(proposals)
+        return proposals
+
+    def add_proposals(self, proposals: list[LearningProposal]) -> list[LearningProposal]:
+        """Persist pending proposals without applying them."""
+        if not proposals:
+            return []
+        proposal_file = self._load_proposal_file()
+        proposal_file.proposals.extend(proposals)
+        self._save_proposal_file(proposal_file)
+        for proposal in proposals:
+            self._append_event("learning_proposal", proposal.model_dump(mode="json"))
+        return proposals
+
+    def list_workflows(self) -> list[WorkflowOutcome]:
+        workflows: list[WorkflowOutcome] = []
+        for event in self._read_events():
+            if event.get("event_type") == "workflow_outcome":
+                workflows.append(WorkflowOutcome.model_validate(event["payload"]))
+        return workflows
+
+    def get_workflow(self, workflow_id: str) -> WorkflowOutcome | None:
+        for outcome in reversed(self.list_workflows()):
+            if outcome.id == workflow_id:
+                return outcome
+        return None
+
+    def list_proposals(
+        self,
+        status: ProposalStatus | None = ProposalStatus.PENDING,
+    ) -> list[LearningProposal]:
+        proposals = self._load_proposal_file().proposals
+        if status is None:
+            return proposals
+        return [proposal for proposal in proposals if proposal.status == status]
+
+    def approve(self, proposal_id: str) -> LearningProposal:
+        proposal_file = self._load_proposal_file()
+        proposal = self._find_proposal(proposal_file, proposal_id)
+        if proposal.status != ProposalStatus.PENDING:
+            raise ValueError(f"Proposal {proposal_id!r} is already {proposal.status.value}")
+
+        if proposal.proposal_type == ProposalType.MEMORY:
+            self._apply_memory_proposal(proposal)
+        elif proposal.proposal_type == ProposalType.SKILL_PATCH:
+            self._apply_skill_patch_proposal(proposal)
+
+        proposal.status = ProposalStatus.APPROVED
+        proposal.resolved_at = datetime.utcnow()
+        self._save_proposal_file(proposal_file)
+        self._append_event("learning_proposal_approved", proposal.model_dump(mode="json"))
+        return proposal
+
+    def reject(self, proposal_id: str) -> LearningProposal:
+        proposal_file = self._load_proposal_file()
+        proposal = self._find_proposal(proposal_file, proposal_id)
+        if proposal.status != ProposalStatus.PENDING:
+            raise ValueError(f"Proposal {proposal_id!r} is already {proposal.status.value}")
+        proposal.status = ProposalStatus.REJECTED
+        proposal.resolved_at = datetime.utcnow()
+        self._save_proposal_file(proposal_file)
+        self._append_event("learning_proposal_rejected", proposal.model_dump(mode="json"))
+        return proposal
+
+    def _proposals_from_feedback(self, feedback: UserFeedback) -> list[LearningProposal]:
+        if not feedback.future_learning:
+            return []
+
+        outcome = self.get_workflow(feedback.workflow_id)
+        learning_text = (feedback.correction or feedback.notes).strip()
+        if not learning_text:
+            return []
+
+        proposals = [
+            self._memory_proposal(feedback=feedback, outcome=outcome, learning_text=learning_text)
+        ]
+        if outcome and outcome.skill_name:
+            skill = self._skill_patch_proposal(
+                feedback=feedback,
+                outcome=outcome,
+                learning_text=learning_text,
+            )
+            if skill is not None:
+                proposals.append(skill)
+        return proposals
+
+    def _memory_proposal(
+        self,
+        *,
+        feedback: UserFeedback,
+        outcome: WorkflowOutcome | None,
+        learning_text: str,
+    ) -> LearningProposal:
+        key = f"hint:user-feedback-{feedback.workflow_id}"
+        before = self._current_memory_value(key)
+        after = {
+            "key": key,
+            "value": learning_text,
+            "category": "skill_hint",
+            "confidence": 0.7 if feedback.rating == FeedbackRating.NEEDS_WORK else 0.8,
+            "source": "user-feedback",
+            "notes": f"Feedback on {outcome.workflow_name if outcome else feedback.workflow_id}",
+        }
+        return LearningProposal(
+            proposal_type=ProposalType.MEMORY,
+            summary=f"Remember user feedback for future workflows: {learning_text[:120]}",
+            source_workflow_id=feedback.workflow_id,
+            source_feedback_id=feedback.id,
+            before=before,
+            after=after,
+        )
+
+    def _skill_patch_proposal(
+        self,
+        *,
+        feedback: UserFeedback,
+        outcome: WorkflowOutcome,
+        learning_text: str,
+    ) -> LearningProposal | None:
+        from trippy.services.skill_learning import SkillLearningService
+
+        if outcome.skill_name is None:
+            return None
+
+        svc = SkillLearningService()
+        lessons = svc.extract_candidate_lessons(
+            [
+                {
+                    "status": "success",
+                    "skill_name": outcome.skill_name,
+                    "quality_notes": [learning_text],
+                    "evidence": [
+                        f"workflow:{outcome.id}",
+                        f"feedback:{feedback.id}",
+                        *(outcome.evidence_refs or []),
+                    ],
+                }
+            ]
+        )
+        if not lessons:
+            return None
+        proposal = svc.propose_skill_patch(outcome.skill_name, lessons)
+        return LearningProposal(
+            proposal_type=ProposalType.SKILL_PATCH,
+            summary=f"Patch {outcome.skill_name} from reviewed feedback",
+            source_workflow_id=feedback.workflow_id,
+            source_feedback_id=feedback.id,
+            before={"summary": proposal.before_summary},
+            after={"skill_patch": proposal.model_dump(mode="json")},
+        )
+
+    def _apply_memory_proposal(self, proposal: LearningProposal) -> None:
+        from trippy.memory.store import MemoryStore
+
+        data = proposal.after
+        if not isinstance(data, dict):
+            raise ValueError("Memory proposal is missing after data")
+        memory = MemoryStore(self._memory_path)
+        memory.set(
+            key=str(data["key"]),
+            value=data["value"],
+            category=str(data["category"]),
+            confidence=float(data.get("confidence", 0.7)),
+            source=str(data.get("source", "learning-review")),
+            notes=str(data["notes"]) if data.get("notes") else None,
+        )
+
+    def _apply_skill_patch_proposal(self, proposal: LearningProposal) -> None:
+        from trippy.services.skill_learning import (
+            SkillLearningService,
+            SkillPatchProposal,
+        )
+
+        data = proposal.after
+        if not isinstance(data, dict) or "skill_patch" not in data:
+            raise ValueError("Skill patch proposal is missing patch data")
+        patch = SkillPatchProposal.model_validate(data["skill_patch"])
+        SkillLearningService().apply_patch(
+            patch,
+            human_approval_required=True,
+            approved_by_human=True,
+        )
+
+    def _current_memory_value(self, key: str) -> Any:
+        from trippy.memory.store import MemoryStore
+
+        entry = MemoryStore(self._memory_path).get(key)
+        return entry.model_dump(mode="json") if entry else None
+
+    def _append_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        event = {
+            "event_id": _new_id("evt"),
+            "event_type": event_type,
+            "created_at": datetime.utcnow().isoformat(),
+            "payload": payload,
+        }
+        with self._events_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event, sort_keys=True) + "\n")
+
+    def _read_events(self) -> list[dict[str, Any]]:
+        if not self._events_path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        for line in self._events_path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+        return events
+
+    def _load_proposal_file(self) -> _ProposalFile:
+        if not self._proposals_path.exists():
+            return _ProposalFile()
+        raw = json.loads(self._proposals_path.read_text(encoding="utf-8"))
+        return _ProposalFile.model_validate(raw)
+
+    def _save_proposal_file(self, proposal_file: _ProposalFile) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._proposals_path.write_text(
+            proposal_file.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+
+    def _find_proposal(self, proposal_file: _ProposalFile, proposal_id: str) -> LearningProposal:
+        for proposal in proposal_file.proposals:
+            if proposal.id == proposal_id:
+                return proposal
+        raise ValueError(f"Proposal {proposal_id!r} not found")
+
+
+EventPayload = Literal[
+    "workflow_outcome",
+    "user_feedback",
+    "learning_proposal",
+    "learning_proposal_approved",
+    "learning_proposal_rejected",
+]

--- a/trippy/services/map_outputs.py
+++ b/trippy/services/map_outputs.py
@@ -1,0 +1,264 @@
+"""Build practical Google Maps artifacts from canonical trip state."""
+
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+from urllib.parse import quote_plus
+
+from trippy.models.maps import MapPin, MapPinCategory, MapRoute, MapRouteMode, TripMapArtifact
+from trippy.models.trip import Segment, SegmentType, Stay, Trip
+
+
+class MapOutputService:
+    """Create linkable map artifacts for a trip."""
+
+    def build_trip_map(self, trip: Trip) -> TripMapArtifact:
+        pins = self._pins_for_trip(trip)
+        routes = self._routes_for_trip(trip)
+        artifact = TripMapArtifact(
+            trip_id=trip.trip_id,
+            title=f"{trip.name} Map",
+            pins=pins,
+            routes=routes,
+            day_groups=_day_groups(pins, routes),
+            notes=[
+                "Coordinates are intentionally not guessed. Google Maps links use address/search queries.",
+                "GeoJSON uses null geometry until a geocoder or My Maps import resolves coordinates.",
+            ],
+        )
+        return artifact
+
+    def write_artifacts(self, trip: Trip, output_dir: Path) -> TripMapArtifact:
+        artifact = self.build_trip_map(trip)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        json_path = output_dir / f"{trip.trip_id}-map.json"
+        geojson_path = output_dir / f"{trip.trip_id}-map.geojson"
+        kml_path = output_dir / f"{trip.trip_id}-map.kml"
+
+        json_path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
+        geojson_path.write_text(json.dumps(artifact.to_geojson(), indent=2), encoding="utf-8")
+        kml_path.write_text(self.to_kml(artifact), encoding="utf-8")
+
+        artifact.exports = {
+            "json": str(json_path),
+            "geojson": str(geojson_path),
+            "kml": str(kml_path),
+        }
+        json_path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
+        return artifact
+
+    def to_kml(self, artifact: TripMapArtifact) -> str:
+        placemarks = []
+        for pin in artifact.pins:
+            description = html.escape(pin.notes or pin.google_maps_url)
+            placemarks.append(
+                "\n".join(
+                    [
+                        "    <Placemark>",
+                        f"      <name>{html.escape(pin.label)}</name>",
+                        f"      <description>{description}</description>",
+                        f"      <address>{html.escape(pin.address or pin.query)}</address>",
+                        "    </Placemark>",
+                    ]
+                )
+            )
+        body = "\n".join(placemarks)
+        return "\n".join(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<kml xmlns="http://www.opengis.net/kml/2.2">',
+                "  <Document>",
+                f"    <name>{html.escape(artifact.title)}</name>",
+                body,
+                "  </Document>",
+                "</kml>",
+                "",
+            ]
+        )
+
+    def _pins_for_trip(self, trip: Trip) -> list[MapPin]:
+        pins: list[MapPin] = []
+        seen: set[tuple[MapPinCategory, str]] = set()
+
+        for segment in trip.segments:
+            if segment.segment_type == SegmentType.FLIGHT:
+                origin_query = _airport_query(segment.origin)
+                destination_query = _airport_query(segment.destination)
+                for label, query, source_id in (
+                    (f"Depart {segment.origin}", origin_query, f"{segment.segment_id}:origin"),
+                    (
+                        f"Arrive {segment.destination}",
+                        destination_query,
+                        f"{segment.segment_id}:destination",
+                    ),
+                ):
+                    key = (MapPinCategory.AIRPORT, query)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    pins.append(
+                        MapPin(
+                            pin_id=f"pin-{len(pins) + 1}",
+                            label=label,
+                            category=MapPinCategory.AIRPORT,
+                            query=query,
+                            google_maps_url=_maps_search_url(query),
+                            source_id=source_id,
+                            notes="Airport pin generated from flight segment.",
+                        )
+                    )
+
+        for stay in trip.stays:
+            query = _stay_query(stay)
+            pins.append(
+                MapPin(
+                    pin_id=f"pin-{len(pins) + 1}",
+                    label=stay.property_name,
+                    category=MapPinCategory.LODGING,
+                    query=query,
+                    address=stay.address,
+                    google_maps_url=_maps_search_url(query),
+                    source_id=stay.stay_id,
+                    day_index=_day_index(trip, stay.check_in),
+                    notes=_stay_notes(stay),
+                )
+            )
+
+        for transfer in trip.transfers:
+            if not transfer.pickup_point:
+                continue
+            query = transfer.pickup_point
+            pins.append(
+                MapPin(
+                    pin_id=f"pin-{len(pins) + 1}",
+                    label=transfer.provider or "Transfer pickup",
+                    category=MapPinCategory.TRANSFER,
+                    query=query,
+                    google_maps_url=_maps_search_url(query),
+                    source_id=transfer.transfer_id,
+                    notes=transfer.notes or transfer.pickup_window,
+                )
+            )
+
+        return pins
+
+    def _routes_for_trip(self, trip: Trip) -> list[MapRoute]:
+        routes: list[MapRoute] = []
+        arrival_segments = [
+            segment
+            for segment in trip.segments
+            if segment.segment_type == SegmentType.FLIGHT and segment.destination
+        ]
+        for stay in trip.stays:
+            arrival = _best_arrival_for_stay(stay, arrival_segments)
+            if arrival is None:
+                continue
+            origin = _airport_query(arrival.destination)
+            destination = _stay_query(stay)
+            routes.append(
+                MapRoute(
+                    route_id=f"route-{len(routes) + 1}",
+                    label=f"{arrival.destination} to {stay.property_name}",
+                    origin_query=origin,
+                    destination_query=destination,
+                    google_maps_url=_directions_url(origin, destination, MapRouteMode.DRIVING),
+                    mode=MapRouteMode.DRIVING,
+                    day_index=_day_index(trip, stay.check_in),
+                    notes="Airport-to-lodging route; verify drive/transit mode for the destination.",
+                )
+            )
+
+        for previous, current in zip(trip.stays, trip.stays[1:], strict=False):
+            origin = _stay_query(previous)
+            destination = _stay_query(current)
+            routes.append(
+                MapRoute(
+                    route_id=f"route-{len(routes) + 1}",
+                    label=f"{previous.property_name} to {current.property_name}",
+                    origin_query=origin,
+                    destination_query=destination,
+                    google_maps_url=_directions_url(origin, destination, MapRouteMode.DRIVING),
+                    mode=MapRouteMode.DRIVING,
+                    day_index=_day_index(trip, current.check_in),
+                    notes="Stay-to-stay transition; check luggage load and buffers.",
+                )
+            )
+        return routes
+
+
+def _maps_search_url(query: str) -> str:
+    return f"https://www.google.com/maps/search/?api=1&query={quote_plus(query)}"
+
+
+def _directions_url(origin: str, destination: str, mode: MapRouteMode) -> str:
+    return (
+        "https://www.google.com/maps/dir/?api=1"
+        f"&origin={quote_plus(origin)}"
+        f"&destination={quote_plus(destination)}"
+        f"&travelmode={mode.value}"
+    )
+
+
+def _airport_query(code_or_city: str) -> str:
+    value = code_or_city.strip()
+    if len(value) == 3 and value.isalpha():
+        return f"{value.upper()} airport"
+    return value
+
+
+def _stay_query(stay: Stay) -> str:
+    if stay.address:
+        return stay.address
+    return ", ".join(part for part in [stay.property_name, stay.city, stay.country] if part)
+
+
+def _stay_notes(stay: Stay) -> str:
+    notes = []
+    if stay.check_in:
+        notes.append(f"Check-in {stay.check_in}")
+    if stay.check_in_time:
+        notes.append(f"after {stay.check_in_time}")
+    if stay.room_type:
+        notes.append(stay.room_type)
+    if stay.notes:
+        notes.append(stay.notes)
+    return "; ".join(notes)
+
+
+def _day_index(trip: Trip, value: object) -> int | None:
+    if trip.start_date is None or value is None or not hasattr(value, "toordinal"):
+        return None
+    return max(1, int(value.toordinal() - trip.start_date.toordinal()) + 1)
+
+
+def _best_arrival_for_stay(stay: Stay, segments: list[Segment]) -> Segment | None:
+    if not segments:
+        return None
+    if stay.check_in is None:
+        return segments[0]
+    candidates = []
+    for segment in segments:
+        arrive_at = segment.arrive_at
+        if arrive_at is not None and arrive_at.date() <= stay.check_in:
+            candidates.append(segment)
+    if candidates:
+        return sorted(
+            candidates,
+            key=lambda segment: segment.arrive_at.timestamp() if segment.arrive_at else 0.0,
+        )[-1]
+    return segments[0]
+
+
+def _day_groups(pins: list[MapPin], routes: list[MapRoute]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {}
+    for pin in pins:
+        if pin.day_index is None:
+            continue
+        groups.setdefault(f"day-{pin.day_index}", []).append(pin.pin_id)
+    for route in routes:
+        if route.day_index is None:
+            continue
+        groups.setdefault(f"day-{route.day_index}", []).append(route.route_id)
+    return groups

--- a/trippy/services/phase_planner.py
+++ b/trippy/services/phase_planner.py
@@ -30,7 +30,6 @@ class PhasePlannerService:
         self._trips_dir = trips_dir or config.TRIPS_PATH
 
     def status(self) -> list[PhaseStatus]:
-        from trippy import config
         from trippy.memory.store import MemoryStore
         from trippy.services.trip_state import TripStateService
 
@@ -38,9 +37,18 @@ class PhasePlannerService:
         trip_svc = TripStateService(self._trips_dir)
         trips = trip_svc.load_all()
 
-        has_google_creds = (
-            config.GMAIL_CREDENTIALS_PATH.exists()
-            and (config.GMAIL_TOKEN_PATH.exists() or config.GOOGLE_TOKEN_PATH.exists())
+        from trippy.services.setup import CheckStatus, SetupDoctor
+
+        doctor = SetupDoctor()
+        setup_report = doctor.run()
+        google_checks = {
+            check.name: check.status
+            for check in setup_report.checks
+            if check.name in {"google_credentials", "google_token", "google_scopes"}
+        }
+        has_google_creds = all(
+            google_checks.get(name) == CheckStatus.PASS
+            for name in ("google_credentials", "google_token", "google_scopes")
         )
         has_trips = len(trips) > 0
         has_preferences = memory.get_value("pref:preferences_object") is not None
@@ -54,7 +62,14 @@ class PhasePlannerService:
                 phase=2,
                 title="Live Google credentials",
                 complete=has_google_creds,
-                blockers=[] if has_google_creds else ["Missing Google credentials/token files"],
+                blockers=[]
+                if has_google_creds
+                else [
+                    check.summary
+                    for check in setup_report.checks
+                    if check.name in {"google_credentials", "google_token", "google_scopes"}
+                    and check.status in {CheckStatus.FAIL, CheckStatus.SKIP}
+                ],
                 next_step="Run: trippy phase-run 2",
             )
         )
@@ -84,7 +99,9 @@ class PhasePlannerService:
                 phase=5,
                 title="Gmail reconciliation in production",
                 complete=has_confirmation,
-                blockers=[] if has_confirmation else ["No parsed confirmations linked to trips yet"],
+                blockers=[]
+                if has_confirmation
+                else ["No parsed confirmations linked to trips yet"],
                 next_step="Run: trippy phase-run 5 --max-emails 50",
             )
         )
@@ -115,7 +132,9 @@ class PhasePlannerService:
 
     def _run_phase_2(self) -> dict[str, Any]:
         from trippy import config
+        from trippy.services.setup import SetupDoctor
 
+        report = SetupDoctor().run()
         return {
             "phase": 2,
             "credentials_path": str(config.GMAIL_CREDENTIALS_PATH),
@@ -123,6 +142,9 @@ class PhasePlannerService:
             "google_token_path": str(config.GOOGLE_TOKEN_PATH),
             "credentials_exist": config.GMAIL_CREDENTIALS_PATH.exists(),
             "token_exists": config.GMAIL_TOKEN_PATH.exists() or config.GOOGLE_TOKEN_PATH.exists(),
+            "setup_ok": report.ok,
+            "checks": [check.model_dump(mode="json") for check in report.checks],
+            "next_actions": report.next_actions,
         }
 
     def _run_phase_3(self, **kwargs: Any) -> dict[str, Any]:
@@ -163,7 +185,15 @@ class PhasePlannerService:
         from trippy.skills.runners.gmail_reconciler import GmailReconcilerRunner
 
         runner = GmailReconcilerRunner()
-        result = runner.run({"max_emails": kwargs.get("max_emails", 50)})
+        result = runner.run(
+            {
+                "max_emails": kwargs.get("max_emails", 50),
+                "trip_id": kwargs.get("trip_id"),
+                "label": kwargs.get("label", "INBOX"),
+                "query": kwargs.get("query"),
+                "dry_run": kwargs.get("dry_run", False),
+            }
+        )
         return {"phase": 5, "reconciled": result}
 
     def _run_phase_6(self, **kwargs: Any) -> dict[str, Any]:
@@ -183,18 +213,37 @@ class PhasePlannerService:
         runner = FrictionAuditRunner()
         audit_result = runner.run({"trip_id": trip_id, "check_preferences": True})
 
-        # Minimal self-improvement loop: store a reusable hint when high/critical
+        # Minimal self-improvement loop: propose a reusable hint when high/critical.
         critical = int(audit_result.get("critical", 0))
         high = int(audit_result.get("high", 0))
+        learning_proposals: list[str] = []
         if critical > 0 or high > 0:
-            memory = MemoryStore(config.MEMORY_PATH)
-            memory.set(
-                key="hint:always-run-friction-audit-after-reconcile",
-                value=True,
-                category="skill_hint",
-                confidence=0.8,
-                source="phase-runner",
-                notes="High/critical risk found; enforce post-reconcile friction audit.",
+            from trippy.services.learning import (
+                LearningEventStore,
+                LearningProposal,
+                ProposalType,
             )
 
-        return {"phase": 6, "audit": audit_result}
+            memory = MemoryStore(config.MEMORY_PATH)
+            key = "hint:always-run-friction-audit-after-reconcile"
+            existing = memory.get(key)
+            proposals = LearningEventStore(memory_path=memory.path).add_proposals(
+                [
+                    LearningProposal(
+                        proposal_type=ProposalType.MEMORY,
+                        summary="Review hint: always run friction audit after reconciliation",
+                        before=existing.model_dump(mode="json") if existing else None,
+                        after={
+                            "key": key,
+                            "value": True,
+                            "category": "skill_hint",
+                            "confidence": 0.8,
+                            "source": "phase-runner",
+                            "notes": "High/critical risk found; enforce post-reconcile friction audit.",
+                        },
+                    )
+                ]
+            )
+            learning_proposals = [proposal.id for proposal in proposals]
+
+        return {"phase": 6, "audit": audit_result, "learning_proposals": learning_proposals}

--- a/trippy/services/retrospective.py
+++ b/trippy/services/retrospective.py
@@ -1,0 +1,169 @@
+"""Post-trip retrospective workflow with review-gated learning proposals."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from trippy.models.retrospective import TripRetrospectiveInput, TripRetrospectiveResult
+from trippy.services.learning import (
+    LearningEventStore,
+    LearningProposal,
+    ProposalType,
+    WorkflowOutcome,
+    WorkflowStatus,
+)
+from trippy.services.trip_state import TripStateService
+
+
+class RetrospectiveService:
+    """Capture post-trip lessons without silently mutating memory."""
+
+    def __init__(
+        self,
+        trip_state: TripStateService | None = None,
+        learning_store: LearningEventStore | None = None,
+    ) -> None:
+        self._trip_state = trip_state or TripStateService()
+        self._learning_store = learning_store or LearningEventStore()
+
+    def record(self, retrospective: TripRetrospectiveInput) -> TripRetrospectiveResult:
+        trip = self._trip_state.load(retrospective.trip_id)
+        if trip is None:
+            raise ValueError(f"Trip {retrospective.trip_id!r} not found")
+
+        outcome = self._learning_store.record_workflow(
+            WorkflowOutcome(
+                workflow_name="post-trip-retrospective",
+                skill_name="trippy-preference-extractor",
+                trip_id=trip.trip_id,
+                status=WorkflowStatus.SUCCESS,
+                summary=f"Captured retrospective for {trip.name}",
+                metrics={
+                    "worked": len(retrospective.worked),
+                    "friction": len(retrospective.friction),
+                    "hard_rules": len(retrospective.hard_rules),
+                    "never_repeat": len(retrospective.never_repeat),
+                    "favorites": len(retrospective.favorites),
+                },
+                artifacts={"retrospective": retrospective.model_dump(mode="json")},
+                evidence_refs=[f"trip:{trip.trip_id}", "source:post-trip-retrospective"],
+            )
+        )
+        proposals = self._learning_store.add_proposals(
+            _proposals_from_retrospective(retrospective, source_workflow_id=outcome.id)
+        )
+        return TripRetrospectiveResult(
+            trip_id=trip.trip_id,
+            workflow_id=outcome.id,
+            proposal_ids=[proposal.id for proposal in proposals],
+            summary=f"Captured retrospective and created {len(proposals)} review-gated proposal(s).",
+        )
+
+
+def retrospective_store(learning_dir: Path, memory_path: Path) -> LearningEventStore:
+    return LearningEventStore(learning_dir, memory_path=memory_path)
+
+
+def _proposals_from_retrospective(
+    retrospective: TripRetrospectiveInput,
+    *,
+    source_workflow_id: str,
+) -> list[LearningProposal]:
+    proposals: list[LearningProposal] = []
+    for item in retrospective.hard_rules:
+        proposals.append(
+            _memory_proposal(
+                retrospective,
+                key=f"rule:retro:{retrospective.trip_id}:{_slug(item)}",
+                value=item,
+                category="preference",
+                confidence=0.85,
+                summary=f"Review hard travel rule from retrospective: {item[:120]}",
+                source_workflow_id=source_workflow_id,
+            )
+        )
+    for item in retrospective.never_repeat:
+        proposals.append(
+            _memory_proposal(
+                retrospective,
+                key=f"rule:never-repeat:{retrospective.trip_id}:{_slug(item)}",
+                value=item,
+                category="skill_hint",
+                confidence=0.8,
+                summary=f"Review never-repeat lesson from retrospective: {item[:120]}",
+                source_workflow_id=source_workflow_id,
+            )
+        )
+    for item in retrospective.friction:
+        proposals.append(
+            _memory_proposal(
+                retrospective,
+                key=f"friction:retro:{retrospective.trip_id}:{_slug(item)}",
+                value=item,
+                category="skill_hint",
+                confidence=0.75,
+                summary=f"Review friction lesson from retrospective: {item[:120]}",
+                source_workflow_id=source_workflow_id,
+            )
+        )
+    for item in retrospective.favorites:
+        proposals.append(
+            _memory_proposal(
+                retrospective,
+                key=f"favorite:retro:{retrospective.trip_id}:{_slug(item)}",
+                value=item,
+                category="trip_insight",
+                confidence=0.7,
+                summary=f"Review favorite trip pattern from retrospective: {item[:120]}",
+                source_workflow_id=source_workflow_id,
+            )
+        )
+
+    if retrospective.pace:
+        proposals.append(
+            _memory_proposal(
+                retrospective,
+                key=f"pace:retro:{retrospective.trip_id}",
+                value=retrospective.pace,
+                category="preference",
+                confidence=0.75,
+                summary=f"Review pacing lesson from retrospective: {retrospective.pace[:120]}",
+                source_workflow_id=source_workflow_id,
+            )
+        )
+    return proposals
+
+
+def _memory_proposal(
+    retrospective: TripRetrospectiveInput,
+    *,
+    key: str,
+    value: str,
+    category: str,
+    confidence: float,
+    summary: str,
+    source_workflow_id: str,
+) -> LearningProposal:
+    return LearningProposal(
+        proposal_type=ProposalType.MEMORY,
+        summary=summary,
+        source_workflow_id=source_workflow_id,
+        after={
+            "key": key,
+            "value": {
+                "trip_id": retrospective.trip_id,
+                "lesson": value,
+                "evidence": "post-trip-retrospective",
+            },
+            "category": category,
+            "confidence": confidence,
+            "source": "post-trip-retrospective",
+            "notes": retrospective.notes,
+        },
+    )
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:48] or "lesson"

--- a/trippy/services/setup.py
+++ b/trippy/services/setup.py
@@ -1,0 +1,449 @@
+"""First-run setup diagnostics and Google OAuth validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from trippy import config
+from trippy.ingest.google_auth import ALL_SCOPES, GoogleAuthManager, missing_required_scopes
+
+
+class CheckStatus(StrEnum):
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
+class SetupCheck(BaseModel):
+    name: str
+    status: CheckStatus
+    summary: str
+    detail: str | None = None
+
+
+class SetupReport(BaseModel):
+    ok: bool
+    checks: list[SetupCheck]
+    next_actions: list[str] = Field(default_factory=list)
+
+    def check(self, name: str) -> SetupCheck | None:
+        for item in self.checks:
+            if item.name == name:
+                return item
+        return None
+
+
+class SetupDoctor:
+    """Deterministic readiness checks for running Trippy locally and live."""
+
+    def __init__(self, project_root: Path | None = None) -> None:
+        self._root = project_root or Path.cwd()
+
+    def run(self, *, create_paths: bool = True) -> SetupReport:
+        checks = [
+            self._check_env_file(),
+            *self._check_storage_paths(create_paths=create_paths),
+            self._check_database(),
+            self._check_anthropic_key(),
+            self._check_google_credentials(),
+            self._check_google_token(),
+            self._check_google_scopes(),
+            self._check_sheet_template(),
+            self._check_mcp_config(),
+        ]
+        next_actions = self._next_actions(checks)
+        ok = not any(check.status == CheckStatus.FAIL for check in checks)
+        return SetupReport(ok=ok, checks=checks, next_actions=next_actions)
+
+    def google_ready(self) -> bool:
+        report = self.run()
+        required = {"google_credentials", "google_token", "google_scopes"}
+        return all(
+            check.name not in required or check.status == CheckStatus.PASS
+            for check in report.checks
+        )
+
+    def _check_env_file(self) -> SetupCheck:
+        env_path = self._root / ".env"
+        if env_path.exists():
+            return SetupCheck(name="env_file", status=CheckStatus.PASS, summary=".env file found")
+        return SetupCheck(
+            name="env_file",
+            status=CheckStatus.WARN,
+            summary=".env file not found",
+            detail="Copy .env.example to .env when you are ready to use live credentials.",
+        )
+
+    def _check_storage_paths(self, *, create_paths: bool) -> list[SetupCheck]:
+        checks: list[SetupCheck] = []
+        paths = {
+            "db_parent": config.DB_PATH.parent,
+            "trips_dir": config.TRIPS_PATH,
+            "vault_dir": config.VAULT_PATH,
+            "export_dir": config.EXPORT_PATH,
+            "learning_dir": config.LEARNING_PATH,
+        }
+        for name, path in paths.items():
+            try:
+                if create_paths:
+                    path.mkdir(parents=True, exist_ok=True)
+                    probe = path / ".trippy-write-check"
+                    probe.write_text("ok", encoding="utf-8")
+                    probe.unlink(missing_ok=True)
+                elif not path.exists():
+                    checks.append(
+                        SetupCheck(
+                            name=name,
+                            status=CheckStatus.WARN,
+                            summary=f"Path does not exist yet: {path}",
+                        )
+                    )
+                    continue
+                checks.append(
+                    SetupCheck(
+                        name=name,
+                        status=CheckStatus.PASS,
+                        summary=f"Writable: {path}",
+                    )
+                )
+            except Exception as exc:
+                checks.append(
+                    SetupCheck(
+                        name=name,
+                        status=CheckStatus.FAIL,
+                        summary=f"Not writable: {path}",
+                        detail=str(exc),
+                    )
+                )
+        return checks
+
+    def _check_database(self) -> SetupCheck:
+        if not config.DB_PATH.exists():
+            return SetupCheck(
+                name="database",
+                status=CheckStatus.WARN,
+                summary="Database not initialized",
+                detail="Run: trippy db-init",
+            )
+        try:
+            with sqlite3.connect(config.DB_PATH) as conn:
+                tables = {
+                    row[0]
+                    for row in conn.execute(
+                        "select name from sqlite_master where type = 'table'"
+                    ).fetchall()
+                }
+                if "alembic_version" not in tables:
+                    return SetupCheck(
+                        name="database",
+                        status=CheckStatus.WARN,
+                        summary="Database exists but Alembic version table is missing",
+                        detail="Run: trippy db-init",
+                    )
+            return SetupCheck(
+                name="database",
+                status=CheckStatus.PASS,
+                summary=f"Database initialized: {config.DB_PATH}",
+            )
+        except Exception as exc:
+            return SetupCheck(
+                name="database",
+                status=CheckStatus.FAIL,
+                summary=f"Database cannot be inspected: {config.DB_PATH}",
+                detail=str(exc),
+            )
+
+    def _check_anthropic_key(self) -> SetupCheck:
+        key = config.ANTHROPIC_API_KEY.strip()
+        if key and not key.startswith("sk-ant-..."):
+            return SetupCheck(
+                name="anthropic_key", status=CheckStatus.PASS, summary="Anthropic key set"
+            )
+        return SetupCheck(
+            name="anthropic_key",
+            status=CheckStatus.FAIL,
+            summary="ANTHROPIC_API_KEY is missing",
+            detail="Set ANTHROPIC_API_KEY in .env before running the interactive agent or parser.",
+        )
+
+    def _check_google_credentials(self) -> SetupCheck:
+        if config.GMAIL_CREDENTIALS_PATH.exists():
+            return SetupCheck(
+                name="google_credentials",
+                status=CheckStatus.PASS,
+                summary=f"OAuth client secrets found: {config.GMAIL_CREDENTIALS_PATH}",
+            )
+        return SetupCheck(
+            name="google_credentials",
+            status=CheckStatus.FAIL,
+            summary="Google OAuth client secrets missing",
+            detail=f"Save a Desktop OAuth client JSON at {config.GMAIL_CREDENTIALS_PATH}.",
+        )
+
+    def _token_path(self) -> Path:
+        if config.GOOGLE_TOKEN_PATH.exists():
+            return config.GOOGLE_TOKEN_PATH
+        return config.GMAIL_TOKEN_PATH
+
+    def _check_google_token(self) -> SetupCheck:
+        token_path = self._token_path()
+        if token_path.exists():
+            return SetupCheck(
+                name="google_token",
+                status=CheckStatus.PASS,
+                summary=f"Google OAuth token found: {token_path}",
+            )
+        return SetupCheck(
+            name="google_token",
+            status=CheckStatus.FAIL,
+            summary="Google OAuth token missing",
+            detail="Run: trippy auth-google",
+        )
+
+    def _check_google_scopes(self) -> SetupCheck:
+        token_path = self._token_path()
+        if not token_path.exists():
+            return SetupCheck(
+                name="google_scopes",
+                status=CheckStatus.SKIP,
+                summary="Google OAuth scopes not checked because token is missing",
+            )
+        try:
+            missing = missing_required_scopes(token_path, ALL_SCOPES)
+        except Exception as exc:
+            return SetupCheck(
+                name="google_scopes",
+                status=CheckStatus.FAIL,
+                summary="Google OAuth token cannot be parsed",
+                detail=str(exc),
+            )
+        if missing:
+            return SetupCheck(
+                name="google_scopes",
+                status=CheckStatus.FAIL,
+                summary="Google OAuth token is missing required scopes",
+                detail="Run: trippy auth-google --force\nMissing: " + ", ".join(sorted(missing)),
+            )
+        return SetupCheck(
+            name="google_scopes",
+            status=CheckStatus.PASS,
+            summary="Google OAuth token includes Gmail read, Sheets write, and Drive write scopes",
+        )
+
+    def _check_sheet_template(self) -> SetupCheck:
+        if config.SHEET_TEMPLATE_ID.strip():
+            return SetupCheck(
+                name="sheet_template",
+                status=CheckStatus.PASS,
+                summary="TRIPPY_SHEET_TEMPLATE_ID is configured",
+            )
+        return SetupCheck(
+            name="sheet_template",
+            status=CheckStatus.WARN,
+            summary="TRIPPY_SHEET_TEMPLATE_ID is not set",
+            detail="Trip sheet creation will create a blank Trippy sheet instead of copying a template.",
+        )
+
+    def _check_mcp_config(self) -> SetupCheck:
+        cfg_path = self._root / "mcp_config.json"
+        spec = importlib.util.find_spec("trippy.mcp.server")
+        if not cfg_path.exists():
+            return SetupCheck(
+                name="mcp_config",
+                status=CheckStatus.WARN,
+                summary="mcp_config.json not found",
+            )
+        if spec is None:
+            return SetupCheck(
+                name="mcp_config",
+                status=CheckStatus.FAIL,
+                summary="trippy.mcp.server is not importable",
+            )
+        try:
+            json.loads(cfg_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            return SetupCheck(
+                name="mcp_config",
+                status=CheckStatus.FAIL,
+                summary="mcp_config.json is not valid JSON",
+                detail=str(exc),
+            )
+        return SetupCheck(
+            name="mcp_config",
+            status=CheckStatus.PASS,
+            summary="MCP config found and server module is importable",
+        )
+
+    def _next_actions(self, checks: list[SetupCheck]) -> list[str]:
+        by_name = {check.name: check for check in checks}
+        actions: list[str] = []
+        if (
+            by_name.get(
+                "anthropic_key", SetupCheck(name="", status=CheckStatus.PASS, summary="")
+            ).status
+            == CheckStatus.FAIL
+        ):
+            actions.append("Set ANTHROPIC_API_KEY in .env.")
+        if (
+            by_name.get(
+                "google_credentials", SetupCheck(name="", status=CheckStatus.PASS, summary="")
+            ).status
+            == CheckStatus.FAIL
+        ):
+            actions.append(f"Save Google OAuth client secrets to {config.GMAIL_CREDENTIALS_PATH}.")
+        if (
+            by_name.get(
+                "google_token", SetupCheck(name="", status=CheckStatus.PASS, summary="")
+            ).status
+            == CheckStatus.FAIL
+        ):
+            actions.append("Run: trippy auth-google")
+        if (
+            by_name.get(
+                "google_scopes", SetupCheck(name="", status=CheckStatus.PASS, summary="")
+            ).status
+            == CheckStatus.FAIL
+        ):
+            actions.append("Run: trippy auth-google --force")
+        if (
+            by_name.get("database", SetupCheck(name="", status=CheckStatus.PASS, summary="")).status
+            == CheckStatus.WARN
+        ):
+            actions.append("Run: trippy db-init")
+        return actions
+
+
+class AuthGoogleResult(BaseModel):
+    ok: bool
+    checks: list[SetupCheck]
+
+
+class GoogleAuthValidator:
+    """Runs OAuth and validates live Gmail, Sheets, and Drive capabilities."""
+
+    def __init__(self, auth_manager: GoogleAuthManager | None = None) -> None:
+        self._auth_manager = auth_manager
+
+    def run(self, *, force: bool = False) -> AuthGoogleResult:
+        checks: list[SetupCheck] = []
+        if force:
+            config.GOOGLE_TOKEN_PATH.unlink(missing_ok=True)
+            config.GMAIL_TOKEN_PATH.unlink(missing_ok=True)
+
+        auth = self._auth_manager or GoogleAuthManager(token_path=config.GOOGLE_TOKEN_PATH)
+        try:
+            auth.get_credentials()
+            checks.append(
+                SetupCheck(
+                    name="oauth",
+                    status=CheckStatus.PASS,
+                    summary=f"OAuth token ready: {config.GOOGLE_TOKEN_PATH}",
+                )
+            )
+        except Exception as exc:
+            checks.append(
+                SetupCheck(
+                    name="oauth",
+                    status=CheckStatus.FAIL,
+                    summary="OAuth flow failed",
+                    detail=str(exc),
+                )
+            )
+            return AuthGoogleResult(ok=False, checks=checks)
+
+        checks.append(self._validate_gmail(auth))
+        temp_sheet_id = ""
+        sheet_check, temp_sheet_id = self._validate_sheets(auth)
+        checks.append(sheet_check)
+        checks.append(self._validate_drive(auth, temp_sheet_id))
+        if config.SHEET_TEMPLATE_ID:
+            checks.append(self._validate_template(auth))
+
+        ok = not any(check.status == CheckStatus.FAIL for check in checks)
+        return AuthGoogleResult(ok=ok, checks=checks)
+
+    def _validate_gmail(self, auth: GoogleAuthManager) -> SetupCheck:
+        try:
+            service = auth.build_service("gmail", "v1")
+            service.users().labels().list(userId="me").execute()
+            return SetupCheck(
+                name="gmail", status=CheckStatus.PASS, summary="Gmail readonly access works"
+            )
+        except Exception as exc:
+            return SetupCheck(
+                name="gmail",
+                status=CheckStatus.FAIL,
+                summary="Gmail readonly validation failed",
+                detail=str(exc),
+            )
+
+    def _validate_sheets(self, auth: GoogleAuthManager) -> tuple[SetupCheck, str]:
+        title = f"Trippy Auth Validation {datetime.utcnow().isoformat(timespec='seconds')}"
+        try:
+            service = auth.build_service("sheets", "v4")
+            resp = service.spreadsheets().create(body={"properties": {"title": title}}).execute()
+            sheet_id = str(resp["spreadsheetId"])
+            service.spreadsheets().values().update(
+                spreadsheetId=sheet_id,
+                range="Sheet1!A1",
+                valueInputOption="USER_ENTERED",
+                body={"values": [["Trippy auth validation"]]},
+            ).execute()
+            return (
+                SetupCheck(
+                    name="sheets",
+                    status=CheckStatus.PASS,
+                    summary="Sheets create/write access works",
+                ),
+                sheet_id,
+            )
+        except Exception as exc:
+            return (
+                SetupCheck(
+                    name="sheets",
+                    status=CheckStatus.FAIL,
+                    summary="Sheets create/write validation failed",
+                    detail=str(exc),
+                ),
+                "",
+            )
+
+    def _validate_drive(self, auth: GoogleAuthManager, temp_sheet_id: str) -> SetupCheck:
+        try:
+            service = auth.build_service("drive", "v3")
+            service.files().list(pageSize=1, fields="files(id,name)").execute()
+            if temp_sheet_id:
+                service.files().delete(fileId=temp_sheet_id).execute()
+            return SetupCheck(name="drive", status=CheckStatus.PASS, summary="Drive access works")
+        except Exception as exc:
+            return SetupCheck(
+                name="drive",
+                status=CheckStatus.FAIL,
+                summary="Drive validation failed",
+                detail=str(exc),
+            )
+
+    def _validate_template(self, auth: GoogleAuthManager) -> SetupCheck:
+        try:
+            service = auth.build_service("drive", "v3")
+            service.files().get(fileId=config.SHEET_TEMPLATE_ID, fields="id,name").execute()
+            return SetupCheck(
+                name="sheet_template_access",
+                status=CheckStatus.PASS,
+                summary="Template sheet is accessible",
+            )
+        except Exception as exc:
+            return SetupCheck(
+                name="sheet_template_access",
+                status=CheckStatus.FAIL,
+                summary="Template sheet cannot be accessed",
+                detail=str(exc),
+            )

--- a/trippy/services/sheet_sync.py
+++ b/trippy/services/sheet_sync.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import date, datetime
-from typing import Any
+from typing import Any, cast
 
 from trippy.models.trip import ChecklistItem, Segment, Stay, Trip
 from trippy.services.trip_state import TripStateService
@@ -54,7 +54,9 @@ _TRANSFERS_COLS = [
 class SheetSyncService:
     """Manages the Trippy trip sheet ↔ canonical state sync."""
 
-    def __init__(self, auth_manager: Any | None = None, state_service: TripStateService | None = None) -> None:
+    def __init__(
+        self, auth_manager: Any | None = None, state_service: TripStateService | None = None
+    ) -> None:
         self._auth = auth_manager
         self._state = state_service or TripStateService()
 
@@ -333,7 +335,7 @@ class SheetSyncService:
                 .get(spreadsheetId=sheet_id, range=range_name)
                 .execute()
             )
-            return resp.get("values", [])
+            return cast(list[list[str]], resp.get("values", []))
         except Exception as exc:
             logger.warning("pull range failed sheet=%s range=%s err=%s", sheet_id, range_name, exc)
             return []
@@ -344,8 +346,7 @@ class SheetSyncService:
             if not row:
                 continue
             mapped = {
-                col: str(row[idx]).strip() if idx < len(row) else ""
-                for idx, col in enumerate(cols)
+                col: str(row[idx]).strip() if idx < len(row) else "" for idx, col in enumerate(cols)
             }
             if any(mapped.values()):
                 data.append(mapped)
@@ -414,7 +415,9 @@ class SheetSyncService:
                     "Segment ID not found in canonical trip; row ignored.",
                 )
                 continue
-            self._merge_model_field(trip, seg, f"flights.{seg_id}.carrier", "carrier", row.get("Carrier"), ts)
+            self._merge_model_field(
+                trip, seg, f"flights.{seg_id}.carrier", "carrier", row.get("Carrier"), ts
+            )
             self._merge_model_field(
                 trip,
                 seg,
@@ -423,7 +426,9 @@ class SheetSyncService:
                 row.get("Confirmation"),
                 ts,
             )
-            self._merge_model_field(trip, seg, f"flights.{seg_id}.notes", "notes", row.get("Notes"), ts)
+            self._merge_model_field(
+                trip, seg, f"flights.{seg_id}.notes", "notes", row.get("Notes"), ts
+            )
 
         by_stay_id = {stay.stay_id: stay for stay in trip.stays}
         for row in pulled.get("hotels", []):
@@ -597,10 +602,8 @@ class SheetSyncService:
         reason: str,
     ) -> None:
         trip.sync.sync_conflicts.append(
-            (
-                f"{ts.isoformat()} field={field_key} sheet={sheet_value!r} "
-                f"canonical={canonical_value!r} reason={reason}"
-            )
+            f"{ts.isoformat()} field={field_key} sheet={sheet_value!r} "
+            f"canonical={canonical_value!r} reason={reason}"
         )
 
 

--- a/trippy/services/skill_learning.py
+++ b/trippy/services/skill_learning.py
@@ -189,7 +189,9 @@ class SkillLearningService:
     ) -> int:
         """Apply a proposal to the skill definition, guarded by approval flag."""
         if human_approval_required and not approved_by_human:
-            raise PermissionError("Human approval required before applying skill definition changes")
+            raise PermissionError(
+                "Human approval required before applying skill definition changes"
+            )
 
         path = Path(proposal.definition_path)
         if not path.exists():

--- a/trippy/services/source_registry.py
+++ b/trippy/services/source_registry.py
@@ -1,0 +1,301 @@
+"""Deterministic travel source registry and routing rules."""
+
+from __future__ import annotations
+
+from trippy.models.sources import (
+    SourceAccessMode,
+    SourceConfidence,
+    SourcePlan,
+    TravelSource,
+    TravelSourceCategory,
+)
+
+
+class TravelSourceRegistry:
+    """Registry for choosing travel sources without ad hoc browsing."""
+
+    def __init__(self, sources: list[TravelSource] | None = None) -> None:
+        self._sources = sources or _default_sources()
+
+    def list_sources(
+        self,
+        category: TravelSourceCategory | None = None,
+    ) -> list[TravelSource]:
+        if category is None:
+            return list(self._sources)
+        return [source for source in self._sources if category in source.categories]
+
+    def get(self, platform_name: str) -> TravelSource | None:
+        normalized = platform_name.casefold()
+        for source in self._sources:
+            if source.platform_name.casefold() == normalized:
+                return source
+        return None
+
+    def plan_for(self, category: TravelSourceCategory) -> SourcePlan:
+        routing = _ROUTING[category]
+        return SourcePlan(
+            category=category,
+            primary=self._sources_by_name(routing["primary"], category=category),
+            secondary=self._sources_by_name(routing["secondary"], category=category),
+            validation=self._sources_by_name(routing["validation"], category=category),
+            notes=_ROUTING_NOTES[category],
+        )
+
+    def _sources_by_name(
+        self,
+        names: list[str],
+        *,
+        category: TravelSourceCategory,
+    ) -> list[TravelSource]:
+        sources = []
+        for name in names:
+            source = self.get(name)
+            if source is not None and category in source.categories:
+                sources.append(source)
+        return sources
+
+
+_ROUTING: dict[TravelSourceCategory, dict[str, list[str]]] = {
+    TravelSourceCategory.FLIGHTS: {
+        "primary": ["Google Flights"],
+        "secondary": ["Kayak.ca", "Expedia", "Flighthub"],
+        "validation": ["Kayak.ca", "Expedia"],
+    },
+    TravelSourceCategory.CITY_LODGING: {
+        "primary": ["Booking.com"],
+        "secondary": ["Expedia"],
+        "validation": ["Tripadvisor", "Trivago", "Expedia"],
+    },
+    TravelSourceCategory.PRIVATE_LODGING: {
+        "primary": ["Airbnb", "VRBO"],
+        "secondary": ["Booking.com"],
+        "validation": ["Tripadvisor", "Booking.com"],
+    },
+    TravelSourceCategory.TOURS: {
+        "primary": ["GetYourGuide"],
+        "secondary": ["Airbnb Experiences"],
+        "validation": ["Tripadvisor"],
+    },
+    TravelSourceCategory.CAR_RENTALS: {
+        "primary": ["Booking.com"],
+        "secondary": ["Expedia", "Kayak.ca"],
+        "validation": ["Tripadvisor"],
+    },
+    TravelSourceCategory.DEALS: {
+        "primary": ["Travelzoo"],
+        "secondary": ["Expedia"],
+        "validation": ["Tripadvisor"],
+    },
+    TravelSourceCategory.VALIDATION: {
+        "primary": ["Tripadvisor"],
+        "secondary": ["Trivago", "Expedia"],
+        "validation": [],
+    },
+}
+
+
+_ROUTING_NOTES: dict[TravelSourceCategory, list[str]] = {
+    TravelSourceCategory.FLIGHTS: [
+        "Use Google Flights first for schedule shape, directness, and total travel time.",
+        "Cross-check price and routing with Kayak.ca, Expedia, and Flighthub before recommending.",
+        "Do not treat an OTA fare as final until baggage, seats, cancellation, and airline booking path are clear.",
+    ],
+    TravelSourceCategory.CITY_LODGING: [
+        "Prioritize central, walkable boutique hotels with explicit family bed fit.",
+        "Validate neighborhood, reviews, and location tradeoffs before recommending.",
+    ],
+    TravelSourceCategory.PRIVATE_LODGING: [
+        "Use private rentals mainly outside dense city cores or when space/privacy clearly beats hotel convenience.",
+        "Validate access, parking, safety, reviews, cancellation, and bed layout hard.",
+    ],
+    TravelSourceCategory.TOURS: [
+        "Prefer small, safe, well-reviewed operators over mass-market large-group experiences.",
+        "Cross-check operator quality and crowd signals before recommending.",
+    ],
+    TravelSourceCategory.CAR_RENTALS: [
+        "Prefer Booking.com first, with Expedia and Kayak.ca as comparison layers.",
+        "Penalize weak pickup/dropoff clarity, hidden fees, poor cancellation terms, weak vehicle fit, and destination parking pain.",
+    ],
+    TravelSourceCategory.DEALS: [
+        "Use Travelzoo for inspiration and deal awareness, not as the sole source of final booking confidence.",
+    ],
+    TravelSourceCategory.VALIDATION: [
+        "Use validation sources to catch review, location, crowd, and quality issues before ready-to-click handoff.",
+    ],
+}
+
+
+def _default_sources() -> list[TravelSource]:
+    return [
+        TravelSource(
+            platform_name="Google Flights",
+            categories=[TravelSourceCategory.FLIGHTS],
+            strengths=[
+                "Fast flight schedule discovery",
+                "Good directness and total-duration comparison",
+                "Good calendar and fare-shape exploration",
+            ],
+            weaknesses=[
+                "Not a booking system",
+                "Does not fully resolve baggage, seat, loyalty, or OTA terms",
+            ],
+            confidence_level=SourceConfidence.HIGH,
+            access_modes=[
+                SourceAccessMode.BROWSER_AUTOMATION,
+                SourceAccessMode.MANUAL_HANDOFF,
+            ],
+            prefer_when=["discovering flight shape", "comparing direct vs connection tradeoffs"],
+            avoid_when=["final payment handoff without airline/OTA validation"],
+        ),
+        TravelSource(
+            platform_name="Kayak.ca",
+            categories=[TravelSourceCategory.FLIGHTS, TravelSourceCategory.CAR_RENTALS],
+            strengths=["Broad comparison surface", "Useful fare and rental cross-checking"],
+            weaknesses=["Can route to lower-trust booking paths", "Terms can vary by provider"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["secondary flight comparison", "car rental price validation"],
+            avoid_when=["provider terms are unclear", "hidden-fee risk is high"],
+        ),
+        TravelSource(
+            platform_name="Expedia",
+            categories=[
+                TravelSourceCategory.FLIGHTS,
+                TravelSourceCategory.CITY_LODGING,
+                TravelSourceCategory.CAR_RENTALS,
+                TravelSourceCategory.DEALS,
+                TravelSourceCategory.VALIDATION,
+            ],
+            strengths=["Broad inventory", "Useful package, lodging, and car comparison"],
+            weaknesses=["OTA terms and cancellation rules need careful review"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["cross-checking price and availability", "bundled comparison"],
+            avoid_when=["terms are worse than booking direct", "support chain is unclear"],
+        ),
+        TravelSource(
+            platform_name="Flighthub",
+            categories=[TravelSourceCategory.FLIGHTS],
+            strengths=["Additional Canadian-market flight fare comparison"],
+            weaknesses=["Lower trust for final handoff unless terms are very clear"],
+            confidence_level=SourceConfidence.LOW,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["spot-checking fare competitiveness"],
+            avoid_when=["family comfort, flexibility, or support quality matters more than fare"],
+        ),
+        TravelSource(
+            platform_name="Booking.com",
+            categories=[
+                TravelSourceCategory.CITY_LODGING,
+                TravelSourceCategory.PRIVATE_LODGING,
+                TravelSourceCategory.CAR_RENTALS,
+            ],
+            strengths=[
+                "Strong lodging inventory",
+                "Good city hotel discovery",
+                "Useful car-rental comparison surface",
+            ],
+            weaknesses=[
+                "Room/bed layouts still need explicit validation",
+                "Map areas can be too broad",
+            ],
+            confidence_level=SourceConfidence.HIGH,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["central city hotels", "car rental first-pass discovery"],
+            avoid_when=["bed setup is ambiguous", "location creates unnecessary transit burden"],
+        ),
+        TravelSource(
+            platform_name="Tripadvisor",
+            categories=[
+                TravelSourceCategory.CITY_LODGING,
+                TravelSourceCategory.PRIVATE_LODGING,
+                TravelSourceCategory.TOURS,
+                TravelSourceCategory.CAR_RENTALS,
+                TravelSourceCategory.DEALS,
+                TravelSourceCategory.VALIDATION,
+            ],
+            strengths=[
+                "Review validation",
+                "Neighborhood, attraction, and operator quality signals",
+            ],
+            weaknesses=["Ranking can be noisy", "Availability and final pricing are not enough"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["validating reviews, safety, crowds, and location quality"],
+            avoid_when=["using it as the only booking source"],
+        ),
+        TravelSource(
+            platform_name="Trivago",
+            categories=[TravelSourceCategory.CITY_LODGING, TravelSourceCategory.VALIDATION],
+            strengths=["Hotel price and distribution cross-checking"],
+            weaknesses=["Thin on family-specific fit and bed detail"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["hotel price validation"],
+            avoid_when=["deciding family fit without primary lodging detail"],
+        ),
+        TravelSource(
+            platform_name="Airbnb",
+            categories=[TravelSourceCategory.PRIVATE_LODGING],
+            strengths=["Private family space", "Kitchen/laundry/privacy options"],
+            weaknesses=["Access, safety, cancellation, exact location, and bed setup vary widely"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["non-city private stays", "space and privacy materially improve comfort"],
+            avoid_when=["dense city core where boutique hotel convenience is better"],
+        ),
+        TravelSource(
+            platform_name="VRBO",
+            categories=[TravelSourceCategory.PRIVATE_LODGING],
+            strengths=["Family-sized vacation rentals", "Good for non-city private stays"],
+            weaknesses=["Inventory quality and location practicality require careful validation"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["family-sized private stays outside major city cores"],
+            avoid_when=["parking, road access, or safety details are weak"],
+        ),
+        TravelSource(
+            platform_name="GetYourGuide",
+            categories=[TravelSourceCategory.TOURS],
+            strengths=[
+                "Structured tour discovery",
+                "Clear cancellation and operator info in many cases",
+            ],
+            weaknesses=["Can skew mass-market; group size and crowd exposure need review"],
+            confidence_level=SourceConfidence.HIGH,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["small-group tours and activities with review/safety signals"],
+            avoid_when=["large-group or low-specificity operator listings"],
+        ),
+        TravelSource(
+            platform_name="Airbnb Experiences",
+            categories=[TravelSourceCategory.TOURS],
+            strengths=["Smaller, local-feeling activities when available"],
+            weaknesses=["Inventory coverage is inconsistent by destination"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["small intimate food or neighborhood experiences"],
+            avoid_when=["safety/review depth is weak"],
+        ),
+        TravelSource(
+            platform_name="Hertz",
+            categories=[TravelSourceCategory.CAR_RENTALS],
+            strengths=["Direct rental provider", "Useful for direct terms and loyalty checks"],
+            weaknesses=["Not the default first discovery surface for Trippy"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["validating direct rental terms after aggregator discovery"],
+            avoid_when=["aggregator has clearer family-fit comparison"],
+        ),
+        TravelSource(
+            platform_name="Travelzoo",
+            categories=[TravelSourceCategory.DEALS],
+            strengths=["Inspiration and deal discovery"],
+            weaknesses=["Deal fit can be generic and restrictive"],
+            confidence_level=SourceConfidence.MEDIUM,
+            access_modes=[SourceAccessMode.BROWSER_AUTOMATION, SourceAccessMode.MANUAL_HANDOFF],
+            prefer_when=["inspiration and opportunistic deal scanning"],
+            avoid_when=["deal constraints undermine comfort or family fit"],
+        ),
+    ]

--- a/trippy/services/travel_intelligence.py
+++ b/trippy/services/travel_intelligence.py
@@ -1,0 +1,310 @@
+"""Extract reusable family travel intelligence from canonical trip history."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from trippy.models.intelligence import (
+    EvidenceRef,
+    EvidenceSourceType,
+    IntelligenceCategory,
+    PreferenceSignal,
+    TravelIntelligenceReport,
+)
+from trippy.models.trip import StayType, Trip, TripStatus
+from trippy.services.learning import LearningEventStore, LearningProposal, ProposalType
+
+_CENTRALITY_HINTS = {
+    "central",
+    "downtown",
+    "urban core",
+    "walkable",
+    "old town",
+    "city centre",
+    "city center",
+    "shinjuku",
+    "ginza",
+    "near transit",
+}
+
+
+class TravelIntelligenceService:
+    """Turns past trips into structured, reviewable planning intelligence."""
+
+    def analyze(self, trips: list[Trip], *, min_support: int = 1) -> TravelIntelligenceReport:
+        lived = [trip for trip in trips if trip.status == TripStatus.LIVED]
+        evidence_trips = lived or trips
+        signals: list[PreferenceSignal] = []
+        friction_patterns: list[PreferenceSignal] = []
+        destination_affinities: list[PreferenceSignal] = []
+        vendor_patterns: list[PreferenceSignal] = []
+
+        if not evidence_trips:
+            return TravelIntelligenceReport(
+                trips_analyzed=0,
+                lived_trips_analyzed=0,
+                summary="No canonical trips available for intelligence extraction.",
+            )
+
+        signals.extend(self._family_fit_signals(evidence_trips, min_support=min_support))
+        signals.extend(self._lodging_signals(evidence_trips, min_support=min_support))
+        signals.extend(self._pacing_signals(evidence_trips, min_support=min_support))
+        vendor_patterns.extend(self._vendor_signals(evidence_trips, min_support=min_support))
+        destination_affinities.extend(self._destination_signals(evidence_trips))
+        friction_patterns.extend(self._friction_signals(evidence_trips, min_support=min_support))
+
+        total = (
+            len(signals)
+            + len(friction_patterns)
+            + len(destination_affinities)
+            + len(vendor_patterns)
+        )
+        return TravelIntelligenceReport(
+            trips_analyzed=len(trips),
+            lived_trips_analyzed=len(lived),
+            signals=signals,
+            friction_patterns=friction_patterns,
+            destination_affinities=destination_affinities,
+            vendor_patterns=vendor_patterns,
+            summary=f"Extracted {total} travel intelligence signal(s) from {len(evidence_trips)} evidence trip(s).",
+        )
+
+    def propose_memory_updates(
+        self,
+        report: TravelIntelligenceReport,
+        *,
+        learning_dir: Path | None = None,
+        memory_path: Path | None = None,
+        source_workflow_id: str | None = None,
+        min_confidence: float = 0.5,
+    ) -> list[LearningProposal]:
+        """Create review-gated memory proposals for extracted intelligence."""
+        proposals: list[LearningProposal] = []
+        for signal in report.all_signals:
+            if signal.confidence < min_confidence:
+                continue
+            category = (
+                "skill_hint"
+                if signal.category in {IntelligenceCategory.FRICTION, IntelligenceCategory.VENDOR}
+                else "preference"
+            )
+            after = {
+                "key": f"intel:{signal.key}",
+                "value": {
+                    "category": signal.category.value,
+                    "value": signal.value,
+                    "rationale": signal.rationale,
+                    "support_count": signal.support_count,
+                    "evidence": [item.model_dump(mode="json") for item in signal.evidence],
+                },
+                "category": category,
+                "confidence": signal.confidence,
+                "source": "travel-intelligence",
+                "notes": signal.rationale,
+            }
+            proposals.append(
+                LearningProposal(
+                    proposal_type=ProposalType.MEMORY,
+                    summary=f"Remember travel intelligence: {signal.rationale[:140]}",
+                    source_workflow_id=source_workflow_id,
+                    before=None,
+                    after=after,
+                )
+            )
+        return LearningEventStore(learning_dir, memory_path=memory_path).add_proposals(proposals)
+
+    def _family_fit_signals(self, trips: list[Trip], *, min_support: int) -> list[PreferenceSignal]:
+        family_trips = [trip for trip in trips if len(trip.travelers) >= 5]
+        if len(family_trips) < min_support:
+            return []
+        return [
+            PreferenceSignal(
+                key="family_requires_three_bed_validation",
+                category=IntelligenceCategory.LODGING,
+                value={"travelers": 5, "minimum_beds": 3},
+                confidence=_confidence(len(family_trips), len(trips)),
+                support_count=len(family_trips),
+                evidence=[
+                    _trip_evidence(
+                        trip,
+                        "Trip includes at least five travelers; lodging must validate bed fit.",
+                    )
+                    for trip in family_trips
+                ],
+                rationale="Family trips require explicit sleeping-fit validation for at least 3 beds.",
+            )
+        ]
+
+    def _lodging_signals(self, trips: list[Trip], *, min_support: int) -> list[PreferenceSignal]:
+        signals: list[PreferenceSignal] = []
+        central_hotels = [
+            (trip, stay)
+            for trip in trips
+            for stay in trip.stays
+            if stay.stay_type == StayType.HOTEL
+            and _has_any_hint(stay.notes, stay.address, stay.property_name)
+        ]
+        rentals = [
+            (trip, stay)
+            for trip in trips
+            for stay in trip.stays
+            if stay.stay_type in {StayType.AIRBNB, StayType.VRBO, StayType.HOUSE}
+        ]
+        if len(central_hotels) >= min_support:
+            signals.append(
+                PreferenceSignal(
+                    key="city_core_hotel_pattern",
+                    category=IntelligenceCategory.LODGING,
+                    value={"preferred_context": "central walkable city hotel"},
+                    confidence=_confidence(
+                        len(central_hotels), max(1, sum(len(t.stays) for t in trips))
+                    ),
+                    support_count=len(central_hotels),
+                    evidence=[
+                        _trip_evidence(
+                            trip, f"{stay.property_name} has central/walkable location signals."
+                        )
+                        for trip, stay in central_hotels
+                    ],
+                    rationale="Past stays show value in central, walkable city lodging.",
+                )
+            )
+        if len(rentals) >= min_support:
+            signals.append(
+                PreferenceSignal(
+                    key="private_rental_pattern",
+                    category=IntelligenceCategory.LODGING,
+                    value={
+                        "successful_stay_types": sorted(
+                            {stay.stay_type.value for _, stay in rentals}
+                        )
+                    },
+                    confidence=_confidence(len(rentals), max(1, sum(len(t.stays) for t in trips))),
+                    support_count=len(rentals),
+                    evidence=[
+                        _trip_evidence(trip, f"{stay.property_name} used as private lodging.")
+                        for trip, stay in rentals
+                    ],
+                    rationale="Private rentals are part of the family's successful lodging pattern when context fits.",
+                )
+            )
+        return signals
+
+    def _pacing_signals(self, trips: list[Trip], *, min_support: int) -> list[PreferenceSignal]:
+        stays = [stay for trip in trips for stay in trip.stays if stay.nights]
+        if len(stays) < min_support:
+            return []
+        avg_nights = sum(stay.nights or 0 for stay in stays) / len(stays)
+        return [
+            PreferenceSignal(
+                key="average_nights_per_stop",
+                category=IntelligenceCategory.PACING,
+                value={
+                    "average_nights": round(avg_nights, 1),
+                    "minimum_recommended": max(2, int(avg_nights)),
+                },
+                confidence=_confidence(len(stays), len(stays) + 2),
+                support_count=len(stays),
+                evidence=[
+                    _trip_evidence(trip, f"{stay.property_name}: {stay.nights} night(s).")
+                    for trip in trips
+                    for stay in trip.stays
+                    if stay.nights
+                ],
+                rationale=f"Historical stays average {avg_nights:.1f} nights per stop; avoid overcompressed pacing.",
+            )
+        ]
+
+    def _vendor_signals(self, trips: list[Trip], *, min_support: int) -> list[PreferenceSignal]:
+        carrier_counts: Counter[str] = Counter(
+            segment.carrier for trip in trips for segment in trip.segments if segment.carrier
+        )
+        signals: list[PreferenceSignal] = []
+        for carrier, count in carrier_counts.most_common():
+            if count < min_support:
+                continue
+            signals.append(
+                PreferenceSignal(
+                    key=f"carrier_pattern_{_slug(carrier)}",
+                    category=IntelligenceCategory.VENDOR,
+                    value={"carrier": carrier, "segments": count},
+                    confidence=_confidence(count, sum(carrier_counts.values())),
+                    support_count=count,
+                    evidence=[
+                        _trip_evidence(trip, f"{carrier} segment found in trip history.")
+                        for trip in trips
+                        if any(segment.carrier == carrier for segment in trip.segments)
+                    ],
+                    rationale=f"{carrier} appears repeatedly in family flight history; check loyalty and comfort fit.",
+                )
+            )
+        return signals
+
+    def _destination_signals(self, trips: list[Trip]) -> list[PreferenceSignal]:
+        signals: list[PreferenceSignal] = []
+        for trip in trips:
+            if not trip.destination_summary:
+                continue
+            signals.append(
+                PreferenceSignal(
+                    key=f"destination_history_{trip.trip_id}",
+                    category=IntelligenceCategory.DESTINATION,
+                    value={"destination_summary": trip.destination_summary, "trip_name": trip.name},
+                    confidence=0.6 if trip.status == TripStatus.LIVED else 0.4,
+                    support_count=1,
+                    evidence=[
+                        _trip_evidence(trip, f"Destination history: {trip.destination_summary}")
+                    ],
+                    rationale=f"{trip.destination_summary} is known family trip context for future comparisons.",
+                )
+            )
+        return signals
+
+    def _friction_signals(self, trips: list[Trip], *, min_support: int) -> list[PreferenceSignal]:
+        risks = [risk for trip in trips for risk in trip.risk_flags]
+        counts: Counter[str] = Counter(risk.category for risk in risks)
+        signals: list[PreferenceSignal] = []
+        for category, count in counts.items():
+            if count < min_support:
+                continue
+            signals.append(
+                PreferenceSignal(
+                    key=f"recurring_friction_{_slug(category)}",
+                    category=IntelligenceCategory.FRICTION,
+                    value={"risk_category": category, "count": count},
+                    confidence=_confidence(count, max(1, len(risks))),
+                    support_count=count,
+                    evidence=[
+                        _trip_evidence(trip, f"Risk category {category} appeared in trip audit.")
+                        for trip in trips
+                        if any(risk.category == category for risk in trip.risk_flags)
+                    ],
+                    rationale=f"Recurring friction category '{category}' should be checked early in future planning.",
+                )
+            )
+        return signals
+
+
+def _trip_evidence(trip: Trip, description: str) -> EvidenceRef:
+    return EvidenceRef(
+        source_type=EvidenceSourceType.TRIP,
+        source_id=trip.trip_id,
+        trip_id=trip.trip_id,
+        description=description,
+    )
+
+
+def _confidence(support: int, total: int) -> float:
+    if total <= 0:
+        return 0.0
+    return min(0.95, max(0.45, support / total))
+
+
+def _has_any_hint(*values: str | None) -> bool:
+    text = " ".join(value or "" for value in values).lower()
+    return any(hint in text for hint in _CENTRALITY_HINTS)
+
+
+def _slug(text: str) -> str:
+    return "".join(ch.lower() if ch.isalnum() else "-" for ch in text).strip("-")

--- a/trippy/services/trip_ideation.py
+++ b/trippy/services/trip_ideation.py
@@ -1,0 +1,229 @@
+"""Deterministic first-pass trip concept generation and comparison."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from trippy.memory.store import MemoryStore
+from trippy.models.ideas import TripComparison, TripConcept, TripIdeaRequest
+from trippy.models.preferences import FamilyTravelPreferences
+
+
+@dataclass(frozen=True)
+class _ConceptTemplate:
+    concept_id: str
+    title: str
+    destinations: list[str]
+    recommended_duration_days: int
+    best_season: str
+    estimated_cost_band_cad: str
+    estimated_flight_hours: float
+    direct_flight_friendliness: int
+    base_family_fit: int
+    base_comfort: int
+    food_score: int
+    crowd_risk: int
+    tags: set[str]
+    risks: list[str]
+
+
+_TEMPLATES = [
+    _ConceptTemplate(
+        concept_id="portugal-food-cities-coast",
+        title="Portugal Food Cities + Coast",
+        destinations=["Lisbon", "Porto", "Douro Valley or Cascais"],
+        recommended_duration_days=10,
+        best_season="spring or fall",
+        estimated_cost_band_cad="CAD 18k-28k for family of 5 before splurge meals",
+        estimated_flight_hours=7.0,
+        direct_flight_friendliness=7,
+        base_family_fit=86,
+        base_comfort=84,
+        food_score=88,
+        crowd_risk=45,
+        tags={"food", "culture", "city", "coast", "walkable", "low-crowd"},
+        risks=["Lisbon hills and parking can be annoying; avoid rental car while in-city."],
+    ),
+    _ConceptTemplate(
+        concept_id="japan-food-rail-cities",
+        title="Japan Food + Rail Cities",
+        destinations=["Tokyo", "Kyoto", "Osaka or Hiroshima"],
+        recommended_duration_days=14,
+        best_season="late fall or shoulder-season spring",
+        estimated_cost_band_cad="CAD 28k-45k for family of 5 depending on flights and room setup",
+        estimated_flight_hours=13.0,
+        direct_flight_friendliness=8,
+        base_family_fit=84,
+        base_comfort=78,
+        food_score=97,
+        crowd_risk=75,
+        tags={"food", "culture", "city", "transit", "adventure", "rail"},
+        risks=["Crowds are real; lodging must validate 3+ beds and central transit access."],
+    ),
+    _ConceptTemplate(
+        concept_id="mexico-city-oaxaca-food",
+        title="Mexico City + Oaxaca Food Trip",
+        destinations=["Mexico City", "Oaxaca"],
+        recommended_duration_days=9,
+        best_season="winter or early spring",
+        estimated_cost_band_cad="CAD 16k-26k for family of 5",
+        estimated_flight_hours=5.5,
+        direct_flight_friendliness=8,
+        base_family_fit=80,
+        base_comfort=78,
+        food_score=96,
+        crowd_risk=55,
+        tags={"food", "culture", "city", "walkable", "short-flight"},
+        risks=["Choose neighborhoods carefully; private transfers may beat rental car stress."],
+    ),
+    _ConceptTemplate(
+        concept_id="costa-rica-private-rental-adventure",
+        title="Costa Rica Private Rental + Adventure",
+        destinations=["Arenal", "Manuel Antonio or Guanacaste"],
+        recommended_duration_days=10,
+        best_season="winter dry season",
+        estimated_cost_band_cad="CAD 20k-34k for family of 5",
+        estimated_flight_hours=5.5,
+        direct_flight_friendliness=6,
+        base_family_fit=86,
+        base_comfort=76,
+        food_score=72,
+        crowd_risk=50,
+        tags={"adventure", "nature", "beach", "rental", "chill"},
+        risks=[
+            "Driving and parking are practical in some areas, stressful in others; vet roads hard."
+        ],
+    ),
+    _ConceptTemplate(
+        concept_id="italy-food-culture-rail",
+        title="Italy Food + Culture By Rail",
+        destinations=["Rome", "Florence", "Bologna or Venice"],
+        recommended_duration_days=12,
+        best_season="spring or fall",
+        estimated_cost_band_cad="CAD 24k-38k for family of 5",
+        estimated_flight_hours=8.5,
+        direct_flight_friendliness=7,
+        base_family_fit=82,
+        base_comfort=80,
+        food_score=94,
+        crowd_risk=80,
+        tags={"food", "culture", "city", "rail", "walkable"},
+        risks=["Peak crowds can crush comfort; use shoulder season and central boutique hotels."],
+    ),
+]
+
+
+class TripIdeationService:
+    """Generate ranked family-fit trip concepts from loose constraints."""
+
+    def __init__(
+        self,
+        preferences: FamilyTravelPreferences | None = None,
+        memory: MemoryStore | None = None,
+    ) -> None:
+        self._prefs = preferences or FamilyTravelPreferences()
+        self._memory = memory
+
+    def compare(self, request: TripIdeaRequest, *, limit: int = 5) -> TripComparison:
+        concepts = [self._score_template(template, request) for template in _TEMPLATES]
+        ranked = sorted(concepts, key=lambda concept: concept.total_score, reverse=True)[:limit]
+        recommendation = ranked[0].concept_id if ranked else None
+        return TripComparison(
+            request=request,
+            concepts=ranked,
+            recommended_concept_id=recommendation,
+            scoring_notes=[
+                "Scores are deterministic first-pass estimates, not live prices or availability.",
+                "Visa, entry, vaccination, exact fare, and listing availability require live research before booking.",
+                "Family smoothness, central lodging, food access, bed fit, and crowd/transport friction are weighted above raw price.",
+            ],
+        )
+
+    def _score_template(self, template: _ConceptTemplate, request: TripIdeaRequest) -> TripConcept:
+        score = template.base_family_fit + template.base_comfort + template.food_score
+        rationale = [
+            "Fits comfort-first family travel better than lowest-price optimization.",
+            "Food access is scored as a major trip objective.",
+        ]
+        why_not = list(template.risks)
+
+        goals = {goal.lower() for goal in request.goals}
+        avoid = {item.lower() for item in request.avoid}
+        matched_goals = goals & template.tags
+        score += len(matched_goals) * 8
+        if matched_goals:
+            rationale.append(f"Matches requested goals: {', '.join(sorted(matched_goals))}.")
+
+        if request.duration_days:
+            diff = abs(request.duration_days - template.recommended_duration_days)
+            if diff <= 2:
+                score += 12
+                rationale.append("Duration is close to the recommended pacing.")
+            elif request.duration_days < template.recommended_duration_days:
+                score -= 14
+                why_not.append("Requested duration may compress the itinerary too much.")
+
+        if request.max_flight_hours and template.estimated_flight_hours > request.max_flight_hours:
+            penalty = int((template.estimated_flight_hours - request.max_flight_hours) * 4)
+            score -= penalty
+            why_not.append(
+                f"Estimated flight time around {template.estimated_flight_hours:.1f}h exceeds requested max."
+            )
+
+        if request.direct_flight_preferred or self._prefs.flight.prefer_direct:
+            score += template.direct_flight_friendliness
+            if template.direct_flight_friendliness < 7:
+                why_not.append("Direct-flight friendliness is only moderate; verify exact routing.")
+
+        if "crowds" in avoid or self._prefs.crowd.avoid_huge_crowds_when_possible:
+            crowd_penalty = max(0, template.crowd_risk - 55)
+            score -= crowd_penalty
+            if crowd_penalty:
+                why_not.append("Crowd exposure needs careful season and activity selection.")
+
+        if "food" in template.tags and self._prefs.food.food_is_major_objective:
+            score += 10
+
+        if "city" in template.tags and self._prefs.lodging_context.city_prefer_urban_core:
+            rationale.append("Requires central, walkable lodging to preserve comfort and time.")
+
+        if "rental" in template.tags and self._prefs.lodging_context.non_city_prefer_private_rental:
+            rationale.append(
+                "Private rental can work well outside major city cores if location and access are vetted."
+            )
+
+        required_research = [
+            "Live flight options, total travel time, layovers, baggage, seats, and loyalty application.",
+            "Exact lodging short list with bed layout, king-bed availability, location, safety, parking/access, and cancellation terms.",
+            "Visa/entry requirements, passport validity rules, vaccination or health precautions, and local cash guidance.",
+            "Small-group tour/activity operators with strong review and safety signals.",
+        ]
+
+        return TripConcept(
+            concept_id=template.concept_id,
+            title=template.title,
+            destinations=template.destinations,
+            recommended_duration_days=template.recommended_duration_days,
+            best_season=template.best_season,
+            estimated_cost_band_cad=template.estimated_cost_band_cad,
+            estimated_travel_burden=_travel_burden(template.estimated_flight_hours),
+            estimated_flight_hours=template.estimated_flight_hours,
+            direct_flight_friendliness=template.direct_flight_friendliness,
+            family_fit_score=template.base_family_fit,
+            comfort_convenience_score=template.base_comfort,
+            food_score=template.food_score,
+            crowd_risk=template.crowd_risk,
+            total_score=max(0, min(100, score // 3)),
+            rationale=rationale,
+            why_it_may_not_fit=why_not,
+            major_risks=template.risks,
+            required_research=required_research,
+        )
+
+
+def _travel_burden(flight_hours: float) -> str:
+    if flight_hours <= 6:
+        return "moderate"
+    if flight_hours <= 9:
+        return "meaningful"
+    return "high"

--- a/trippy/services/trip_ideation.py
+++ b/trippy/services/trip_ideation.py
@@ -7,12 +7,14 @@ from dataclasses import dataclass
 from trippy.memory.store import MemoryStore
 from trippy.models.ideas import TripComparison, TripConcept, TripIdeaRequest
 from trippy.models.preferences import FamilyTravelPreferences
+from trippy.services.country_priors import CountryPriorService
 
 
 @dataclass(frozen=True)
 class _ConceptTemplate:
     concept_id: str
     title: str
+    countries: list[str]
     destinations: list[str]
     recommended_duration_days: int
     best_season: str
@@ -31,6 +33,7 @@ _TEMPLATES = [
     _ConceptTemplate(
         concept_id="portugal-food-cities-coast",
         title="Portugal Food Cities + Coast",
+        countries=["Portugal"],
         destinations=["Lisbon", "Porto", "Douro Valley or Cascais"],
         recommended_duration_days=10,
         best_season="spring or fall",
@@ -47,6 +50,7 @@ _TEMPLATES = [
     _ConceptTemplate(
         concept_id="japan-food-rail-cities",
         title="Japan Food + Rail Cities",
+        countries=["Japan"],
         destinations=["Tokyo", "Kyoto", "Osaka or Hiroshima"],
         recommended_duration_days=14,
         best_season="late fall or shoulder-season spring",
@@ -63,6 +67,7 @@ _TEMPLATES = [
     _ConceptTemplate(
         concept_id="mexico-city-oaxaca-food",
         title="Mexico City + Oaxaca Food Trip",
+        countries=["Mexico"],
         destinations=["Mexico City", "Oaxaca"],
         recommended_duration_days=9,
         best_season="winter or early spring",
@@ -79,6 +84,7 @@ _TEMPLATES = [
     _ConceptTemplate(
         concept_id="costa-rica-private-rental-adventure",
         title="Costa Rica Private Rental + Adventure",
+        countries=["Costa Rica"],
         destinations=["Arenal", "Manuel Antonio or Guanacaste"],
         recommended_duration_days=10,
         best_season="winter dry season",
@@ -97,6 +103,7 @@ _TEMPLATES = [
     _ConceptTemplate(
         concept_id="italy-food-culture-rail",
         title="Italy Food + Culture By Rail",
+        countries=["Italy"],
         destinations=["Rome", "Florence", "Bologna or Venice"],
         recommended_duration_days=12,
         best_season="spring or fall",
@@ -123,6 +130,7 @@ class TripIdeationService:
     ) -> None:
         self._prefs = preferences or FamilyTravelPreferences()
         self._memory = memory
+        self._country_priors = CountryPriorService()
 
     def compare(self, request: TripIdeaRequest, *, limit: int = 5) -> TripComparison:
         concepts = [self._score_template(template, request) for template in _TEMPLATES]
@@ -146,6 +154,18 @@ class TripIdeationService:
             "Food access is scored as a major trip objective.",
         ]
         why_not = list(template.risks)
+        country_fits = [
+            fit
+            for country in template.countries
+            if (fit := self._country_priors.fit_for_country(country))
+        ]
+        for fit in country_fits:
+            score += fit.score_adjustment
+            rationale.append(f"Fit based on past country-level history: {fit.rationale}")
+            if fit.caution_signals:
+                why_not.append(
+                    f"{fit.country} country prior has caution signals: {', '.join(fit.caution_signals[:4])}."
+                )
 
         goals = {goal.lower() for goal in request.goals}
         avoid = {item.lower() for item in request.avoid}
@@ -197,6 +217,7 @@ class TripIdeationService:
             "Exact lodging short list with bed layout, king-bed availability, location, safety, parking/access, and cancellation terms.",
             "Visa/entry requirements, passport validity rules, vaccination or health precautions, and local cash guidance.",
             "Small-group tour/activity operators with strong review and safety signals.",
+            "Validate country prior against exact sub-region, season, logistics, and trip style.",
         ]
 
         return TripConcept(
@@ -214,6 +235,7 @@ class TripIdeationService:
             food_score=template.food_score,
             crowd_risk=template.crowd_risk,
             total_score=max(0, min(100, score // 3)),
+            country_prior_signals=[fit.rationale for fit in country_fits],
             rationale=rationale,
             why_it_may_not_fit=why_not,
             major_risks=template.risks,

--- a/trippy/skills/definitions/trippy-preference-extractor.md
+++ b/trippy/skills/definitions/trippy-preference-extractor.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 Analyse a set of canonical trip records and derive durable family travel preferences.
-Write those preferences to Hermes memory with confidence scores based on evidence strength.
+Create review-gated Hermes learning proposals with confidence scores based on evidence strength.
+Do not mutate durable memory until a human approves the proposal.
 
 This skill distinguishes durable preferences ("we consistently avoid 6 AM departures")
 from one-off exceptions ("took a 5 AM flight once for a very cheap deal").
@@ -30,28 +31,31 @@ If `trip_ids` omitted, loads all lived trips from `~/.trippy/trips/`.
 5. Analyse pacing (number of destinations per week)
 6. Identify what changed: did they upgrade cabin? book direct more often?
 7. Distinguish patterns (seen in ≥min_evidence_trips) from outliers
-8. Write durable preferences to memory with source_trips reference
-9. Write family profile updates (passport expiry from traveler data)
+8. Propose durable preferences with source_trips reference
+9. Propose family profile updates (passport expiry from traveler data)
+10. Wait for `trippy learn approve <proposal-id>` before memory changes
 
 ## Outputs
 ```json
 {
-  "preferences_written": {
+  "preferences_proposed": {
     "departure_time": "Earliest acceptable 07:30 (conf=75%, 4 trips)",
     "min_connection_international": "110 min (conf=80%, 3 trips)",
     "nights_per_destination": "3+ preferred (conf=70%, 5 stays)"
   },
+  "learning_proposals": ["lp-..."],
   "profile_updates": ["Ken passport expiry updated"],
   "skip_reason": null
 }
 ```
 
 ## Persistence After Success
-- All inferred preferences written to memory under category: "preference"
-- Family profile updates written under category: "profile"
-- Write timestamp to memory: "pref:last_extraction_date"
+- All inferred preferences become pending proposals under category: "preference"
+- Family profile updates become pending proposals under category: "profile"
+- Approval through `trippy learn approve <proposal-id>` is required before persistence
 
 ## Do NOT Write to Memory
+- Any inferred preference before explicit review approval
 - Trip-specific confirmation codes or booking details
 - Costs for specific trips (averages only, if relevant)
 - One-off decisions that don't generalize

--- a/trippy/skills/runners/gmail_reconciler.py
+++ b/trippy/skills/runners/gmail_reconciler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from inspect import signature
 from pathlib import Path
 from typing import Any
 
@@ -29,18 +30,27 @@ class GmailReconcilerRunner:
         from trippy.db.models import Trip as DbTrip
         from trippy.ingest.gmail_watcher import GmailWatcher
         from trippy.ingest.google_auth import GoogleAuthManager
-        from trippy.ingest.linker import ingest_email
+        from trippy.ingest.linker import TripLinker
         from trippy.ingest.parser import ConfirmationParser
         from trippy.services.sheet_sync import SheetSyncService
         from trippy.services.trip_state import TripStateService
 
         max_emails: int = inputs.get("max_emails", 50)
+        label: str = inputs.get("label", "INBOX")
+        query: str | None = inputs.get("query")
+        target_trip_id: str | None = inputs.get("trip_id")
+        dry_run: bool = bool(inputs.get("dry_run", False))
 
         auth = self._auth_manager or GoogleAuthManager()
         watcher = GmailWatcher(auth_manager=auth)
         watcher.authenticate()
 
-        emails = watcher.fetch_new_messages(max_results=max_emails)
+        emails = _fetch_candidate_emails(
+            watcher=watcher,
+            label=label,
+            query=query,
+            max_emails=max_emails,
+        )
         logger.info("GmailReconciler: fetched %d candidate emails", len(emails))
 
         parser = ConfirmationParser(anthropic_client=self._anthropic_client)
@@ -58,7 +68,7 @@ class GmailReconcilerRunner:
         ambiguities: list[dict[str, Any]] = []
 
         for email_content in emails:
-            eml_path = watcher.save_to_vault(email_content, vault_path)
+            eml_path = None if dry_run else watcher.save_to_vault(email_content, vault_path)
             atts = [(a.filename, a.content_type, a.data) for a in email_content.attachments]
             parse_result = parser.parse(
                 body_text=email_content.body_text,
@@ -72,9 +82,40 @@ class GmailReconcilerRunner:
                 continue
 
             conf = parse_result.confirmation
+            db_trip_name: str | None = None
+            db_trip_slug: str | None = None
+            canonical_from_db: Any | None = None
+            matches_target = False
             with factory() as session:
-                link = ingest_email(conf, session, raw_email_path=str(eml_path))
+                linker = TripLinker(session)
+                link = linker.link(conf, raw_email_path=str(eml_path) if eml_path else None)
                 db_trip = session.get(DbTrip, link.trip_id) if link.trip_id is not None else None
+                matches_target = _db_trip_matches_filter(db_trip, target_trip_id)
+                if db_trip is not None:
+                    db_trip_name = db_trip.name
+                    db_trip_slug = db_trip.name.lower().replace(" ", "-")
+                    if matches_target:
+                        canonical_from_db = trip_state.from_db_trip(db_trip)
+                if dry_run or not matches_target:
+                    session.rollback()
+                else:
+                    session.commit()
+
+            if link.linked and not matches_target:
+                unlinked_count += 1
+                ambiguity = {
+                    "type": "target_trip_mismatch",
+                    "vendor": conf.vendor,
+                    "code": conf.confirmation_code,
+                    "confirmation_type": conf.confirmation_type,
+                    "target_trip_id": target_trip_id,
+                    "linked_trip_name": db_trip_name,
+                    "reason": "Confirmation matched a different trip than the requested trip_id",
+                    "email_subject": email_content.subject,
+                }
+                ambiguities.append(ambiguity)
+                unlinked.append(ambiguity)
+                continue
 
             if link.linked:
                 linked_count += 1
@@ -90,19 +131,31 @@ class GmailReconcilerRunner:
                     )
                     continue
 
-                trip = trip_state.load(db_trip.name.lower().replace(" ", "-"))
+                trip = trip_state.load(db_trip_slug or "")
                 if trip is None:
-                    trip = trip_state.from_db_trip(db_trip)
+                    trip = canonical_from_db
+                if trip is None:
+                    ambiguities.append(
+                        {
+                            "type": "canonical_trip_missing",
+                            "confirmation_code": conf.confirmation_code,
+                            "vendor": conf.vendor,
+                            "trip_db_id": link.trip_id,
+                            "reason": "Linked trip could not be converted to canonical state",
+                        }
+                    )
+                    continue
 
                 canonical_confirmation = _to_canonical_confirmation(
                     confirmation=conf,
                     subject=email_content.subject,
-                    eml_path=eml_path,
+                    eml_path=eml_path or Path("dry-run"),
                 )
                 match_info = _attach_confirmation_to_trip(trip, canonical_confirmation, conf)
-                trip_state.save(trip)
+                if not dry_run:
+                    trip_state.save(trip)
 
-                if trip.sync.google_sheet_id:
+                if trip.sync.google_sheet_id and not dry_run:
                     sheet_sync.push_trip_to_sheet(trip, trip.sync.google_sheet_id)
 
                 updates.append(
@@ -114,6 +167,7 @@ class GmailReconcilerRunner:
                         "method": link.method,
                         "linked_segment_id": match_info.get("linked_segment_id"),
                         "linked_stay_id": match_info.get("linked_stay_id"),
+                        "dry_run": dry_run,
                     }
                 )
                 if match_info["ambiguity"] is not None:
@@ -139,6 +193,10 @@ class GmailReconcilerRunner:
                 )
 
         return {
+            "dry_run": dry_run,
+            "target_trip_id": target_trip_id,
+            "label": label,
+            "query": query,
             "emails_scanned": len(emails),
             "confirmations_parsed": linked_count + unlinked_count,
             "confirmations_linked": linked_count,
@@ -148,6 +206,32 @@ class GmailReconcilerRunner:
             "unlinked": unlinked,
             "ambiguities": ambiguities,
         }
+
+
+def _fetch_candidate_emails(
+    *,
+    watcher: Any,
+    label: str,
+    query: str | None,
+    max_emails: int,
+) -> list[Any]:
+    """Call GmailWatcher while staying compatible with older injected test fakes."""
+    params = signature(watcher.fetch_new_messages).parameters
+    kwargs: dict[str, Any] = {"max_results": max_emails}
+    if "label" in params:
+        kwargs["label"] = label
+    if "query" in params:
+        kwargs["query"] = query
+    return watcher.fetch_new_messages(**kwargs)  # type: ignore[no-any-return]
+
+
+def _db_trip_matches_filter(db_trip: Any | None, target_trip_id: str | None) -> bool:
+    if target_trip_id is None:
+        return True
+    if db_trip is None:
+        return False
+    slug = str(db_trip.name).lower().replace(" ", "-")
+    return target_trip_id in {str(db_trip.id), slug}
 
 
 def _to_canonical_confirmation(confirmation: Any, subject: str, eml_path: Path) -> Any:
@@ -166,7 +250,9 @@ def _to_canonical_confirmation(confirmation: Any, subject: str, eml_path: Path) 
     )
 
 
-def _attach_confirmation_to_trip(trip: Any, canonical_confirmation: Any, parsed: Any) -> dict[str, Any]:
+def _attach_confirmation_to_trip(
+    trip: Any, canonical_confirmation: Any, parsed: Any
+) -> dict[str, Any]:
     """Attach confirmation to canonical trip and enrich a matching segment/stay."""
     trip.confirmations.append(canonical_confirmation)
 
@@ -214,7 +300,9 @@ def _attach_confirmation_to_trip(trip: Any, canonical_confirmation: Any, parsed:
                 parsed.property_name and stay.property_name.lower() == parsed.property_name.lower()
             )
             date_match = bool(
-                parsed.check_in and stay.check_in and stay.check_in.isoformat() == parsed.check_in[:10]
+                parsed.check_in
+                and stay.check_in
+                and stay.check_in.isoformat() == parsed.check_in[:10]
             )
             if city_match or property_match or date_match:
                 stay.confirmation_code = parsed.confirmation_code

--- a/trippy/skills/runners/preference_extractor.py
+++ b/trippy/skills/runners/preference_extractor.py
@@ -6,6 +6,11 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from trippy.memory.store import MemoryStore
+from trippy.models.profile import FamilyProfile, TravelerProfile
+from trippy.models.trip import Traveler, Trip
+from trippy.services.learning import LearningEventStore, LearningProposal, ProposalType
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,8 +28,6 @@ class PreferenceExtractorRunner:
     def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
         from trippy import config
         from trippy.memory.preference_writer import PreferenceWriter
-        from trippy.memory.profile_manager import ProfileManager
-        from trippy.memory.store import MemoryStore
         from trippy.services.trip_state import TripStateService
 
         memory = self._memory_store or MemoryStore(config.MEMORY_PATH)
@@ -34,6 +37,8 @@ class PreferenceExtractorRunner:
         # Load trips to analyse
         trip_ids: list[str] | None = inputs.get("trip_ids")
         min_evidence = inputs.get("min_evidence_trips", 2)
+        propose_learning: bool = inputs.get("propose_learning", True)
+        learning_dir = inputs.get("learning_dir")
 
         if trip_ids:
             trips = [t for tid in trip_ids if (t := state_svc.load(tid)) is not None]
@@ -44,31 +49,149 @@ class PreferenceExtractorRunner:
             return {"skip_reason": "No trips found to analyse", "preferences_written": {}}
 
         writer = PreferenceWriter(memory=memory)
-        written = writer.extract_and_write(trips, min_trips=min_evidence)
-
-        # Update family profile from traveler data
-        profile_mgr = ProfileManager(memory=memory)
+        candidates = writer.extract_candidates(trips, min_trips=min_evidence)
+        learning_store = LearningEventStore(
+            _as_path(learning_dir),
+            memory_path=memory.path,
+        )
+        proposals: list[LearningProposal] = []
+        preferences_proposed: dict[str, str] = {}
         profile_updates: list[str] = []
-        for trip in trips:
-            if trip.travelers:
-                before = len(profile_mgr.load().travelers)
-                profile_mgr.update_from_trip_travelers(trip.travelers)
-                after = len(profile_mgr.load().travelers)
-                if after > before:
-                    profile_updates.append(
-                        f"Added {after - before} new traveler(s) from {trip.trip_id}"
-                    )
+
+        if propose_learning:
+            for name, candidate in candidates.items():
+                proposals.append(_candidate_to_proposal(candidate, memory))
+                preferences_proposed[name] = str(candidate["reason"])
+
+            profile_proposal, profile_updates = _profile_update_proposal(memory, trips)
+            if profile_proposal is not None:
+                proposals.append(profile_proposal)
+
+            proposals = learning_store.add_proposals(proposals)
+
+        from trippy.services.travel_intelligence import TravelIntelligenceService
+
+        intelligence = TravelIntelligenceService().analyze(trips, min_support=min_evidence)
+        intelligence_proposals: list[LearningProposal] = []
+        if propose_learning:
+            intelligence_proposals = TravelIntelligenceService().propose_memory_updates(
+                intelligence,
+                learning_dir=_as_path(learning_dir),
+                memory_path=memory.path,
+                min_confidence=0.5,
+            )
+            proposals.extend(intelligence_proposals)
 
         logger.info(
-            "PreferenceExtractor: wrote %d preferences, %d profile updates",
-            len(written),
+            "PreferenceExtractor: proposed %d preferences, %d profile updates",
+            len(preferences_proposed),
             len(profile_updates),
         )
 
         return {
             "trips_analysed": len(trips),
             "lived_trips": len([t for t in trips if t.status.value == "lived"]),
-            "preferences_written": written,
+            "preferences_written": {},
+            "preferences_proposed": preferences_proposed,
+            "intelligence_summary": intelligence.summary,
+            "intelligence_signals": len(intelligence.all_signals),
+            "learning_proposals": [proposal.id for proposal in proposals],
             "profile_updates": profile_updates,
+            "review_required": True,
             "skip_reason": None,
         }
+
+
+def _as_path(path: Any) -> Path | None:
+    return Path(path) if path else None
+
+
+def _candidate_to_proposal(
+    candidate: dict[str, Any],
+    memory: MemoryStore,
+) -> LearningProposal:
+    key = str(candidate["key"])
+    existing = memory.get(key)
+    return LearningProposal(
+        proposal_type=ProposalType.MEMORY,
+        summary=f"Review extracted family preference: {candidate['reason']}",
+        before=existing.model_dump(mode="json") if existing else None,
+        after={
+            "key": key,
+            "value": candidate["value"],
+            "category": candidate["category"],
+            "confidence": candidate["confidence"],
+            "source": candidate["source"],
+            "notes": candidate.get("notes"),
+        },
+    )
+
+
+def _profile_update_proposal(
+    memory: MemoryStore,
+    trips: list[Trip],
+) -> tuple[LearningProposal | None, list[str]]:
+    from trippy.memory.profile_manager import ProfileManager
+
+    current = ProfileManager(memory=memory).load()
+    updated = FamilyProfile.model_validate(current.model_dump(mode="json"))
+    updates: list[str] = []
+
+    for trip in trips:
+        for traveler in trip.travelers:
+            updates.extend(_merge_traveler(updated, traveler, source_trip_id=trip.trip_id))
+
+    if updated.model_dump(mode="json") == current.model_dump(mode="json"):
+        return None, []
+
+    return (
+        LearningProposal(
+            proposal_type=ProposalType.MEMORY,
+            summary=f"Review family profile updates from trip history ({len(updates)} change(s))",
+            before={
+                "key": "profile:family",
+                "value": current.model_dump(mode="json"),
+                "category": "profile",
+            },
+            after={
+                "key": "profile:family",
+                "value": updated.model_dump(mode="json"),
+                "category": "profile",
+                "confidence": 1.0,
+                "source": "preference-extractor",
+                "notes": "; ".join(updates[:8]),
+            },
+        ),
+        updates,
+    )
+
+
+def _merge_traveler(
+    profile: FamilyProfile,
+    traveler: Traveler,
+    *,
+    source_trip_id: str,
+) -> list[str]:
+    existing = profile.get_traveler(traveler.name)
+    if existing is None:
+        profile.travelers.append(
+            TravelerProfile(
+                name=traveler.name,
+                passport_country=traveler.passport_country,
+                passport_expiry=traveler.passport_expiry,
+                date_of_birth=traveler.date_of_birth,
+                is_minor=traveler.is_minor,
+            )
+        )
+        return [f"Add traveler {traveler.name} from {source_trip_id}"]
+
+    updates: list[str] = []
+    if traveler.passport_expiry and (
+        existing.passport_expiry is None or traveler.passport_expiry > existing.passport_expiry
+    ):
+        existing.passport_expiry = traveler.passport_expiry
+        updates.append(f"Update {traveler.name} passport expiry from {source_trip_id}")
+    if traveler.passport_country and not existing.passport_country:
+        existing.passport_country = traveler.passport_country
+        updates.append(f"Update {traveler.name} passport country from {source_trip_id}")
+    return updates

--- a/trippy/skills/runners/trip_sheet_creator.py
+++ b/trippy/skills/runners/trip_sheet_creator.py
@@ -137,13 +137,28 @@ class TripSheetCreatorRunner:
         if "europe" in dest_lower:
             flags.append("Check ETIAS requirement (effective 2025)")
 
+        next_actions: list[str] = []
+        if sheet_result.get("error"):
+            next_actions.append(
+                "Run trippy doctor and trippy auth-google, then retry sheet creation."
+            )
+        elif not sheet_result.get("spreadsheet_id"):
+            next_actions.append(
+                "Configure Google credentials to create the human-facing trip sheet."
+            )
+        else:
+            next_actions.append("Open the generated sheet and fill in tentative flights/stays.")
+
         return {
+            "canonical_saved": True,
             "trip_id": trip.trip_id,
             "trip_name": trip.name,
             "sheet_id": sheet_result.get("spreadsheet_id", ""),
             "sheet_url": sheet_result.get("url", ""),
+            "sheet_error": sheet_result.get("error"),
             "suggestion_summary": _suggest_structure(destinations),
             "flags": flags,
+            "next_actions": next_actions,
         }
 
 

--- a/trippy/thin_slice.py
+++ b/trippy/thin_slice.py
@@ -2,8 +2,8 @@
 
 This script proves the architecture by running the complete flow:
 1. Load a past trip from canonical state (or seed from JSON)
-2. Extract durable preferences from the trip
-3. Create/update family profile in memory
+2. Propose durable preferences from the trip
+3. Propose family profile updates
 4. Start a new trip from a rough idea
 5. Create a Google Sheet from template (mocked if no credentials)
 6. Ingest one booking confirmation email (from fixture or Gmail)
@@ -42,8 +42,6 @@ def run_thin_slice(
 ) -> dict[str, Any]:
     """Execute the complete thin-slice flow. Returns a results dict."""
     from trippy import config
-    from trippy.memory.preference_writer import PreferenceWriter
-    from trippy.memory.profile_manager import ProfileManager
     from trippy.memory.store import MemoryStore
     from trippy.models.trip import (
         ChecklistItem,
@@ -59,6 +57,7 @@ def run_thin_slice(
     )
     from trippy.services.friction_detector import FrictionDetector
     from trippy.services.trip_state import TripStateService
+    from trippy.skills.runners.preference_extractor import PreferenceExtractorRunner
 
     trips_dir = trips_dir or config.TRIPS_PATH
     memory_path = memory_path or config.MEMORY_PATH
@@ -167,28 +166,39 @@ def run_thin_slice(
     # -----------------------------------------------------------------------
     # STEP 2: Extract preferences from past trip
     # -----------------------------------------------------------------------
-    console.print(Panel("[bold]Step 2:[/bold] Extract durable preferences", style="cyan"))
+    console.print(Panel("[bold]Step 2:[/bold] Propose durable preferences", style="cyan"))
 
-    writer = PreferenceWriter(memory=memory)
     past_trip.status = TripStatus.LIVED  # treat as completed for analysis
     trip_svc.save(past_trip)
 
-    written = writer.extract_and_write([past_trip], min_trips=1)  # min=1 for demo
-    console.print(f"  [green]✓[/green] Wrote {len(written)} preference(s) to memory:")
-    for key, desc in written.items():
+    extracted = PreferenceExtractorRunner(memory_store=memory, trips_dir=trips_dir).run(
+        {
+            "trip_ids": [past_trip.trip_id],
+            "min_evidence_trips": 1,
+            "learning_dir": memory_path.parent / "learning",
+        }
+    )
+    proposed = extracted.get("preferences_proposed", {})
+    proposals = extracted.get("learning_proposals", [])
+    console.print(f"  [green]✓[/green] Proposed {len(proposed)} preference(s):")
+    for key, desc in proposed.items():
         console.print(f"    · {key}: {desc}")
-    results["step2_preferences"] = written
+    console.print(f"  Review-gated proposal(s): {len(proposals)}")
+    results["step2_preferences"] = proposed
+    results["step2_learning_proposals"] = proposals
 
     # -----------------------------------------------------------------------
-    # STEP 3: Update family profile
+    # STEP 3: Propose family profile updates
     # -----------------------------------------------------------------------
-    console.print(Panel("[bold]Step 3:[/bold] Update family profile", style="cyan"))
+    console.print(Panel("[bold]Step 3:[/bold] Propose family profile updates", style="cyan"))
 
-    profile_mgr = ProfileManager(memory=memory)
-    profile = profile_mgr.update_from_trip_travelers(past_trip.travelers)
-    console.print(f"  [green]✓[/green] Profile: {profile.num_travelers} travelers")
-    console.print(f"    {profile.to_context_string()}")
-    results["step3_profile_count"] = profile.num_travelers
+    profile_updates = extracted.get("profile_updates", [])
+    if profile_updates:
+        for update in profile_updates:
+            console.print(f"    · {update}")
+    else:
+        console.print("  [green]✓[/green] No profile changes proposed")
+    results["step3_profile_count"] = len(past_trip.travelers)
 
     # -----------------------------------------------------------------------
     # STEP 4: Start a new trip
@@ -334,8 +344,9 @@ def run_thin_slice(
         Panel(
             f"[bold green]Thin slice complete.[/bold green]\n\n"
             f"Past trip mined:  [cyan]{results['step1_trip_id']}[/cyan]\n"
-            f"Preferences saved: [cyan]{len(results['step2_preferences'])} entries[/cyan]\n"
-            f"Family profile:   [cyan]{results['step3_profile_count']} travelers[/cyan]\n"
+            f"Preferences proposed: [cyan]{len(results['step2_preferences'])} entries[/cyan]\n"
+            f"Profile evidence:     [cyan]{results['step3_profile_count']} travelers[/cyan]\n"
+            f"Learning proposals:   [cyan]{len(results['step2_learning_proposals'])}[/cyan]\n"
             f"New trip:         [cyan]{results['step4_new_trip_id']}[/cyan]\n"
             f"Sheet:            [cyan]{results['step5_sheet_url']}[/cyan]\n"
             f"Confirmation:     [cyan]{results['step6_confirmation']}[/cyan]\n"


### PR DESCRIPTION
## Summary

Builds the next Trippy foundation as a Chapman-family-specific travel system rather than a generic travel assistant.

This PR adds:
- first-run readiness commands: `trippy doctor` and `trippy auth-google`
- Google OAuth scope fixes for Gmail read, Sheets write, and Drive write workflows
- review-gated Hermes learning: workflow outcomes, feedback, learning proposals, approve/reject flow
- past-trip intelligence extraction and review-gated memory proposals
- expanded family preference model and comfort-first friction checks
- deterministic trip ideation and comparison with family-fit scoring
- country-level travel priors from the historical country ratings sheet
- explicit travel source registry and routing plans for flights, lodging, tours, cars, validation, and deals
- Google Maps artifact generation with JSON, GeoJSON, KML, and Google Maps links
- static Past / Planned / Ideas dashboard exports
- post-trip retrospective workflow that creates review-gated learning proposals
- CLI `--json` output that is valid machine-readable JSON

## Why

Trippy needs durable planning intelligence, explicit friction checks, and review-gated learning before deeper booking automation. The goal is to make first real family use reliable and inspectable while keeping payments and final purchase confirmation human-reviewed.

## Country Prior Layer

The historical country ratings sheet is now encoded as directional planning priors, not hard rules. These priors influence:
- destination ideation and ranking
- fit rationale based on past country-level history
- caution signals in friction analysis
- review-gated future memory proposals

Examples include strong positive priors for Greece, Peru, France, Thailand, New Zealand, Japan, Belize, and Canada, plus mixed/caution signals for places where safety, crowds, road stress, health, food, cost, or travel burden historically mattered.

## Review-Gated Learning

No preference, profile, memory, or skill learning is applied silently. Workflows and feedback create proposals; `trippy learn approve <proposal-id>` is required before memory or skill mutation.

## Validation

- `uv run ruff check .`
- `uv run mypy trippy/`
- `uv run pytest` -> `239 passed, 5 skipped`
- `git diff --check`
- CLI smoke checks for `trippy sources --category flights --json` and `trippy country-priors Japan --json`
