### PR TITLE
[codex] Improve guided Trippy planner workflow

### DIFF
--- a/tests/unit/test_planning_advisor.py
+++ b/tests/unit/test_planning_advisor.py
@@ -1,0 +1,174 @@
+"""Tests for preference-rich planning-advisor prompts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trippy.models.ideas import TripIdeaRequest
+from trippy.models.planning_advice import PlanningAdviceKind
+from trippy.models.trip_planning import (
+    TravelWindow,
+    TripIntake,
+    TripIntakeMode,
+    TripParty,
+    TripPartyType,
+)
+from trippy.services.lodging_shortlist import LodgingShortlistService
+from trippy.services.planning_advisor import PlanningAdvisorService
+from trippy.services.trip_ideation import TripIdeationService
+from trippy.services.trip_intake import TripIntakeService
+from trippy.services.trip_planner import TripPlannerService
+
+
+def test_planning_advisor_prompt_is_deeply_contextual(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_couple_intake())
+    draft = TripPlannerService(intake_service).draft(intake.trip_id)
+
+    result = PlanningAdvisorService(enabled=False).advise_lodging_structure(
+        intake,
+        draft.get_option(),
+    )
+
+    assert result.kind == PlanningAdviceKind.LODGING_STRUCTURE
+    assert result.status == "disabled"
+    assert "Family Travel Preferences" in result.prompt
+    assert "Azores 2026" in result.prompt
+    assert "6-8 days" in result.prompt
+    assert "couple" in result.prompt
+    assert "king bed strongly preferred" in result.prompt
+    assert "one stay or split stays" in result.prompt
+
+
+def test_planning_advisor_parses_llm_json_response() -> None:
+    client = _FakeAnthropicClient(
+        {
+            "summary": "Split only if the second base cuts real driving.",
+            "recommendation": "Use two bases if Pico is kept; otherwise one Sao Miguel base.",
+            "rationale": ["Protects downtime", "Avoids backtracking"],
+            "next_actions": ["Verify exact flight timing", "Compare two lodging bases"],
+            "questions_for_user": ["Is Pico a must-have?"],
+            "warnings": ["Do not add a one-night move."],
+            "evidence_needed": ["Exact inter-island schedule"],
+            "stay_strategy": "split_stay",
+            "night_plan": [{"region": "Sao Miguel", "nights": 5, "reason": "main base"}],
+            "confidence": 0.72,
+        }
+    )
+    service = PlanningAdvisorService(anthropic_client=client, enabled=True)
+
+    comparison = TripIdeationService().compare(
+        TripIdeaRequest(
+            duration_days=6,
+            travelers=2,
+            party_type="couple",
+            goals=["food", "nature"],
+            avoid=["crowds"],
+        )
+    )
+    result = service.advise_trip_ideas(comparison.request, comparison)
+
+    assert result.status == "llm_success"
+    assert result.confidence == 0.72
+    assert result.stay_strategy == "split_stay"
+    assert result.next_actions[0] == "Verify exact flight timing"
+    assert client.calls
+    assert "Return JSON only" in client.calls[0]["messages"][0]["content"]
+
+
+def test_idea_comparison_and_lodging_shortlist_record_advisor_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+
+    comparison = TripIdeationService().compare(
+        TripIdeaRequest(
+            duration_days=6,
+            travelers=2,
+            party_type="couple",
+            goals=["food", "nature"],
+            avoid=["crowds"],
+        )
+    )
+    assert comparison.advisor["kind"] == "trip_ideas"
+    assert "duration" in comparison.advisor["prompt"].lower()
+
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_couple_intake())
+    planner = TripPlannerService(intake_service)
+    planner.select_option(intake.trip_id, planner.draft(intake.trip_id).recommended_option_id or "")
+    lodging = LodgingShortlistService(intake_service, planner).build(intake.trip_id)
+
+    advisor = lodging.artifacts["planning_advisor"]
+    structure = lodging.artifacts["lodging_structure"]
+    assert advisor["kind"] == "lodging_structure"
+    assert "Current Trip Intake" in advisor["prompt"]
+    assert structure["advisor_status"] in {
+        "disabled",
+        "skipped_no_api_key",
+        "llm_success",
+        "llm_failed",
+    }
+
+
+class _FakeAnthropicClient:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, Any]] = []
+        self.messages = self
+
+    def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="text",
+                    text=json.dumps(self.payload),
+                )
+            ]
+        )
+
+
+def _azores_couple_intake() -> TripIntake:
+    return TripIntake(
+        trip_id="azores-2026",
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Azores 2026",
+        destination_seeds=["Azores"],
+        travel_window=TravelWindow(label="late summer 2026"),
+        duration_days="6 to 8 days",
+        travelers=2,
+        party=TripParty(
+            party_type=TripPartyType.COUPLE,
+            adults=2,
+            children=0,
+            explicit=True,
+            defaulted_from_family_profile=False,
+        ),
+        goals=["food", "nature", "hot springs", "not overpacked"],
+        avoidances=["stressful driving", "crowds"],
+        freeform_notes="KenNSue trip. Prefer practical bases and great food.",
+    )
+
+
+def _patch_planning_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import trippy.config as config
+
+    monkeypatch.setattr(config, "INTAKES_PATH", tmp_path / "intakes")
+    monkeypatch.setattr(config, "PLANS_PATH", tmp_path / "plans")
+    monkeypatch.setattr(config, "SHORTLISTS_PATH", tmp_path / "shortlists")
+    monkeypatch.setattr(config, "LEARNING_PATH", tmp_path / "learning")
+    monkeypatch.setattr(config, "MEMORY_PATH", tmp_path / "memory.json")
+    monkeypatch.setattr(config, "TRIPS_PATH", tmp_path / "trips")
+    monkeypatch.setattr(config, "WORKSPACES_PATH", tmp_path / "workspaces")
+    monkeypatch.setattr(config, "EXPORT_PATH", tmp_path / "export")

--- a/tests/unit/test_trip_ideation.py
+++ b/tests/unit/test_trip_ideation.py
@@ -38,6 +38,27 @@ def test_trip_ideas_penalize_long_flights_for_short_max() -> None:
     assert any("exceeds requested max" in reason for reason in japan.why_it_may_not_fit)
 
 
+def test_trip_ideas_respect_short_duration_before_generic_ranking() -> None:
+    comparison = TripIdeationService().compare(
+        TripIdeaRequest(
+            duration_days=6,
+            travelers=2,
+            max_flight_hours=8,
+            goals=["food", "nature", "low-friction"],
+            avoid=["too long", "huge crowds"],
+        ),
+        limit=3,
+    )
+
+    assert len(comparison.concepts) == 3
+    assert all(concept.recommended_duration_days <= 6 for concept in comparison.concepts)
+    assert not any(
+        concept.concept_id in {"mexico-city-oaxaca-food", "portugal-food-cities-coast"}
+        for concept in comparison.concepts
+    )
+    assert any("Requested duration is 6" in note for note in comparison.scoring_notes)
+
+
 def test_trip_ideas_include_country_prior_rationale() -> None:
     comparison = TripIdeationService().compare(
         TripIdeaRequest(duration_days=14, goals=["food", "culture"]),

--- a/tests/unit/test_trip_ideation.py
+++ b/tests/unit/test_trip_ideation.py
@@ -26,12 +26,11 @@ def test_trip_ideas_rank_food_focused_options() -> None:
 def test_trip_ideas_penalize_long_flights_for_short_max() -> None:
     comparison = TripIdeationService().compare(
         TripIdeaRequest(
-            duration_days=7,
             max_flight_hours=6,
             goals=["food"],
             avoid=["crowds"],
         ),
-        limit=10,
+        limit=20,
     )
 
     japan = next(c for c in comparison.concepts if c.concept_id == "japan-food-rail-cities")
@@ -57,6 +56,66 @@ def test_trip_ideas_respect_short_duration_before_generic_ranking() -> None:
         for concept in comparison.concepts
     )
     assert any("Requested duration is 6" in note for note in comparison.scoring_notes)
+
+
+def test_trip_ideas_respect_explicit_caribbean_region_intent() -> None:
+    comparison = TripIdeationService().compare(
+        TripIdeaRequest(
+            duration_days=6,
+            travelers=2,
+            max_flight_hours=8,
+            goals=["Caribbean", "beach", "great food"],
+            avoid=["huge crowds", "stressful transfers"],
+        ),
+        limit=3,
+    )
+
+    concept_ids = {concept.concept_id for concept in comparison.concepts}
+    assert len(comparison.concepts) == 3
+    assert "azores-sao-miguel-short-comfort" not in concept_ids
+    assert concept_ids <= {
+        "belize-reef-jungle-short",
+        "curacao-color-beach-drivable-short",
+        "st-lucia-private-rental-food-short",
+        "mexico-caribbean-food-beach-short",
+    }
+    assert all(concept.recommended_duration_days <= 6 for concept in comparison.concepts)
+    assert any(
+        "Explicit destination intent detected: caribbean" in note
+        for note in comparison.scoring_notes
+    )
+
+
+def test_trip_ideas_treat_snorkeling_as_required_experience() -> None:
+    comparison = TripIdeationService().compare(
+        TripIdeaRequest(
+            time_of_year="march break",
+            duration_days=7,
+            travelers=5,
+            max_flight_hours=5,
+            goals=["great food", "low friction", "memorable snorkling"],
+            avoid=["huge crowds", "stressful transfers"],
+        ),
+        limit=3,
+    )
+
+    concept_ids = {concept.concept_id for concept in comparison.concepts}
+    assert len(comparison.concepts) == 3
+    assert concept_ids <= {
+        "belize-reef-jungle-short",
+        "cayman-reef-food-easy-week",
+        "curacao-color-beach-drivable-short",
+        "mexico-caribbean-food-beach-short",
+    }
+    assert "quebec-city-montreal-food-short" not in concept_ids
+    assert "mexico-city-food-short" not in concept_ids
+    assert "azores-sao-miguel-short-comfort" not in concept_ids
+    assert all(
+        any("snorkeling" in item for item in concept.rationale) for concept in comparison.concepts
+    )
+    assert any(
+        "Required experience detected: snorkeling" in note for note in comparison.scoring_notes
+    )
 
 
 def test_trip_ideas_include_country_prior_rationale() -> None:

--- a/tests/unit/test_trip_planning_pipeline.py
+++ b/tests/unit/test_trip_planning_pipeline.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from typer.testing import CliRunner
@@ -19,6 +21,7 @@ from trippy.models.shortlists import (
     VerificationStatus,
 )
 from trippy.models.source_research import SourceAdapterCapability, SourceResearchStatus
+from trippy.models.trip import Trip
 from trippy.models.trip_planning import (
     TravelerAgeBand,
     TravelWindow,
@@ -28,6 +31,7 @@ from trippy.models.trip_planning import (
     TripPartyType,
     TripTraveler,
     WorkspaceStatus,
+    WorkspaceTab,
 )
 from trippy.services.activity_shortlist import ActivityShortlistService
 from trippy.services.car_shortlist import CarShortlistService
@@ -96,8 +100,12 @@ def test_azores_golden_path_services(
     assert tabs["Flights"].rows[0][1] in {"researched", "verified_live"}
     assert tabs["Flights"].rows[0][2] == "yes"
     assert tabs["Lodging"].rows[0][1] in {"recommended", "researched"}
-    assert tabs["Cars"].rows[0][7] >= 5
-    assert any(row[5] == "activity" for row in tabs["Master Timeline"].rows)
+    assert tabs["Cars"].rows[0][8] >= 5
+    timeline = tabs["Master Timeline"].rows
+    assert any(row[5] == "activity" for row in timeline)
+    assert [int(row[0]) for row in timeline] == sorted(int(row[0]) for row in timeline)
+    assert all(row[1] for row in timeline)
+    assert all("summer 2027" in row[1] for row in timeline)
     assert any("Traveler Roster" in row for row in tabs["Overview"].rows)
 
     canonical = TripStateService().load(intake.trip_id)
@@ -121,7 +129,23 @@ def test_azores_golden_path_services(
 
     assert flights.category == ShortlistCategory.FLIGHTS
     assert flights.recommended_option_id == "flight-direct-yyz-pdl"
-    assert "google.com/travel/flights" in flights.flight_options[0].deep_link
+    flight_link = flights.flight_options[0].deep_link
+    flight_params = parse_qs(urlparse(flight_link).query)
+    assert "google.com/travel/flights" in flight_link
+    assert "?q=" not in flight_link
+    assert flight_params["tfu"] == ["EgIIACIA"]
+    assert flight_params["origin"] == ["YYZ"]
+    assert flight_params["destination"] == ["PDL"]
+    assert flight_params["departure"] == ["2027-06-15"]
+    assert "f=0" not in flight_params["tfs"][0]
+    tfs_padding = "=" * (-len(flight_params["tfs"][0]) % 4)
+    tfs_payload = base64.urlsafe_b64decode(flight_params["tfs"][0] + tfs_padding)
+    assert b"YYZ" in tfs_payload
+    assert b"PDL" in tfs_payload
+    assert b"2027-06-15" in tfs_payload
+    assert any(
+        "placeholder search dates" in note for note in flights.flight_options[0].confidence_notes
+    )
     assert lodging.lodging_options
     assert lodging.recommended_option_id is not None
     assert cars.car_options[0].booking_source == "Booking.com"
@@ -153,6 +177,92 @@ def test_azores_golden_path_services(
     planned = next(tile for tile in dashboard.planned_trips if tile.trip_id == intake.trip_id)
     assert planned.planning_status["workspace"] == "prepared_local"
     assert planned.shortlist_status["flights"].startswith("3 option")
+    assert planned.planning_completeness < 100
+
+
+def test_google_workspace_updates_existing_sheet_instead_of_creating_new() -> None:
+    class _Request:
+        def __init__(self, response: dict[str, object]) -> None:
+            self.response = response
+
+        def execute(self) -> dict[str, object]:
+            return self.response
+
+    class _Values:
+        def __init__(self) -> None:
+            self.batch_clears: list[dict[str, object]] = []
+            self.batch_updates: list[dict[str, object]] = []
+
+        def batchClear(self, spreadsheetId: str, body: dict[str, object]) -> _Request:  # noqa: N803
+            self.batch_clears.append({"spreadsheetId": spreadsheetId, "body": body})
+            return _Request({})
+
+        def batchUpdate(self, spreadsheetId: str, body: dict[str, object]) -> _Request:  # noqa: N803
+            self.batch_updates.append({"spreadsheetId": spreadsheetId, "body": body})
+            return _Request({})
+
+    class _Spreadsheets:
+        def __init__(self) -> None:
+            self.created: list[dict[str, object]] = []
+            self.batch_updates: list[dict[str, object]] = []
+            self.values_api = _Values()
+
+        def create(self, body: dict[str, object]) -> _Request:
+            self.created.append(body)
+            return _Request({"spreadsheetId": "new-sheet", "spreadsheetUrl": "new-url"})
+
+        def get(self, spreadsheetId: str, fields: str) -> _Request:  # noqa: N803
+            return _Request(
+                {
+                    "spreadsheetUrl": "https://docs.google.com/spreadsheets/d/sheet-123",
+                    "sheets": [
+                        {"properties": {"sheetId": 1, "title": "Overview"}},
+                        {"properties": {"sheetId": 2, "title": "Flights"}},
+                    ],
+                }
+            )
+
+        def batchUpdate(self, spreadsheetId: str, body: dict[str, object]) -> _Request:  # noqa: N803
+            self.batch_updates.append({"spreadsheetId": spreadsheetId, "body": body})
+            return _Request({})
+
+        def values(self) -> _Values:
+            return self.values_api
+
+    class _SheetsService:
+        def __init__(self) -> None:
+            self.spreadsheets_api = _Spreadsheets()
+
+        def spreadsheets(self) -> _Spreadsheets:
+            return self.spreadsheets_api
+
+    class _Auth:
+        def __init__(self) -> None:
+            self.service = _SheetsService()
+
+        def build_service(self, name: str, version: str) -> _SheetsService:
+            assert (name, version) == ("sheets", "v4")
+            return self.service
+
+    auth = _Auth()
+    workspace = TripWorkspaceService(auth_manager=auth)
+    result = workspace._try_create_google_sheet(
+        Trip(trip_id="azores-2027", name="Azores 2027"),
+        [
+            WorkspaceTab(name="Overview", headers=["Field", "Value"], rows=[["Trip", "Azores"]]),
+            WorkspaceTab(name="Flights", headers=["Airline"], rows=[["TAP"]]),
+        ],
+        folder_id=None,
+        existing_sheet_id="sheet-123",
+        existing_sheet_url="https://docs.google.com/spreadsheets/d/sheet-123",
+    )
+
+    sheets = auth.service.spreadsheets_api
+    assert result["spreadsheet_id"] == "sheet-123"
+    assert result["operation"] == "updated"
+    assert sheets.created == []
+    assert sheets.values_api.batch_clears[0]["spreadsheetId"] == "sheet-123"
+    assert sheets.values_api.batch_updates[0]["spreadsheetId"] == "sheet-123"
 
 
 def test_cli_azores_golden_path(
@@ -248,6 +358,11 @@ def test_cli_azores_golden_path(
     assert map_result.exit_code == 0, map_result.output
     map_payload = json.loads(map_result.output)
     assert map_payload["map"]["pins"]
+    assert map_payload["map"]["pins"][0]["label"].startswith("01 ·")
+    assert "google.com/maps/dir" in map_payload["map"]["primary_google_maps_url"]
+    assert Path(map_payload["map"]["exports"]["kml"]).exists()
+    assert Path(map_payload["map"]["exports"]["csv"]).exists()
+    assert "01," in Path(map_payload["map"]["exports"]["csv"]).read_text(encoding="utf-8")
     assert map_payload["workflow_id"].startswith("wf-")
 
     for command in ("flights", "lodging", "cars", "activities"):
@@ -598,6 +713,58 @@ def test_selecting_flight_updates_recommendation_and_workspace_timeline(
     timeline = tabs["Master Timeline"].rows
     assert any(row[0] == "Best Flight Rationale" and row[1] for row in overview)
     assert any(chosen.airline in row[6] for row in timeline)
+
+
+def test_selecting_lodging_and_manual_split_drives_workspace_timeline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_intake())
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+
+    lodging_service = LodgingShortlistService(intake_service, planner)
+    lodging = lodging_service.build(intake.trip_id)
+    option_id = lodging.lodging_options[0].option_id
+    selected = lodging_service.select_lodging(intake.trip_id, option_id)
+    assert selected.recommended_option_id == option_id
+    assert selected.lodging_options[0].row_status == ShortlistRowStatus.APPROVED
+
+    updated = lodging_service.update_stay_structure(
+        intake.trip_id,
+        strategy="split_stay",
+        night_plan=[
+            {
+                "region": "Ponta Delgada",
+                "nights": 4,
+                "lodging_option_id": option_id,
+                "notes": "central first base",
+            },
+            {
+                "region": "Furnas",
+                "nights": 3,
+                "notes": "second base to reduce backtracking",
+            },
+        ],
+        notes="Manual same-island split test.",
+    )
+    structure = updated.artifacts["lodging_structure"]
+    assert structure["strategy"] == "split_stay"
+    assert structure["data_status"] == "manual_override"
+
+    workspace = TripWorkspaceService(intake_service, planner).prepare(
+        intake.trip_id,
+        create_google_sheet=False,
+    )
+    tabs = {tab.name: tab for tab in workspace.tabs}
+    stay_plan = tabs["Stay Plan"].rows
+    timeline = tabs["Master Timeline"].rows
+    assert any(row[1] == "Furnas" and row[2] == 3 for row in stay_plan)
+    assert any(row[6] == "Check in: Furnas" for row in timeline)
+    assert any("second base" in row[18] for row in timeline)
 
 
 def test_selected_plan_shapes_research_targets(

--- a/tests/unit/test_trip_planning_pipeline.py
+++ b/tests/unit/test_trip_planning_pipeline.py
@@ -43,6 +43,7 @@ from trippy.services.shortlist_store import ShortlistStore
 from trippy.services.source_research import (
     LinkResearchAdapter,
     OpenClawResearchAdapter,
+    PlaywrightActivityAdapter,
     PlaywrightFlightAdapter,
     PlaywrightLodgingAdapter,
     SourceResearchService,
@@ -143,6 +144,18 @@ def test_azores_golden_path_services(
     assert b"YYZ" in tfs_payload
     assert b"PDL" in tfs_payload
     assert b"2027-06-15" in tfs_payload
+    flight_links = [
+        link
+        for option in flights.flight_options
+        for link in [option.deep_link, *option.comparison_links.values()]
+    ]
+    assert all("Flights-Search" not in link for link in flight_links)
+    assert all("flighthub.com" not in link for link in flight_links)
+    assert any(
+        "ca.kayak.com/flights/YYZ-PDL/2027-06-15/2027-06-25/5adults"
+        in link
+        for link in flight_links
+    )
     assert any(
         "placeholder search dates" in note for note in flights.flight_options[0].confidence_notes
     )
@@ -153,6 +166,16 @@ def test_azores_golden_path_services(
     assert "Flights-Search" not in cars.car_options[1].deep_link
     assert "/flights/" not in cars.car_options[2].deep_link
     assert activities.activity_options[0].source == "GetYourGuide"
+    activity_links = [
+        link
+        for option in activities.activity_options
+        for link in [option.deep_link, *option.validation_links.values()]
+    ]
+    assert all("airbnb.ca" not in link for link in activity_links)
+    assert all(
+        "Airbnb Experiences" not in option.validation_links
+        for option in activities.activity_options
+    )
     assert flights.flight_options[0].row_status == ShortlistRowStatus.RESEARCHED
     assert (
         flights.flight_options[0].validation.verification_status
@@ -589,6 +612,98 @@ def test_flight_deep_research_enriches_existing_shortlist_state(
     assert first.date_viability_signal
 
 
+def test_flight_shortlist_uses_duffel_live_offers_when_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    monkeypatch.setattr("trippy.config.DUFFEL_ACCESS_TOKEN", "test-token")
+
+    def fake_duffel_request(token: str, payload: dict[str, object]) -> dict[str, object]:
+        assert token == "test-token"
+        data = payload["data"]
+        assert isinstance(data, dict)
+        slices = data["slices"]
+        assert isinstance(slices, list)
+        assert slices[0]["origin"] == "YYZ"
+        assert slices[0]["destination"] == "PDL"
+        return {
+            "data": {
+                "offers": [
+                    {
+                        "id": "off_live_1",
+                        "total_amount": "1180.00",
+                        "total_currency": "CAD",
+                        "owner": {"name": "Azores Airlines"},
+                        "slices": [
+                            {
+                                "duration": "PT5H55M",
+                                "segments": [
+                                    {
+                                        "departing_at": "2027-06-15T21:15:00-04:00",
+                                        "arriving_at": "2027-06-16T07:10:00+00:00",
+                                        "origin": {"iata_code": "YYZ"},
+                                        "destination": {"iata_code": "PDL"},
+                                        "marketing_carrier": {
+                                            "iata_code": "S4",
+                                            "name": "Azores Airlines",
+                                        },
+                                        "operating_carrier": {"name": "Azores Airlines"},
+                                        "marketing_carrier_flight_number": "332",
+                                    }
+                                ],
+                            },
+                            {
+                                "duration": "PT6H20M",
+                                "segments": [
+                                    {
+                                        "departing_at": "2027-06-22T10:00:00+00:00",
+                                        "arriving_at": "2027-06-22T14:20:00-04:00",
+                                        "origin": {"iata_code": "PDL"},
+                                        "destination": {"iata_code": "YYZ"},
+                                        "marketing_carrier": {
+                                            "iata_code": "S4",
+                                            "name": "Azores Airlines",
+                                        },
+                                        "operating_carrier": {"name": "Azores Airlines"},
+                                        "marketing_carrier_flight_number": "331",
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+
+    monkeypatch.setattr(
+        "trippy.services.flight_shortlist._post_duffel_offer_request",
+        fake_duffel_request,
+    )
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_intake())
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+
+    flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
+    option = flights.flight_options[0]
+
+    assert option.option_id == "duffel-flight-1"
+    assert option.booking_source == "Duffel"
+    assert option.flight_numbers == ["S4332"]
+    assert option.departure_date == "2027-06-15"
+    assert option.departure_time == "9:15 PM"
+    assert option.arrival_date == "2027-06-16"
+    assert option.arrival_time == "7:10 AM"
+    assert option.total_travel_duration == "5h 55m"
+    assert option.price_band == "CAD 1180.00 total"
+    assert option.deep_link.startswith("https://www.google.com/travel/flights/search?")
+    assert option.row_status == ShortlistRowStatus.VERIFIED_LIVE
+    assert option.validation.adapter_used == "duffel"
+    assert "Duffel returned 1 exact offer row" in " ".join(flights.warnings)
+
+
 def test_flight_deep_research_handles_partial_secondary_source_text(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -767,6 +882,65 @@ def test_selecting_lodging_and_manual_split_drives_workspace_timeline(
     assert any("second base" in row[18] for row in timeline)
 
 
+def test_lodging_service_suggests_editable_split_stay_options(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_intake())
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+
+    lodging_service = LodgingShortlistService(intake_service, planner)
+    lodging_service.build(intake.trip_id)
+    updated = lodging_service.suggest_stay_structures(intake.trip_id, use_llm=False)
+
+    structure = updated.artifacts["lodging_structure"]
+    options = structure["options"]
+    assert len(options) == 3
+    assert {option["strategy"] for option in options} == {"single_stay", "split_stay"}
+    assert all(option["night_plan"] for option in options)
+    assert any(
+        any("Furnas" in stay["region"] for stay in option["night_plan"]) for option in options
+    )
+    assert len({option["thumbnail_variant"] for option in options}) >= 2
+
+
+def test_lodging_split_seeds_options_for_each_saved_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_intake())
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+
+    lodging_service = LodgingShortlistService(intake_service, planner)
+    lodging_service.build(intake.trip_id)
+    updated = lodging_service.update_stay_structure(
+        intake.trip_id,
+        strategy="split_stay",
+        night_plan=[
+            {"region": "Ponta Delgada / south coast", "nights": 4},
+            {"region": "Ribeira Grande / north coast", "nights": 2},
+        ],
+        notes="Testing a north-coast second base.",
+    )
+
+    regions = [option.location_area for option in updated.lodging_options]
+    assert any("Ponta Delgada" in region for region in regions)
+    assert any("Ribeira Grande" in region for region in regions)
+    ribeira = next(
+        option for option in updated.lodging_options if "Ribeira Grande" in option.location_area
+    )
+    assert ribeira.option_id.startswith("stay-region-lodging-ribeira-grande")
+    assert any("location-specific search seed" in flag for flag in ribeira.friction_flags)
+
+
 def test_selected_plan_shapes_research_targets(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -789,6 +963,91 @@ def test_selected_plan_shapes_research_targets(
     assert all("Pico" not in option.pickup_location for option in cars.car_options)
     assert all("Pico" not in option.island_location for option in activities.activity_options)
     assert all("Faial" not in option.island_location for option in activities.activity_options)
+
+
+def test_generic_activity_shortlist_offers_multiple_specific_choices(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    intake_service = TripIntakeService()
+    intake = intake_service.create(
+        TripIntake(
+            mode=TripIntakeMode.SELECTED_DESTINATION,
+            trip_name="Grand Cayman",
+            destination_seeds=[
+                "Seven Mile Beach",
+                "West Bay",
+                "Stingray City or Rum Point",
+            ],
+            duration_days=7,
+            party=TripParty(
+                party_type=TripPartyType.WHOLE_FAMILY,
+                adults=2,
+                children=3,
+                explicit=True,
+            ),
+        )
+    )
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+    planner.select_option(intake.trip_id, "single-base-easy")
+
+    activities = ActivityShortlistService(intake_service, planner).build(intake.trip_id)
+
+    assert len(activities.activity_options) >= 5
+    names = " ".join(option.activity_name for option in activities.activity_options)
+    assert "Seven Mile Beach" in names
+    assert "West Bay" in names
+    assert "Stingray" in names
+    assert all(option.price_band == "source price required" for option in activities.activity_options)
+    assert all(
+        option.duration == "source schedule required" for option in activities.activity_options
+    )
+    assert all(not option.suggested_start_time for option in activities.activity_options)
+    assert all("airbnb.ca" not in option.deep_link for option in activities.activity_options)
+
+
+def test_activity_deep_research_extracts_cost_time_and_availability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+
+    def fake_fetcher(url: str, timeout: float) -> tuple[str, str, list[str]]:
+        return (
+            """
+            <html><body>
+            <h1>Stingray Sandbar small-group tour</h1>
+            <p>From C$89 per person. Check availability. Free cancellation.</p>
+            <p>Starts at 9:30 AM and ends at 12:30 PM. Duration 3 hours.</p>
+            <p>Small group limited to 10. Rated 4.8 out of 5.</p>
+            </body></html>
+            """,
+            url,
+            ["fixture activity page"],
+        )
+
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_intake())
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+    activities = ActivityShortlistService(intake_service, planner).build(intake.trip_id)
+
+    researched = SourceResearchService(
+        adapters=[PlaywrightActivityAdapter(fetcher=fake_fetcher)],
+        research_dir=tmp_path / "research",
+    ).research_state(activities, adapter_mode="playwright")
+    option = researched.activity_options[0]
+
+    assert option.price_band == "C$89 per person"
+    assert option.duration in {"3 hours", "3 h"}
+    assert option.suggested_start_time == "9:30 AM"
+    assert option.suggested_end_time == "12:30 PM"
+    assert "availability_signal" in option.validation.extracted_fields
+    assert option.validation.price_status.value == "live_signal"
+    assert option.validation.availability_status.value == "availability_signal"
 
 
 def test_trip_party_edge_cases_are_visible() -> None:
@@ -832,6 +1091,85 @@ def test_trip_party_edge_cases_are_visible() -> None:
     assert "defaulted" not in six.party.summary()
     assert unnamed.party.total_travelers == 4
     assert "defaulted; confirm roster" in unnamed.party.summary()
+
+
+def test_generic_single_base_plan_uses_one_lodging_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    intake_service = TripIntakeService()
+    intake = intake_service.create(
+        TripIntake(
+            mode=TripIntakeMode.SELECTED_DESTINATION,
+            trip_name="Grand Cayman",
+            destination_seeds=[
+                "Seven Mile Beach",
+                "West Bay",
+                "Stingray City or Rum Point",
+            ],
+            duration_days=7,
+            party=TripParty(
+                party_type=TripPartyType.WHOLE_FAMILY,
+                adults=2,
+                children=3,
+                explicit=True,
+            ),
+        )
+    )
+
+    planner = TripPlannerService(intake_service)
+    draft = planner.draft(intake.trip_id)
+
+    single_base = draft.get_option("single-base-easy")
+    assert single_base is not None
+    assert single_base.title == "Seven Mile Beach Single-Base Easy Version"
+    assert single_base.regions == ["Seven Mile Beach"]
+    assert single_base.nights_by_region == {"Seven Mile Beach": 6}
+
+    balanced = draft.get_option("two-region-balanced")
+    assert balanced is not None
+    assert balanced.regions == ["Seven Mile Beach", "West Bay"]
+    assert set(balanced.nights_by_region) == {"Seven Mile Beach", "West Bay"}
+
+    stale = draft.model_dump(mode="json")
+    for option in stale["options"]:
+        if option["option_id"] == "single-base-easy":
+            option["title"] = (
+                "Seven Mile Beach, West Bay, Stingray City or Rum Point Single-Base Easy Version"
+            )
+            option["regions"] = [
+                "Seven Mile Beach",
+                "West Bay",
+                "Stingray City or Rum Point",
+            ]
+            option["nights_by_region"] = {
+                "Seven Mile Beach": 2,
+                "West Bay": 2,
+                "Stingray City or Rum Point": 2,
+            }
+        if option["option_id"] == "two-region-balanced":
+            option["regions"] = [
+                "Seven Mile Beach",
+                "West Bay",
+                "Stingray City or Rum Point",
+            ]
+            option["nights_by_region"] = {
+                "Seven Mile Beach": 3,
+                "West Bay": 3,
+            }
+    planner.path_for(intake.trip_id).write_text(json.dumps(stale), encoding="utf-8")
+
+    loaded = planner.load_draft(intake.trip_id)
+    assert loaded is not None
+    loaded_single = loaded.get_option("single-base-easy")
+    assert loaded_single is not None
+    assert loaded_single.title == "Seven Mile Beach Single-Base Easy Version"
+    assert loaded_single.regions == ["Seven Mile Beach"]
+    assert loaded_single.nights_by_region == {"Seven Mile Beach": 6}
+    loaded_balanced = loaded.get_option("two-region-balanced")
+    assert loaded_balanced is not None
+    assert loaded_balanced.regions == ["Seven Mile Beach", "West Bay"]
 
 
 def _patch_planning_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_ui_server.py
+++ b/tests/unit/test_ui_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -175,6 +176,73 @@ def test_ui_suggest_ideas_respects_six_day_prompt_and_can_capture_idea_feedback(
     assert any(event["event_type"] == "user_feedback" for event in logs["events"])
 
 
+def test_ui_suggest_ideas_respects_caribbean_region_intent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+
+    result = service.suggest_ideas(
+        {
+            "party_type": "couple",
+            "travelers": 2,
+            "adults": 2,
+            "children": 0,
+            "time_of_year": "winter",
+            "duration_days": 6,
+            "max_flight_hours": 8,
+            "goals": "Caribbean, beach, great food",
+            "avoidances": "huge crowds, stressful transfers",
+        }
+    )
+
+    concept_ids = {concept["concept_id"] for concept in result["comparison"]["concepts"]}
+    assert len(concept_ids) == 3
+    assert "azores-sao-miguel-short-comfort" not in concept_ids
+    assert concept_ids <= {
+        "belize-reef-jungle-short",
+        "curacao-color-beach-drivable-short",
+        "st-lucia-private-rental-food-short",
+        "mexico-caribbean-food-beach-short",
+    }
+
+
+def test_ui_suggest_ideas_respects_snorkeling_requirement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+
+    result = service.suggest_ideas(
+        {
+            "party_type": "whole_family",
+            "travelers": 5,
+            "adults": 2,
+            "children": 3,
+            "child_ages": "16, 14, 11",
+            "time_of_year": "march break",
+            "duration_days": 7,
+            "max_flight_hours": 5,
+            "goals": "great food, low friction, memorable snorkling",
+            "avoidances": "huge crowds, stressful transfers",
+        }
+    )
+
+    concept_ids = {concept["concept_id"] for concept in result["comparison"]["concepts"]}
+    assert len(concept_ids) == 3
+    assert "quebec-city-montreal-food-short" not in concept_ids
+    assert "mexico-city-food-short" not in concept_ids
+    assert "azores-sao-miguel-short-comfort" not in concept_ids
+    assert concept_ids <= {
+        "belize-reef-jungle-short",
+        "cayman-reef-food-easy-week",
+        "curacao-color-beach-drivable-short",
+        "mexico-caribbean-food-beach-short",
+    }
+
+
 def test_ui_lodging_candidate_is_evaluated_in_shortlist(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -267,6 +335,31 @@ def test_ui_can_select_lodging_and_override_stay_structure(
     assert any(event["title"] == "ui-trip-plan-lodging-structure" for event in logs["events"])
 
 
+def test_ui_can_generate_stay_structure_options(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+    trip_id = _create_selected_trip(service)
+    service.build_shortlist(trip_id, "lodging")
+
+    result = service.suggest_lodging_structures({"trip_id": trip_id, "use_llm": False})
+    structure = result["shortlist"]["artifacts"]["lodging_structure"]
+    options = structure["options"]
+
+    assert result["option_count"] == 3
+    assert len(options) == 3
+    assert any(option["strategy"] == "split_stay" for option in options)
+    assert any(
+        any("Furnas" in stay["region"] for stay in option["night_plan"]) for option in options
+    )
+    assert any(
+        event["title"] == "ui-trip-plan-lodging-structure-suggest"
+        for event in service.logs(trip_id=trip_id)["events"]
+    )
+
+
 def test_ui_lodging_for_couple_does_not_force_family_bed_query(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -299,6 +392,63 @@ def test_ui_lodging_for_couple_does_not_force_family_bed_query(
     assert "king" in first["bed_layout"]
     assert "family+room+3+beds" not in first["deep_link"]
     assert "king+room" in first["deep_link"]
+
+
+def test_ui_booking_lodging_links_include_trip_dates_and_party(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+    intake_result = service.create_intake(
+        {
+            "trip_name": "Cayman Family 2027",
+            "destinations": "Seven Mile Beach, West Bay",
+            "start_date": "2027-03-13",
+            "end_date": "2027-03-19",
+            "duration": "7 days",
+            "party_type": "whole_family",
+            "adults": 2,
+            "children": 3,
+            "child_ages": "16, 14, 11",
+            "roster": "Ken|adult, Jenn|adult, Child 1|16, Child 2|14, Child 3|11",
+            "departure_airports": "YYZ",
+        }
+    )
+    trip_id = intake_result["intake"]["trip_id"]
+    draft = service.draft_plan(trip_id)
+    service.select_plan(trip_id, draft["draft"]["recommended_option_id"])
+
+    result = service.build_shortlist(trip_id, "lodging")
+
+    first = result["shortlist"]["lodging_options"][0]
+    params = parse_qs(urlparse(first["deep_link"]).query)
+    assert params["checkin"] == ["2027-03-13"]
+    assert params["checkout"] == ["2027-03-19"]
+    assert params["group_adults"] == ["2"]
+    assert params["group_children"] == ["3"]
+    assert params["age"] == ["16", "14", "11"]
+    assert params["no_rooms"] == ["1"]
+
+    user = service.add_lodging_candidate(
+        {
+            "trip_id": trip_id,
+            "name": "Oceanfront Seven Mile Beach 2 BR",
+            "link": "https://www.booking.com/hotel/ky/oceanfront-seven-mile.html",
+            "notes": "West Bay. CAD 900/night. 2 bedrooms, parking.",
+        }
+    )
+    candidate = next(
+        option
+        for option in user["shortlist"]["lodging_options"]
+        if option["option_id"].startswith("user-lodging-")
+    )
+    candidate_params = parse_qs(urlparse(candidate["deep_link"]).query)
+    assert candidate_params["checkin"] == ["2027-03-13"]
+    assert candidate_params["checkout"] == ["2027-03-19"]
+    assert candidate_params["group_adults"] == ["2"]
+    assert candidate_params["group_children"] == ["3"]
+    assert candidate_params["age"] == ["16", "14", "11"]
 
 
 def test_ui_can_approve_and_schedule_activity_for_timeline(
@@ -368,6 +518,15 @@ def test_ui_flight_candidate_is_evaluated_in_shortlist(
             "trip_id": trip_id,
             "name": "Air Canada / TAP candidate",
             "link": "https://www.google.com/travel/flights/search?tfs=test",
+            "flight_numbers": "AC880, TP1861",
+            "departure_date": "2026-08-24",
+            "departure_time": "9:15 PM",
+            "arrival_date": "2026-08-25",
+            "arrival_time": "2:20 PM",
+            "total_duration": "10h 35m",
+            "layover_airports": "LIS",
+            "layover_duration": "2h 20m",
+            "price_band": "CAD 1180 pp",
             "notes": (
                 "Air Canada AC880 and TAP Portugal TP1861, depart 9:15 PM, arrive 2:20 PM, "
                 "duration 10h 35m, 1 stop via LIS, layover 2h 20m, CAD 1180 pp, checked bag included."
@@ -383,7 +542,10 @@ def test_ui_flight_candidate_is_evaluated_in_shortlist(
     assert len(candidates) == 1
     candidate = candidates[0]
     assert candidate["booking_source"] == "Google Flights"
+    assert candidate["flight_numbers"] == ["AC880", "TP1861"]
+    assert candidate["departure_date"] == "2026-08-24"
     assert candidate["departure_time"] == "9:15 PM"
+    assert candidate["arrival_date"] == "2026-08-25"
     assert candidate["arrival_time"] == "2:20 PM"
     assert candidate["layover_airports"] == ["LIS"]
     assert candidate["price_band"] == "CAD 1180 pp"
@@ -415,6 +577,77 @@ def test_ui_select_flight_updates_canonical_shortlist(
     assert chosen["date_viability_signal"]
     logs = service.logs(trip_id=trip_id)
     assert any(event["title"] == "ui-trip-plan-flight-select" for event in logs["events"])
+
+
+def test_ui_can_confirm_core_bookings_and_hydrate_trip_packet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+    trip_id = _create_selected_trip(service)
+    flights = service.build_shortlist(trip_id, "flights")
+    lodging = service.build_shortlist(trip_id, "lodging")
+    flight_id = flights["shortlist"]["flight_options"][0]["option_id"]
+    lodging_id = lodging["shortlist"]["lodging_options"][0]["option_id"]
+    service.select_flight({"trip_id": trip_id, "option_id": flight_id})
+    service.select_lodging({"trip_id": trip_id, "option_id": lodging_id})
+
+    flight_packet = service.update_trip_packet_item(
+        {
+            "trip_id": trip_id,
+            "category": "flight",
+            "option_id": flight_id,
+            "status": "confirmed",
+            "provider": "Azores Airlines",
+            "confirmation_code": "S4-ABC123",
+            "booking_link": "https://www.google.com/travel/flights",
+            "date": "2027-06-12",
+            "start_time": "21:15",
+            "end_time": "08:30",
+            "notes": "Seats still need assignment.",
+        }
+    )
+    lodging_packet = service.update_trip_packet_item(
+        {
+            "trip_id": trip_id,
+            "category": "lodging",
+            "option_id": lodging_id,
+            "status": "confirmed",
+            "provider": "Booking.com",
+            "confirmation_code": "BK-98765",
+            "booking_link": "https://www.booking.com/",
+            "address": "Ponta Delgada, Azores",
+            "date": "2027-06-13",
+            "notes": "Check-in after 15:00.",
+        }
+    )
+
+    assert flight_packet["trip_packet"]["readiness_percent"] < 100
+    assert lodging_packet["trip_packet"]["readiness_percent"] == 100
+    assert lodging_packet["trip_packet"]["status_label"] == "trip packet confirmed"
+
+    snapshot = service.trip_state(trip_id)
+    flight_state = next(
+        shortlist for shortlist in snapshot["shortlists"] if shortlist["category"] == "flights"
+    )
+    lodging_state = next(
+        shortlist for shortlist in snapshot["shortlists"] if shortlist["category"] == "lodging"
+    )
+    assert flight_state["flight_options"][0]["row_status"] == "confirmed"
+    assert lodging_state["lodging_options"][0]["row_status"] == "confirmed"
+
+    workspace = service.build_workspace(trip_id, create_google_sheet=False)
+    tabs = {tab["name"]: tab for tab in workspace["workspace"]["tabs"]}
+    packet_rows = tabs["Trip Packet"]["rows"]
+    timeline = tabs["Master Timeline"]["rows"]
+    assert any(row[4] == "S4-ABC123" for row in packet_rows)
+    assert any(row[4] == "BK-98765" for row in packet_rows)
+    assert any("S4-ABC123" in row[10] for row in timeline)
+    assert any("BK-98765" in row[10] for row in timeline)
+
+    logs = service.logs(trip_id=trip_id)
+    assert any(event["title"] == "ui-trip-packet-update" for event in logs["events"])
 
 
 def test_ui_can_select_car_for_local_movement_planning(

--- a/tests/unit/test_ui_server.py
+++ b/tests/unit/test_ui_server.py
@@ -134,6 +134,47 @@ def test_ui_suggest_ideas_returns_concepts_and_records_workflow(
     assert suggest_events[-1]["metrics"]["concepts"] == 3
 
 
+def test_ui_suggest_ideas_respects_six_day_prompt_and_can_capture_idea_feedback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+
+    result = service.suggest_ideas(
+        {
+            "party_type": "couple",
+            "travelers": 2,
+            "adults": 2,
+            "children": 0,
+            "time_of_year": "late summer",
+            "duration_days": 6,
+            "max_flight_hours": 8,
+            "goals": "great food, nature, low friction",
+            "avoidances": "huge crowds, stressful transfers",
+        }
+    )
+
+    comparison = result["comparison"]
+    assert len(comparison["concepts"]) == 3
+    assert all(concept["recommended_duration_days"] <= 6 for concept in comparison["concepts"])
+
+    too_long_feedback = service.add_feedback(
+        {
+            "workflow_id": result["workflow_id"],
+            "rating": "needs-work",
+            "notes": "One of the generated ideas ignored the 6-day constraint.",
+            "correction": "Respect the requested duration before ranking generated ideas.",
+            "future_learning": True,
+        }
+    )
+
+    assert too_long_feedback["learning_proposals"]
+    logs = service.logs()
+    assert any(event["title"] == "ui-trip-ideas-suggest" for event in logs["events"])
+    assert any(event["event_type"] == "user_feedback" for event in logs["events"])
+
+
 def test_ui_lodging_candidate_is_evaluated_in_shortlist(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -157,6 +198,10 @@ def test_ui_lodging_candidate_is_evaluated_in_shortlist(
         for option in result["shortlist"]["lodging_options"]
         if option["option_id"].startswith("user-lodging-")
     ]
+    structure = result["shortlist"]["artifacts"]["lodging_structure"]
+    assert structure["strategy"] in {"single_stay", "split_stay"}
+    assert structure["data_status"] == "inferred_from_selected_plan"
+    assert structure["night_plan"]
     assert len(candidates) == 1
     candidate = candidates[0]
     assert candidate["source"] == "Booking.com"
@@ -168,6 +213,145 @@ def test_ui_lodging_candidate_is_evaluated_in_shortlist(
 
     logs = service.logs(trip_id=trip_id)
     assert any(event["title"] == "ui-trip-plan-lodging-candidate" for event in logs["events"])
+
+
+def test_ui_can_select_lodging_and_override_stay_structure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+    trip_id = _create_selected_trip(service)
+    lodging = service.build_shortlist(trip_id, "lodging")
+    option_id = lodging["shortlist"]["lodging_options"][0]["option_id"]
+
+    selected = service.select_lodging({"trip_id": trip_id, "option_id": option_id})
+    assert selected["shortlist"]["recommended_option_id"] == option_id
+    chosen = next(
+        option
+        for option in selected["shortlist"]["lodging_options"]
+        if option["option_id"] == option_id
+    )
+    assert chosen["row_status"] == "approved"
+
+    updated = service.update_lodging_structure(
+        {
+            "trip_id": trip_id,
+            "strategy": "split_stay",
+            "night_plan": [
+                {
+                    "region": "Ponta Delgada",
+                    "nights": 4,
+                    "lodging_option_id": option_id,
+                    "notes": "central first base",
+                },
+                {
+                    "region": "Furnas",
+                    "nights": 3,
+                    "notes": "hot springs side of the island",
+                },
+            ],
+            "notes": "Testing whether a same-island split reduces backtracking.",
+        }
+    )
+
+    structure = updated["shortlist"]["artifacts"]["lodging_structure"]
+    assert structure["strategy"] == "split_stay"
+    assert structure["data_status"] == "manual_override"
+    assert structure["night_plan"][0]["region"] == "Ponta Delgada"
+    assert structure["night_plan"][1]["nights"] == 3
+    assert structure["selected_lodging_option_id"] == option_id
+
+    logs = service.logs(trip_id=trip_id)
+    assert any(event["title"] == "ui-trip-plan-lodging-select" for event in logs["events"])
+    assert any(event["title"] == "ui-trip-plan-lodging-structure" for event in logs["events"])
+
+
+def test_ui_lodging_for_couple_does_not_force_family_bed_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+    intake_result = service.create_intake(
+        {
+            "trip_name": "Azores Couple 2027",
+            "destinations": "Azores",
+            "travel_window": "September 2027 flexible",
+            "duration": "6 to 8 days",
+            "party_type": "couple",
+            "travelers": 2,
+            "adults": 2,
+            "children": 0,
+            "roster": "Ken|adult, Sue|adult",
+            "departure_airports": "YYZ",
+            "goals": "food, scenery, low friction",
+            "avoidances": "huge crowds, stressful transfers",
+        }
+    )
+    trip_id = intake_result["intake"]["trip_id"]
+    draft = service.draft_plan(trip_id)
+    service.select_plan(trip_id, draft["draft"]["recommended_option_id"])
+
+    result = service.build_shortlist(trip_id, "lodging")
+
+    first = result["shortlist"]["lodging_options"][0]
+    assert "king" in first["bed_layout"]
+    assert "family+room+3+beds" not in first["deep_link"]
+    assert "king+room" in first["deep_link"]
+
+
+def test_ui_can_approve_and_schedule_activity_for_timeline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+    trip_id = _create_selected_trip(service)
+    activities = service.build_shortlist(trip_id, "activities")
+    option_id = activities["shortlist"]["activity_options"][0]["option_id"]
+
+    approved = service.select_activity({"trip_id": trip_id, "option_id": option_id})
+    chosen = next(
+        option
+        for option in approved["shortlist"]["activity_options"]
+        if option["option_id"] == option_id
+    )
+    assert chosen["row_status"] == "approved"
+    assert chosen["scheduled_day"] == chosen["suggested_day"]
+    assert approved["shortlist"]["artifacts"]["activity_schedule"]["entries"]
+
+    scheduled = service.schedule_activity(
+        {
+            "trip_id": trip_id,
+            "option_id": option_id,
+            "day": 4,
+            "date": "2027-06-18",
+            "start_time": "10:15",
+            "end_time": "13:00",
+            "fixed": True,
+            "notes": "Manual move after reviewing lodging base.",
+        }
+    )
+    moved = next(
+        option
+        for option in scheduled["shortlist"]["activity_options"]
+        if option["option_id"] == option_id
+    )
+    assert moved["scheduled_day"] == 4
+    assert moved["scheduled_start_time"] == "10:15"
+    assert moved["scheduled_flexibility"] == "fixed"
+
+    workspace = service.build_workspace(trip_id, create_google_sheet=False)
+    timeline = next(
+        tab for tab in workspace["workspace"]["tabs"] if tab["name"] == "Master Timeline"
+    )["rows"]
+    assert any(row[5] == "activity" and row[2] == "10:15" for row in timeline)
+    assert any("Manual move" in row[18] for row in timeline)
+
+    logs = service.logs(trip_id=trip_id)
+    assert any(event["title"] == "ui-trip-plan-activity-select" for event in logs["events"])
+    assert any(event["title"] == "ui-trip-plan-activity-schedule" for event in logs["events"])
 
 
 def test_ui_flight_candidate_is_evaluated_in_shortlist(
@@ -231,6 +415,35 @@ def test_ui_select_flight_updates_canonical_shortlist(
     assert chosen["date_viability_signal"]
     logs = service.logs(trip_id=trip_id)
     assert any(event["title"] == "ui-trip-plan-flight-select" for event in logs["events"])
+
+
+def test_ui_can_select_car_for_local_movement_planning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+    trip_id = _create_selected_trip(service)
+    cars = service.build_shortlist(trip_id, "cars")
+    option_id = cars["shortlist"]["car_options"][1]["option_id"]
+
+    result = service.select_car({"trip_id": trip_id, "option_id": option_id})
+
+    assert result["shortlist"]["recommended_option_id"] == option_id
+    chosen = [
+        option for option in result["shortlist"]["car_options"] if option["option_id"] == option_id
+    ][0]
+    assert chosen["row_status"] == "approved"
+    assert chosen["price_band"]
+    assert chosen["comparison_links"]["Expedia"].startswith("https://www.expedia.ca/Cars-Search")
+    assert result["shortlist"]["artifacts"]["selected_car_option_id"] == option_id
+
+    workspace = service.build_workspace(trip_id, create_google_sheet=False)
+    cars_tab = next(tab for tab in workspace["workspace"]["tabs"] if tab["name"] == "Cars")
+    assert any(row[1] == "approved" for row in cars_tab["rows"])
+
+    logs = service.logs(trip_id=trip_id)
+    assert any(event["title"] == "ui-trip-plan-car-select" for event in logs["events"])
 
 
 def test_ui_lodging_candidate_can_run_deep_source_research(

--- a/trippy-local-backup.patch
+++ b/trippy-local-backup.patch
@@ -1,0 +1,7134 @@
+diff --git a/tests/unit/test_trip_ideation.py b/tests/unit/test_trip_ideation.py
+index 5043e36..6369d83 100644
+--- a/tests/unit/test_trip_ideation.py
++++ b/tests/unit/test_trip_ideation.py
+@@ -26,12 +26,11 @@ def test_trip_ideas_rank_food_focused_options() -> None:
+ def test_trip_ideas_penalize_long_flights_for_short_max() -> None:
+     comparison = TripIdeationService().compare(
+         TripIdeaRequest(
+-            duration_days=7,
+             max_flight_hours=6,
+             goals=["food"],
+             avoid=["crowds"],
+         ),
+-        limit=10,
++        limit=20,
+     )
+ 
+     japan = next(c for c in comparison.concepts if c.concept_id == "japan-food-rail-cities")
+@@ -59,6 +58,66 @@ def test_trip_ideas_respect_short_duration_before_generic_ranking() -> None:
+     assert any("Requested duration is 6" in note for note in comparison.scoring_notes)
+ 
+ 
++def test_trip_ideas_respect_explicit_caribbean_region_intent() -> None:
++    comparison = TripIdeationService().compare(
++        TripIdeaRequest(
++            duration_days=6,
++            travelers=2,
++            max_flight_hours=8,
++            goals=["Caribbean", "beach", "great food"],
++            avoid=["huge crowds", "stressful transfers"],
++        ),
++        limit=3,
++    )
++
++    concept_ids = {concept.concept_id for concept in comparison.concepts}
++    assert len(comparison.concepts) == 3
++    assert "azores-sao-miguel-short-comfort" not in concept_ids
++    assert concept_ids <= {
++        "belize-reef-jungle-short",
++        "curacao-color-beach-drivable-short",
++        "st-lucia-private-rental-food-short",
++        "mexico-caribbean-food-beach-short",
++    }
++    assert all(concept.recommended_duration_days <= 6 for concept in comparison.concepts)
++    assert any(
++        "Explicit destination intent detected: caribbean" in note
++        for note in comparison.scoring_notes
++    )
++
++
++def test_trip_ideas_treat_snorkeling_as_required_experience() -> None:
++    comparison = TripIdeationService().compare(
++        TripIdeaRequest(
++            time_of_year="march break",
++            duration_days=7,
++            travelers=5,
++            max_flight_hours=5,
++            goals=["great food", "low friction", "memorable snorkling"],
++            avoid=["huge crowds", "stressful transfers"],
++        ),
++        limit=3,
++    )
++
++    concept_ids = {concept.concept_id for concept in comparison.concepts}
++    assert len(comparison.concepts) == 3
++    assert concept_ids <= {
++        "belize-reef-jungle-short",
++        "cayman-reef-food-easy-week",
++        "curacao-color-beach-drivable-short",
++        "mexico-caribbean-food-beach-short",
++    }
++    assert "quebec-city-montreal-food-short" not in concept_ids
++    assert "mexico-city-food-short" not in concept_ids
++    assert "azores-sao-miguel-short-comfort" not in concept_ids
++    assert all(
++        any("snorkeling" in item for item in concept.rationale) for concept in comparison.concepts
++    )
++    assert any(
++        "Required experience detected: snorkeling" in note for note in comparison.scoring_notes
++    )
++
++
+ def test_trip_ideas_include_country_prior_rationale() -> None:
+     comparison = TripIdeationService().compare(
+         TripIdeaRequest(duration_days=14, goals=["food", "culture"]),
+diff --git a/tests/unit/test_trip_planning_pipeline.py b/tests/unit/test_trip_planning_pipeline.py
+index acc56e5..6dcaa62 100644
+--- a/tests/unit/test_trip_planning_pipeline.py
++++ b/tests/unit/test_trip_planning_pipeline.py
+@@ -43,6 +43,7 @@ from trippy.services.shortlist_store import ShortlistStore
+ from trippy.services.source_research import (
+     LinkResearchAdapter,
+     OpenClawResearchAdapter,
++    PlaywrightActivityAdapter,
+     PlaywrightFlightAdapter,
+     PlaywrightLodgingAdapter,
+     SourceResearchService,
+@@ -143,6 +144,18 @@ def test_azores_golden_path_services(
+     assert b"YYZ" in tfs_payload
+     assert b"PDL" in tfs_payload
+     assert b"2027-06-15" in tfs_payload
++    flight_links = [
++        link
++        for option in flights.flight_options
++        for link in [option.deep_link, *option.comparison_links.values()]
++    ]
++    assert all("Flights-Search" not in link for link in flight_links)
++    assert all("flighthub.com" not in link for link in flight_links)
++    assert any(
++        "ca.kayak.com/flights/YYZ-PDL/2027-06-15/2027-06-25/5adults"
++        in link
++        for link in flight_links
++    )
+     assert any(
+         "placeholder search dates" in note for note in flights.flight_options[0].confidence_notes
+     )
+@@ -153,6 +166,16 @@ def test_azores_golden_path_services(
+     assert "Flights-Search" not in cars.car_options[1].deep_link
+     assert "/flights/" not in cars.car_options[2].deep_link
+     assert activities.activity_options[0].source == "GetYourGuide"
++    activity_links = [
++        link
++        for option in activities.activity_options
++        for link in [option.deep_link, *option.validation_links.values()]
++    ]
++    assert all("airbnb.ca" not in link for link in activity_links)
++    assert all(
++        "Airbnb Experiences" not in option.validation_links
++        for option in activities.activity_options
++    )
+     assert flights.flight_options[0].row_status == ShortlistRowStatus.RESEARCHED
+     assert (
+         flights.flight_options[0].validation.verification_status
+@@ -589,6 +612,98 @@ def test_flight_deep_research_enriches_existing_shortlist_state(
+     assert first.date_viability_signal
+ 
+ 
++def test_flight_shortlist_uses_duffel_live_offers_when_configured(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_planning_paths(tmp_path, monkeypatch)
++    monkeypatch.setattr("trippy.config.DUFFEL_ACCESS_TOKEN", "test-token")
++
++    def fake_duffel_request(token: str, payload: dict[str, object]) -> dict[str, object]:
++        assert token == "test-token"
++        data = payload["data"]
++        assert isinstance(data, dict)
++        slices = data["slices"]
++        assert isinstance(slices, list)
++        assert slices[0]["origin"] == "YYZ"
++        assert slices[0]["destination"] == "PDL"
++        return {
++            "data": {
++                "offers": [
++                    {
++                        "id": "off_live_1",
++                        "total_amount": "1180.00",
++                        "total_currency": "CAD",
++                        "owner": {"name": "Azores Airlines"},
++                        "slices": [
++                            {
++                                "duration": "PT5H55M",
++                                "segments": [
++                                    {
++                                        "departing_at": "2027-06-15T21:15:00-04:00",
++                                        "arriving_at": "2027-06-16T07:10:00+00:00",
++                                        "origin": {"iata_code": "YYZ"},
++                                        "destination": {"iata_code": "PDL"},
++                                        "marketing_carrier": {
++                                            "iata_code": "S4",
++                                            "name": "Azores Airlines",
++                                        },
++                                        "operating_carrier": {"name": "Azores Airlines"},
++                                        "marketing_carrier_flight_number": "332",
++                                    }
++                                ],
++                            },
++                            {
++                                "duration": "PT6H20M",
++                                "segments": [
++                                    {
++                                        "departing_at": "2027-06-22T10:00:00+00:00",
++                                        "arriving_at": "2027-06-22T14:20:00-04:00",
++                                        "origin": {"iata_code": "PDL"},
++                                        "destination": {"iata_code": "YYZ"},
++                                        "marketing_carrier": {
++                                            "iata_code": "S4",
++                                            "name": "Azores Airlines",
++                                        },
++                                        "operating_carrier": {"name": "Azores Airlines"},
++                                        "marketing_carrier_flight_number": "331",
++                                    }
++                                ],
++                            },
++                        ],
++                    }
++                ]
++            }
++        }
++
++    monkeypatch.setattr(
++        "trippy.services.flight_shortlist._post_duffel_offer_request",
++        fake_duffel_request,
++    )
++    intake_service = TripIntakeService()
++    intake = intake_service.create(_azores_intake())
++    planner = TripPlannerService(intake_service)
++    planner.draft(intake.trip_id)
++    planner.select_option(intake.trip_id, "azores-two-island-balanced")
++
++    flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
++    option = flights.flight_options[0]
++
++    assert option.option_id == "duffel-flight-1"
++    assert option.booking_source == "Duffel"
++    assert option.flight_numbers == ["S4332"]
++    assert option.departure_date == "2027-06-15"
++    assert option.departure_time == "9:15 PM"
++    assert option.arrival_date == "2027-06-16"
++    assert option.arrival_time == "7:10 AM"
++    assert option.total_travel_duration == "5h 55m"
++    assert option.price_band == "CAD 1180.00 total"
++    assert option.deep_link.startswith("https://www.google.com/travel/flights/search?")
++    assert option.row_status == ShortlistRowStatus.VERIFIED_LIVE
++    assert option.validation.adapter_used == "duffel"
++    assert "Duffel returned 1 exact offer row" in " ".join(flights.warnings)
++
++
+ def test_flight_deep_research_handles_partial_secondary_source_text(
+     tmp_path: Path,
+     monkeypatch: pytest.MonkeyPatch,
+@@ -767,6 +882,65 @@ def test_selecting_lodging_and_manual_split_drives_workspace_timeline(
+     assert any("second base" in row[18] for row in timeline)
+ 
+ 
++def test_lodging_service_suggests_editable_split_stay_options(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_planning_paths(tmp_path, monkeypatch)
++    intake_service = TripIntakeService()
++    intake = intake_service.create(_azores_intake())
++    planner = TripPlannerService(intake_service)
++    planner.draft(intake.trip_id)
++    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
++
++    lodging_service = LodgingShortlistService(intake_service, planner)
++    lodging_service.build(intake.trip_id)
++    updated = lodging_service.suggest_stay_structures(intake.trip_id, use_llm=False)
++
++    structure = updated.artifacts["lodging_structure"]
++    options = structure["options"]
++    assert len(options) == 3
++    assert {option["strategy"] for option in options} == {"single_stay", "split_stay"}
++    assert all(option["night_plan"] for option in options)
++    assert any(
++        any("Furnas" in stay["region"] for stay in option["night_plan"]) for option in options
++    )
++    assert len({option["thumbnail_variant"] for option in options}) >= 2
++
++
++def test_lodging_split_seeds_options_for_each_saved_base(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_planning_paths(tmp_path, monkeypatch)
++    intake_service = TripIntakeService()
++    intake = intake_service.create(_azores_intake())
++    planner = TripPlannerService(intake_service)
++    planner.draft(intake.trip_id)
++    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
++
++    lodging_service = LodgingShortlistService(intake_service, planner)
++    lodging_service.build(intake.trip_id)
++    updated = lodging_service.update_stay_structure(
++        intake.trip_id,
++        strategy="split_stay",
++        night_plan=[
++            {"region": "Ponta Delgada / south coast", "nights": 4},
++            {"region": "Ribeira Grande / north coast", "nights": 2},
++        ],
++        notes="Testing a north-coast second base.",
++    )
++
++    regions = [option.location_area for option in updated.lodging_options]
++    assert any("Ponta Delgada" in region for region in regions)
++    assert any("Ribeira Grande" in region for region in regions)
++    ribeira = next(
++        option for option in updated.lodging_options if "Ribeira Grande" in option.location_area
++    )
++    assert ribeira.option_id.startswith("stay-region-lodging-ribeira-grande")
++    assert any("location-specific search seed" in flag for flag in ribeira.friction_flags)
++
++
+ def test_selected_plan_shapes_research_targets(
+     tmp_path: Path,
+     monkeypatch: pytest.MonkeyPatch,
+@@ -791,6 +965,91 @@ def test_selected_plan_shapes_research_targets(
+     assert all("Faial" not in option.island_location for option in activities.activity_options)
+ 
+ 
++def test_generic_activity_shortlist_offers_multiple_specific_choices(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_planning_paths(tmp_path, monkeypatch)
++    intake_service = TripIntakeService()
++    intake = intake_service.create(
++        TripIntake(
++            mode=TripIntakeMode.SELECTED_DESTINATION,
++            trip_name="Grand Cayman",
++            destination_seeds=[
++                "Seven Mile Beach",
++                "West Bay",
++                "Stingray City or Rum Point",
++            ],
++            duration_days=7,
++            party=TripParty(
++                party_type=TripPartyType.WHOLE_FAMILY,
++                adults=2,
++                children=3,
++                explicit=True,
++            ),
++        )
++    )
++    planner = TripPlannerService(intake_service)
++    planner.draft(intake.trip_id)
++    planner.select_option(intake.trip_id, "single-base-easy")
++
++    activities = ActivityShortlistService(intake_service, planner).build(intake.trip_id)
++
++    assert len(activities.activity_options) >= 5
++    names = " ".join(option.activity_name for option in activities.activity_options)
++    assert "Seven Mile Beach" in names
++    assert "West Bay" in names
++    assert "Stingray" in names
++    assert all(option.price_band == "source price required" for option in activities.activity_options)
++    assert all(
++        option.duration == "source schedule required" for option in activities.activity_options
++    )
++    assert all(not option.suggested_start_time for option in activities.activity_options)
++    assert all("airbnb.ca" not in option.deep_link for option in activities.activity_options)
++
++
++def test_activity_deep_research_extracts_cost_time_and_availability(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_planning_paths(tmp_path, monkeypatch)
++
++    def fake_fetcher(url: str, timeout: float) -> tuple[str, str, list[str]]:
++        return (
++            """
++            <html><body>
++            <h1>Stingray Sandbar small-group tour</h1>
++            <p>From C$89 per person. Check availability. Free cancellation.</p>
++            <p>Starts at 9:30 AM and ends at 12:30 PM. Duration 3 hours.</p>
++            <p>Small group limited to 10. Rated 4.8 out of 5.</p>
++            </body></html>
++            """,
++            url,
++            ["fixture activity page"],
++        )
++
++    intake_service = TripIntakeService()
++    intake = intake_service.create(_azores_intake())
++    planner = TripPlannerService(intake_service)
++    planner.draft(intake.trip_id)
++    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
++    activities = ActivityShortlistService(intake_service, planner).build(intake.trip_id)
++
++    researched = SourceResearchService(
++        adapters=[PlaywrightActivityAdapter(fetcher=fake_fetcher)],
++        research_dir=tmp_path / "research",
++    ).research_state(activities, adapter_mode="playwright")
++    option = researched.activity_options[0]
++
++    assert option.price_band == "C$89 per person"
++    assert option.duration in {"3 hours", "3 h"}
++    assert option.suggested_start_time == "9:30 AM"
++    assert option.suggested_end_time == "12:30 PM"
++    assert "availability_signal" in option.validation.extracted_fields
++    assert option.validation.price_status.value == "live_signal"
++    assert option.validation.availability_status.value == "availability_signal"
++
++
+ def test_trip_party_edge_cases_are_visible() -> None:
+     couple = TripIntake(
+         mode=TripIntakeMode.SELECTED_DESTINATION,
+@@ -834,6 +1093,85 @@ def test_trip_party_edge_cases_are_visible() -> None:
+     assert "defaulted; confirm roster" in unnamed.party.summary()
+ 
+ 
++def test_generic_single_base_plan_uses_one_lodging_base(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_planning_paths(tmp_path, monkeypatch)
++    intake_service = TripIntakeService()
++    intake = intake_service.create(
++        TripIntake(
++            mode=TripIntakeMode.SELECTED_DESTINATION,
++            trip_name="Grand Cayman",
++            destination_seeds=[
++                "Seven Mile Beach",
++                "West Bay",
++                "Stingray City or Rum Point",
++            ],
++            duration_days=7,
++            party=TripParty(
++                party_type=TripPartyType.WHOLE_FAMILY,
++                adults=2,
++                children=3,
++                explicit=True,
++            ),
++        )
++    )
++
++    planner = TripPlannerService(intake_service)
++    draft = planner.draft(intake.trip_id)
++
++    single_base = draft.get_option("single-base-easy")
++    assert single_base is not None
++    assert single_base.title == "Seven Mile Beach Single-Base Easy Version"
++    assert single_base.regions == ["Seven Mile Beach"]
++    assert single_base.nights_by_region == {"Seven Mile Beach": 6}
++
++    balanced = draft.get_option("two-region-balanced")
++    assert balanced is not None
++    assert balanced.regions == ["Seven Mile Beach", "West Bay"]
++    assert set(balanced.nights_by_region) == {"Seven Mile Beach", "West Bay"}
++
++    stale = draft.model_dump(mode="json")
++    for option in stale["options"]:
++        if option["option_id"] == "single-base-easy":
++            option["title"] = (
++                "Seven Mile Beach, West Bay, Stingray City or Rum Point Single-Base Easy Version"
++            )
++            option["regions"] = [
++                "Seven Mile Beach",
++                "West Bay",
++                "Stingray City or Rum Point",
++            ]
++            option["nights_by_region"] = {
++                "Seven Mile Beach": 2,
++                "West Bay": 2,
++                "Stingray City or Rum Point": 2,
++            }
++        if option["option_id"] == "two-region-balanced":
++            option["regions"] = [
++                "Seven Mile Beach",
++                "West Bay",
++                "Stingray City or Rum Point",
++            ]
++            option["nights_by_region"] = {
++                "Seven Mile Beach": 3,
++                "West Bay": 3,
++            }
++    planner.path_for(intake.trip_id).write_text(json.dumps(stale), encoding="utf-8")
++
++    loaded = planner.load_draft(intake.trip_id)
++    assert loaded is not None
++    loaded_single = loaded.get_option("single-base-easy")
++    assert loaded_single is not None
++    assert loaded_single.title == "Seven Mile Beach Single-Base Easy Version"
++    assert loaded_single.regions == ["Seven Mile Beach"]
++    assert loaded_single.nights_by_region == {"Seven Mile Beach": 6}
++    loaded_balanced = loaded.get_option("two-region-balanced")
++    assert loaded_balanced is not None
++    assert loaded_balanced.regions == ["Seven Mile Beach", "West Bay"]
++
++
+ def _patch_planning_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+     from trippy import config
+ 
+diff --git a/tests/unit/test_ui_server.py b/tests/unit/test_ui_server.py
+index 35c74b8..8509742 100644
+--- a/tests/unit/test_ui_server.py
++++ b/tests/unit/test_ui_server.py
+@@ -3,6 +3,7 @@
+ from __future__ import annotations
+ 
+ from pathlib import Path
++from urllib.parse import parse_qs, urlparse
+ 
+ import pytest
+ 
+@@ -175,6 +176,73 @@ def test_ui_suggest_ideas_respects_six_day_prompt_and_can_capture_idea_feedback(
+     assert any(event["event_type"] == "user_feedback" for event in logs["events"])
+ 
+ 
++def test_ui_suggest_ideas_respects_caribbean_region_intent(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_ui_paths(tmp_path, monkeypatch)
++    service = TrippyUIService()
++
++    result = service.suggest_ideas(
++        {
++            "party_type": "couple",
++            "travelers": 2,
++            "adults": 2,
++            "children": 0,
++            "time_of_year": "winter",
++            "duration_days": 6,
++            "max_flight_hours": 8,
++            "goals": "Caribbean, beach, great food",
++            "avoidances": "huge crowds, stressful transfers",
++        }
++    )
++
++    concept_ids = {concept["concept_id"] for concept in result["comparison"]["concepts"]}
++    assert len(concept_ids) == 3
++    assert "azores-sao-miguel-short-comfort" not in concept_ids
++    assert concept_ids <= {
++        "belize-reef-jungle-short",
++        "curacao-color-beach-drivable-short",
++        "st-lucia-private-rental-food-short",
++        "mexico-caribbean-food-beach-short",
++    }
++
++
++def test_ui_suggest_ideas_respects_snorkeling_requirement(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_ui_paths(tmp_path, monkeypatch)
++    service = TrippyUIService()
++
++    result = service.suggest_ideas(
++        {
++            "party_type": "whole_family",
++            "travelers": 5,
++            "adults": 2,
++            "children": 3,
++            "child_ages": "16, 14, 11",
++            "time_of_year": "march break",
++            "duration_days": 7,
++            "max_flight_hours": 5,
++            "goals": "great food, low friction, memorable snorkling",
++            "avoidances": "huge crowds, stressful transfers",
++        }
++    )
++
++    concept_ids = {concept["concept_id"] for concept in result["comparison"]["concepts"]}
++    assert len(concept_ids) == 3
++    assert "quebec-city-montreal-food-short" not in concept_ids
++    assert "mexico-city-food-short" not in concept_ids
++    assert "azores-sao-miguel-short-comfort" not in concept_ids
++    assert concept_ids <= {
++        "belize-reef-jungle-short",
++        "cayman-reef-food-easy-week",
++        "curacao-color-beach-drivable-short",
++        "mexico-caribbean-food-beach-short",
++    }
++
++
+ def test_ui_lodging_candidate_is_evaluated_in_shortlist(
+     tmp_path: Path,
+     monkeypatch: pytest.MonkeyPatch,
+@@ -267,6 +335,31 @@ def test_ui_can_select_lodging_and_override_stay_structure(
+     assert any(event["title"] == "ui-trip-plan-lodging-structure" for event in logs["events"])
+ 
+ 
++def test_ui_can_generate_stay_structure_options(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_ui_paths(tmp_path, monkeypatch)
++    service = TrippyUIService()
++    trip_id = _create_selected_trip(service)
++    service.build_shortlist(trip_id, "lodging")
++
++    result = service.suggest_lodging_structures({"trip_id": trip_id, "use_llm": False})
++    structure = result["shortlist"]["artifacts"]["lodging_structure"]
++    options = structure["options"]
++
++    assert result["option_count"] == 3
++    assert len(options) == 3
++    assert any(option["strategy"] == "split_stay" for option in options)
++    assert any(
++        any("Furnas" in stay["region"] for stay in option["night_plan"]) for option in options
++    )
++    assert any(
++        event["title"] == "ui-trip-plan-lodging-structure-suggest"
++        for event in service.logs(trip_id=trip_id)["events"]
++    )
++
++
+ def test_ui_lodging_for_couple_does_not_force_family_bed_query(
+     tmp_path: Path,
+     monkeypatch: pytest.MonkeyPatch,
+@@ -301,6 +394,63 @@ def test_ui_lodging_for_couple_does_not_force_family_bed_query(
+     assert "king+room" in first["deep_link"]
+ 
+ 
++def test_ui_booking_lodging_links_include_trip_dates_and_party(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_ui_paths(tmp_path, monkeypatch)
++    service = TrippyUIService()
++    intake_result = service.create_intake(
++        {
++            "trip_name": "Cayman Family 2027",
++            "destinations": "Seven Mile Beach, West Bay",
++            "start_date": "2027-03-13",
++            "end_date": "2027-03-19",
++            "duration": "7 days",
++            "party_type": "whole_family",
++            "adults": 2,
++            "children": 3,
++            "child_ages": "16, 14, 11",
++            "roster": "Ken|adult, Jenn|adult, Child 1|16, Child 2|14, Child 3|11",
++            "departure_airports": "YYZ",
++        }
++    )
++    trip_id = intake_result["intake"]["trip_id"]
++    draft = service.draft_plan(trip_id)
++    service.select_plan(trip_id, draft["draft"]["recommended_option_id"])
++
++    result = service.build_shortlist(trip_id, "lodging")
++
++    first = result["shortlist"]["lodging_options"][0]
++    params = parse_qs(urlparse(first["deep_link"]).query)
++    assert params["checkin"] == ["2027-03-13"]
++    assert params["checkout"] == ["2027-03-19"]
++    assert params["group_adults"] == ["2"]
++    assert params["group_children"] == ["3"]
++    assert params["age"] == ["16", "14", "11"]
++    assert params["no_rooms"] == ["1"]
++
++    user = service.add_lodging_candidate(
++        {
++            "trip_id": trip_id,
++            "name": "Oceanfront Seven Mile Beach 2 BR",
++            "link": "https://www.booking.com/hotel/ky/oceanfront-seven-mile.html",
++            "notes": "West Bay. CAD 900/night. 2 bedrooms, parking.",
++        }
++    )
++    candidate = next(
++        option
++        for option in user["shortlist"]["lodging_options"]
++        if option["option_id"].startswith("user-lodging-")
++    )
++    candidate_params = parse_qs(urlparse(candidate["deep_link"]).query)
++    assert candidate_params["checkin"] == ["2027-03-13"]
++    assert candidate_params["checkout"] == ["2027-03-19"]
++    assert candidate_params["group_adults"] == ["2"]
++    assert candidate_params["group_children"] == ["3"]
++    assert candidate_params["age"] == ["16", "14", "11"]
++
++
+ def test_ui_can_approve_and_schedule_activity_for_timeline(
+     tmp_path: Path,
+     monkeypatch: pytest.MonkeyPatch,
+@@ -368,6 +518,15 @@ def test_ui_flight_candidate_is_evaluated_in_shortlist(
+             "trip_id": trip_id,
+             "name": "Air Canada / TAP candidate",
+             "link": "https://www.google.com/travel/flights/search?tfs=test",
++            "flight_numbers": "AC880, TP1861",
++            "departure_date": "2026-08-24",
++            "departure_time": "9:15 PM",
++            "arrival_date": "2026-08-25",
++            "arrival_time": "2:20 PM",
++            "total_duration": "10h 35m",
++            "layover_airports": "LIS",
++            "layover_duration": "2h 20m",
++            "price_band": "CAD 1180 pp",
+             "notes": (
+                 "Air Canada AC880 and TAP Portugal TP1861, depart 9:15 PM, arrive 2:20 PM, "
+                 "duration 10h 35m, 1 stop via LIS, layover 2h 20m, CAD 1180 pp, checked bag included."
+@@ -383,7 +542,10 @@ def test_ui_flight_candidate_is_evaluated_in_shortlist(
+     assert len(candidates) == 1
+     candidate = candidates[0]
+     assert candidate["booking_source"] == "Google Flights"
++    assert candidate["flight_numbers"] == ["AC880", "TP1861"]
++    assert candidate["departure_date"] == "2026-08-24"
+     assert candidate["departure_time"] == "9:15 PM"
++    assert candidate["arrival_date"] == "2026-08-25"
+     assert candidate["arrival_time"] == "2:20 PM"
+     assert candidate["layover_airports"] == ["LIS"]
+     assert candidate["price_band"] == "CAD 1180 pp"
+@@ -417,6 +579,77 @@ def test_ui_select_flight_updates_canonical_shortlist(
+     assert any(event["title"] == "ui-trip-plan-flight-select" for event in logs["events"])
+ 
+ 
++def test_ui_can_confirm_core_bookings_and_hydrate_trip_packet(
++    tmp_path: Path,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    _patch_ui_paths(tmp_path, monkeypatch)
++    service = TrippyUIService()
++    trip_id = _create_selected_trip(service)
++    flights = service.build_shortlist(trip_id, "flights")
++    lodging = service.build_shortlist(trip_id, "lodging")
++    flight_id = flights["shortlist"]["flight_options"][0]["option_id"]
++    lodging_id = lodging["shortlist"]["lodging_options"][0]["option_id"]
++    service.select_flight({"trip_id": trip_id, "option_id": flight_id})
++    service.select_lodging({"trip_id": trip_id, "option_id": lodging_id})
++
++    flight_packet = service.update_trip_packet_item(
++        {
++            "trip_id": trip_id,
++            "category": "flight",
++            "option_id": flight_id,
++            "status": "confirmed",
++            "provider": "Azores Airlines",
++            "confirmation_code": "S4-ABC123",
++            "booking_link": "https://www.google.com/travel/flights",
++            "date": "2027-06-12",
++            "start_time": "21:15",
++            "end_time": "08:30",
++            "notes": "Seats still need assignment.",
++        }
++    )
++    lodging_packet = service.update_trip_packet_item(
++        {
++            "trip_id": trip_id,
++            "category": "lodging",
++            "option_id": lodging_id,
++            "status": "confirmed",
++            "provider": "Booking.com",
++            "confirmation_code": "BK-98765",
++            "booking_link": "https://www.booking.com/",
++            "address": "Ponta Delgada, Azores",
++            "date": "2027-06-13",
++            "notes": "Check-in after 15:00.",
++        }
++    )
++
++    assert flight_packet["trip_packet"]["readiness_percent"] < 100
++    assert lodging_packet["trip_packet"]["readiness_percent"] == 100
++    assert lodging_packet["trip_packet"]["status_label"] == "trip packet confirmed"
++
++    snapshot = service.trip_state(trip_id)
++    flight_state = next(
++        shortlist for shortlist in snapshot["shortlists"] if shortlist["category"] == "flights"
++    )
++    lodging_state = next(
++        shortlist for shortlist in snapshot["shortlists"] if shortlist["category"] == "lodging"
++    )
++    assert flight_state["flight_options"][0]["row_status"] == "confirmed"
++    assert lodging_state["lodging_options"][0]["row_status"] == "confirmed"
++
++    workspace = service.build_workspace(trip_id, create_google_sheet=False)
++    tabs = {tab["name"]: tab for tab in workspace["workspace"]["tabs"]}
++    packet_rows = tabs["Trip Packet"]["rows"]
++    timeline = tabs["Master Timeline"]["rows"]
++    assert any(row[4] == "S4-ABC123" for row in packet_rows)
++    assert any(row[4] == "BK-98765" for row in packet_rows)
++    assert any("S4-ABC123" in row[10] for row in timeline)
++    assert any("BK-98765" in row[10] for row in timeline)
++
++    logs = service.logs(trip_id=trip_id)
++    assert any(event["title"] == "ui-trip-packet-update" for event in logs["events"])
++
++
+ def test_ui_can_select_car_for_local_movement_planning(
+     tmp_path: Path,
+     monkeypatch: pytest.MonkeyPatch,
+diff --git a/trippy/agent.py b/trippy/agent.py
+index 9a10686..ce690d3 100644
+--- a/trippy/agent.py
++++ b/trippy/agent.py
+@@ -53,6 +53,24 @@ Prioritize practical, step-by-step guidance for:
+ Be concise, actionable, and risk-aware. Flag any high-friction timing or transfer issue.
+ """
+ 
++_PLANNING_STRATEGIST_PROMPT = """
++## Planning Strategy Requirements
++
++For trip ideas, ways to experience a destination or island, stay/split-stay structure,
++activity sequencing, and next-step recommendations:
++- Make an explicit strategy call. Do not merely list possibilities.
++- Ground the call in loaded memory, family travel preferences, country priors, the
++  trip intake, the selected plan shape, and current shortlist evidence.
++- Use `run_planning_service` before making stateful planning claims. For high-level
++  strategy questions, call `run_planning_service` with action `planning_advice` so
++  Trippy builds the preference-rich planning prompt and records the advice context.
++- Never invent source facts such as prices, availability, flight numbers, drive times,
++  bed layouts, or confirmation details. Label seeded/inferred/approximate items plainly.
++- When evidence is missing, state the exact source facts needed before booking.
++- Preserve review-gated learning. If a lesson seems reusable, propose it through the
++  reviewable learning path rather than silently changing memory or skills.
++"""
++
+ 
+ class UserIntent(StrEnum):
+     PLAN_TRIP = "plan_trip"
+@@ -101,6 +119,8 @@ def _build_system_prompt(
+     # Skills summary
+     parts.append(get_all_skill_summaries())
+ 
++    parts.append(_PLANNING_STRATEGIST_PROMPT.strip())
++
+     if operations_mode:
+         parts.append(_OPERATIONS_MODE_PROMPT.strip())
+ 
+@@ -234,6 +254,7 @@ def _skill_tools() -> list[dict[str, Any]]:
+                             "activities",
+                             "select_activity",
+                             "schedule_activity",
++                            "planning_advice",
+                             "propose_learning",
+                         ],
+                     },
+@@ -249,6 +270,16 @@ def _skill_tools() -> list[dict[str, Any]]:
+                     "avoidances": {"type": "array", "items": {"type": "string"}},
+                     "option_id": {"type": "string"},
+                     "notes": {"type": "string"},
++                    "planning_question": {
++                        "type": "string",
++                        "enum": [
++                            "trip_ideas",
++                            "trip_shape",
++                            "island_experience",
++                            "lodging_structure",
++                            "next_steps",
++                        ],
++                    },
+                     "day": {"type": "integer"},
+                     "date": {"type": "string"},
+                     "start_time": {"type": "string"},
+@@ -360,6 +391,51 @@ def _run_planning_service(inputs: dict[str, Any]) -> str:
+     deep_research = bool(inputs.get("deep_research", False))
+     adapter = str(inputs.get("adapter") or "auto")
+     try:
++        if action == "planning_advice":
++            from trippy.models.planning_advice import PlanningAdviceKind
++            from trippy.models.shortlists import ShortlistCategory
++            from trippy.services.planning_advisor import PlanningAdvisorService
++            from trippy.services.shortlist_store import ShortlistStore
++            from trippy.services.trip_intake import TripIntakeService
++            from trippy.services.trip_planner import TripPlannerService
++
++            question = str(inputs.get("planning_question") or "next_steps")
++            kind = PlanningAdviceKind(question)
++            intake = TripIntakeService().load(trip_id) if trip_id else None
++            draft = TripPlannerService().load_draft(trip_id) if trip_id else None
++            if kind == PlanningAdviceKind.LODGING_STRUCTURE and intake is not None and draft:
++                option = draft.get_option()
++                lodging_state = ShortlistStore().load(trip_id, ShortlistCategory.LODGING)
++                if option is not None:
++                    return (
++                        PlanningAdvisorService()
++                        .advise_lodging_structure(intake, option, lodging_state)
++                        .model_dump_json(indent=2)
++                    )
++            if (
++                kind
++                in {
++                    PlanningAdviceKind.TRIP_SHAPE,
++                    PlanningAdviceKind.ISLAND_EXPERIENCE,
++                }
++                and intake is not None
++                and draft is not None
++            ):
++                advisor = PlanningAdvisorService()
++                if kind == PlanningAdviceKind.ISLAND_EXPERIENCE:
++                    return advisor.advise_island_experience(intake, draft).model_dump_json(indent=2)
++                return advisor.advise_trip_shape(intake, draft).model_dump_json(indent=2)
++            shortlists = ShortlistStore().load_all(trip_id) if trip_id else []
++            return (
++                PlanningAdvisorService()
++                .advise_next_steps(
++                    intake,
++                    draft,
++                    shortlists,
++                    user_question=str(inputs.get("notes") or ""),
++                )
++                .model_dump_json(indent=2)
++            )
+         if action == "create_intake":
+             from trippy.models.trip_planning import (
+                 TravelWindow,
+diff --git a/trippy/config.py b/trippy/config.py
+index 7df579b..55f08f0 100644
+--- a/trippy/config.py
++++ b/trippy/config.py
+@@ -42,6 +42,8 @@ GOOGLE_TOKEN_PATH: Path = _expand("GOOGLE_TOKEN_PATH", "~/.trippy/google_token.j
+ 
+ # API keys
+ ANTHROPIC_API_KEY: str = os.environ.get("ANTHROPIC_API_KEY", "")
++PLANNING_LLM_MODEL: str = os.environ.get("TRIPPY_PLANNING_LLM_MODEL", "claude-sonnet-4-6")
++PLANNING_LLM_ENABLED: bool = _bool("TRIPPY_PLANNING_LLM_ENABLED", bool(ANTHROPIC_API_KEY))
+ GOOGLE_SHEETS_API_KEY: str = os.environ.get("GOOGLE_SHEETS_API_KEY", "")
+ SHERPA_API_KEY: str = os.environ.get("SHERPA_API_KEY", "")
+ DUFFEL_ACCESS_TOKEN: str = os.environ.get("DUFFEL_ACCESS_TOKEN", "")
+diff --git a/trippy/models/ideas.py b/trippy/models/ideas.py
+index 23b0e43..d415b80 100644
+--- a/trippy/models/ideas.py
++++ b/trippy/models/ideas.py
+@@ -2,6 +2,8 @@
+ 
+ from __future__ import annotations
+ 
++from typing import Any
++
+ from pydantic import BaseModel, Field
+ 
+ 
+@@ -10,6 +12,9 @@ class TripIdeaRequest(BaseModel):
+     duration_days: int | None = None
+     budget_cad: float | None = None
+     travelers: int = 5
++    party_type: str | None = None
++    adults: int | None = None
++    children: int | None = None
+     max_flight_hours: float | None = None
+     direct_flight_preferred: bool = True
+     goals: list[str] = Field(default_factory=list)
+@@ -46,3 +51,4 @@ class TripComparison(BaseModel):
+     concepts: list[TripConcept]
+     recommended_concept_id: str | None = None
+     scoring_notes: list[str] = Field(default_factory=list)
++    advisor: dict[str, Any] = Field(default_factory=dict)
+diff --git a/trippy/models/shortlists.py b/trippy/models/shortlists.py
+index 2b4a088..46c3217 100644
+--- a/trippy/models/shortlists.py
++++ b/trippy/models/shortlists.py
+@@ -40,6 +40,7 @@ class ShortlistRowStatus(StrEnum):
+     REJECTED = "rejected"
+     APPROVED = "approved"
+     BOOKED = "booked"
++    CONFIRMED = "confirmed"
+ 
+ 
+ class VerificationStatus(StrEnum):
+@@ -114,6 +115,8 @@ class FlightOption(BaseModel):
+     rank: int
+     airline: str
+     flight_numbers: list[str] = Field(default_factory=list)
++    departure_date: str = ""
++    arrival_date: str = ""
+     departure_airport: str
+     arrival_airport: str
+     departure_time: str = ""
+diff --git a/trippy/models/trip_planning.py b/trippy/models/trip_planning.py
+index d9fa293..7d88e47 100644
+--- a/trippy/models/trip_planning.py
++++ b/trippy/models/trip_planning.py
+@@ -392,6 +392,7 @@ class TripPlanDraft(BaseModel):
+     selected_option_id: str | None = None
+     assumptions: list[str] = Field(default_factory=list)
+     source_notes: list[str] = Field(default_factory=list)
++    advisor: dict[str, Any] = Field(default_factory=dict)
+ 
+     def get_option(self, option_id: str | None = None) -> TripPlanOption | None:
+         selected = option_id or self.selected_option_id or self.recommended_option_id
+diff --git a/trippy/services/activity_shortlist.py b/trippy/services/activity_shortlist.py
+index 4528185..955a852 100644
+--- a/trippy/services/activity_shortlist.py
++++ b/trippy/services/activity_shortlist.py
+@@ -160,15 +160,20 @@ def _options_from_profile(
+     intake: TripIntake,
+     selected_regions: list[str],
+ ) -> list[ActivityOption]:
+-    targets = [
+-        target
+-        for target in getattr(profile, "activity_search_targets", [])
+-        if target_matches_selected_regions(
+-            target,
+-            selected_regions,
+-            getattr(profile, "island_or_region_terms", []),
+-        )
+-    ]
++    raw_targets = list(getattr(profile, "activity_search_targets", []))
++    targets = (
++        raw_targets
++        if getattr(profile, "key", "") == "generic"
++        else [
++            target
++            for target in raw_targets
++            if target_matches_selected_regions(
++                target,
++                selected_regions,
++                getattr(profile, "island_or_region_terms", []),
++            )
++        ]
++    )
+     party = intake.party
+     traveler_count = party.total_travelers
+     has_children = party.has_children
+@@ -198,12 +203,11 @@ def _options_from_profile(
+                     if has_children
+                     else f"Must fit {traveler_count} adult traveler(s)."
+                 ),
+-                price_band="live verify per person/family total",
+-                duration="half-day target unless explicitly planned as a full-day anchor",
++                price_band="source price required",
++                duration="source schedule required",
+                 deep_link=source_search_url("GetYourGuide", query),
+                 validation_links={
+                     "Tripadvisor": source_search_url("Tripadvisor", query),
+-                    "Airbnb Experiences": source_search_url("Airbnb Experiences", query),
+                 },
+                 family_pace_fit_score=88 if idx <= 3 else 74,
+                 safety_confidence_score=78,
+@@ -220,7 +224,7 @@ def _options_from_profile(
+                 ],
+                 friction_flags=flags,
+                 confidence_notes=[
+-                    "Source link is the start of live validation, not a confirmed booking option."
++                    "Source research must extract current cost, bookable time, duration, and availability before booking."
+                 ],
+                 live_data_status=LiveDataStatus.HANDOFF_REQUIRED,
+             )
+@@ -245,14 +249,16 @@ def _apply_activity_schedule_suggestions(
+ ) -> None:
+     anchors = _stay_day_anchors(option, lodging_state)
+     used_days: set[int] = set()
+-    for idx, activity in enumerate(state.activity_options, start=1):
++    for activity in state.activity_options:
+         anchor = _best_anchor_for_activity(activity, anchors) or anchors[0]
+         day = _suggested_activity_day(
+             anchor, used_days, int(getattr(option, "duration_days", 0) or 0)
+         )
+         used_days.add(day)
+-        start_time = "09:30" if idx % 2 else "14:00"
+-        end_time = _default_end_time(start_time, activity.duration)
++        start_time = _source_field(activity, "start_time")
++        end_time = _source_field(activity, "end_time") or (
++            _default_end_time(start_time, activity.duration) if start_time else ""
++        )
+         date_value = _date_for_day(intake.travel_window.start_date, day)
+         activity.suggested_day = day
+         activity.suggested_date = date_value.isoformat() if date_value else ""
+@@ -265,6 +271,13 @@ def _apply_activity_schedule_suggestions(
+     _write_activity_schedule_artifact(state)
+ 
+ 
++def _source_field(activity: ActivityOption, field: str) -> str:
++    value = ""
++    if activity.validation and isinstance(activity.validation.extracted_fields, dict):
++        value = str(activity.validation.extracted_fields.get(field) or "").strip()
++    return value
++
++
+ def _merge_existing_activity_state(
+     state: ResearchShortlistState,
+     existing: ResearchShortlistState | None,
+@@ -345,6 +358,13 @@ def _write_activity_schedule_artifact(state: ResearchShortlistState) -> None:
+                 "notes": option.scheduling_notes,
+             }
+         )
++    entries.sort(
++        key=lambda entry: (
++            int(entry.get("scheduled_day") or entry.get("suggested_day") or 999),
++            str(entry.get("scheduled_start_time") or entry.get("suggested_start_time") or "99:99"),
++            str(entry.get("activity_name") or ""),
++        )
++    )
+     state.artifacts["activity_schedule"] = {
+         "data_status": "suggested_and_manual",
+         "summary": (
+diff --git a/trippy/services/destination_profiles.py b/trippy/services/destination_profiles.py
+index 48fed69..ded4f08 100644
+--- a/trippy/services/destination_profiles.py
++++ b/trippy/services/destination_profiles.py
+@@ -51,16 +51,56 @@ def profile_for_intake(intake: TripIntake) -> DestinationProfile:
+                 "query": f"{destination} car rental SUV minivan family luggage",
+             }
+         ],
+-        activity_search_targets=[
+-            {
+-                "name": f"{destination} small-group family activities",
+-                "location": destination,
+-                "query": f"{destination} small group family activities",
+-            }
+-        ],
++        activity_search_targets=_generic_activity_search_targets(intake, destination),
+     )
+ 
+ 
++def _generic_activity_search_targets(
++    intake: TripIntake,
++    destination: str,
++) -> list[dict[str, str]]:
++    seeds = [seed.strip() for seed in intake.destination_seeds if seed.strip()] or [destination]
++    targets: list[dict[str, str]] = []
++    for seed in seeds[:5]:
++        lower = seed.lower()
++        if "stingray" in lower:
++            name = f"{seed} family stingray and sandbar tour"
++            query = f"{seed} small group family stingray sandbar tour"
++        elif "rum point" in lower:
++            name = f"{seed} family boat and beach day"
++            query = f"{seed} small group family boat beach tour"
++        elif any(term in lower for term in ["beach", "bay", "island", "coast"]):
++            name = f"{seed} family snorkeling or beach activity"
++            query = f"{seed} family snorkeling beach activity small group"
++        else:
++            name = f"{seed} family-friendly guided activity"
++            query = f"{seed} family friendly guided activity small group"
++        targets.append({"name": name, "location": seed, "query": query})
++    if len(targets) < 5:
++        targets.extend(
++            [
++                {
++                    "name": f"{destination} private family highlights tour",
++                    "location": destination,
++                    "query": f"{destination} private family highlights tour",
++                },
++                {
++                    "name": f"{destination} family food or culture experience",
++                    "location": destination,
++                    "query": f"{destination} family food culture experience",
++                },
++            ]
++        )
++    deduped: list[dict[str, str]] = []
++    seen: set[str] = set()
++    for target in targets:
++        key = target["query"].lower()
++        if key not in seen:
++            seen.add(key)
++            deduped.append(target)
++    return deduped[:8]
++
++
+ _AZORES = DestinationProfile(
+     key="azores",
+     title="Azores, Portugal",
+diff --git a/trippy/services/flight_shortlist.py b/trippy/services/flight_shortlist.py
+index ac28883..616b819 100644
+--- a/trippy/services/flight_shortlist.py
++++ b/trippy/services/flight_shortlist.py
+@@ -3,17 +3,27 @@
+ from __future__ import annotations
+ 
+ import base64
++import json
+ import re
+-from datetime import date, timedelta
++from datetime import date, datetime, timedelta
++from urllib.error import HTTPError, URLError
+ from urllib.parse import urlencode, urlparse
++from urllib.request import Request, urlopen
+ 
++from trippy import config
+ from trippy.models.shortlists import (
++    AvailabilityStatus,
+     FlightOption,
++    FreshnessStatus,
+     LiveDataStatus,
++    PriceStatus,
+     RecommendationGrade,
+     ResearchShortlistState,
+     ShortlistCategory,
+     ShortlistRowStatus,
++    SourceType,
++    SourceValidation,
++    VerificationStatus,
+ )
+ from trippy.models.sources import TravelSourceCategory
+ from trippy.services.destination_profiles import profile_for_intake
+@@ -23,8 +33,6 @@ from trippy.services.shortlist_store import (
+     ShortlistStore,
+     source_plan,
+     source_plan_payload,
+-    source_search_url,
+-    trip_query,
+ )
+ from trippy.services.source_research import SourceResearchService
+ from trippy.services.trip_intake import TripIntakeService
+@@ -59,9 +67,9 @@ class FlightShortlistService:
+         )
+         plan = source_plan(TravelSourceCategory.FLIGHTS)
+         profile = profile_for_intake(ctx.intake)
+-        options = _azores_options(
+-            ctx, profile.gateway_airports[0] if profile.gateway_airports else "destination"
+-        )
++        gateway = profile.gateway_airports[0] if profile.gateway_airports else "destination"
++        live_options, live_notes = _duffel_live_options(ctx, gateway)
++        options = live_options or _azores_options(ctx, gateway)
+         state = ResearchShortlistState(
+             trip_id=trip_id,
+             category=ShortlistCategory.FLIGHTS,
+@@ -74,12 +82,21 @@ class FlightShortlistService:
+                 "availability, fare rules, baggage, seats, and Aeroplan eligibility before handoff."
+             ),
+             warnings=[
+-                "Flight numbers and fares are not asserted unless the source link confirms them live.",
++                (
++                    "Live Duffel offers populated exact flight rows."
++                    if live_options
++                    else "Flight numbers and fares are not asserted unless a live provider or source link confirms them."
++                ),
++                *live_notes,
+                 *profile.flight_notes,
+             ],
+             next_actions=[
+-                "Open the Google Flights link for the top option and verify exact dates.",
+-                "Cross-check the same routing on Kayak.ca, Expedia, and Flighthub.",
++                (
++                    "Review the live provider offer details, then cross-check the top option in Google Flights."
++                    if live_options
++                    else "Configure DUFFEL_ACCESS_TOKEN or add a flight candidate with exact itinerary text to replace placeholders."
++                ),
++                "Cross-check the same routing on Kayak.ca before booking.",
+                 "Reject multi-ticket routings unless airport, baggage, and delay protection are clearly acceptable.",
+             ],
+         )
+@@ -172,16 +189,7 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
+     traveler_count = ctx.intake.party.total_travelers
+     party_note = ctx.intake.party.summary()
+     date_hint = _flight_date_hint(ctx)
+-    query_base = trip_query(
+-        ctx.intake,
+-        f"flights {origin} to {gateway} {traveler_count} travelers",
+-    )
+-    comparison = {
+-        "Google Flights": _flight_source_url("Google Flights", origin, gateway, ctx),
+-        "Kayak.ca": _flight_source_url("Kayak.ca", origin, gateway, ctx),
+-        "Expedia": _flight_source_url("Expedia", origin, gateway, ctx),
+-        "Flighthub": source_search_url("Flighthub", query_base),
+-    }
++    comparison = _flight_comparison_links(origin, gateway, ctx)
+     return [
+         FlightOption(
+             option_id="flight-direct-yyz-pdl",
+@@ -286,10 +294,7 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
+             deep_link=_flight_source_url("Kayak.ca", origin, gateway, ctx),
+             traveler_count=traveler_count,
+             traveler_fit=f"Weak fit for {party_note} unless protected, because luggage/recheck risk scales with party size.",
+-            comparison_links={
+-                "Google Flights": _flight_source_url("Google Flights", origin, gateway, ctx),
+-                "Expedia": _flight_source_url("Expedia", origin, gateway, ctx),
+-            },
++            comparison_links=_flight_comparison_links(origin, gateway, ctx),
+             aeroplan_relevance="Possible on the Toronto-Boston leg only; weak overall unless same-ticket.",
+             friction_score=48,
+             family_comfort_score=62,
+@@ -311,6 +316,228 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
+     ]
+ 
+ 
++def _duffel_live_options(
++    ctx: ShortlistContext,
++    gateway: str,
++) -> tuple[list[FlightOption], list[str]]:
++    token = config.DUFFEL_ACCESS_TOKEN.strip()
++    if not token:
++        return [], ["DUFFEL_ACCESS_TOKEN is not configured, so flight rows are search handoffs."]
++    origin = _iata_or_text(
++        ctx.intake.departure_airports[0] if ctx.intake.departure_airports else "YYZ"
++    )
++    destination = _iata_or_text(gateway)
++    if not _looks_like_iata(origin) or not _looks_like_iata(destination):
++        return [], [
++            f"Duffel live search skipped because route codes are not IATA: {origin} to {destination}."
++        ]
++    departure_date, return_date = _flight_dates(ctx)
++    try:
++        payload = _duffel_offer_request_payload(
++            ctx, origin, destination, departure_date, return_date
++        )
++        response = _post_duffel_offer_request(token, payload)
++    except (HTTPError, URLError, TimeoutError, OSError, ValueError) as exc:
++        return [], [f"Duffel live flight search failed: {exc}"]
++    offers = list((response.get("data") or {}).get("offers") or [])
++    if not offers:
++        return [], ["Duffel returned no live offers for this route/date search."]
++    comparison = _flight_comparison_links(origin, destination, ctx)
++    options = [
++        option
++        for option in (
++            _duffel_offer_to_option(offer, index, ctx, origin, destination, comparison)
++            for index, offer in enumerate(offers[:8], start=1)
++        )
++        if option is not None
++    ]
++    return options, [
++        f"Duffel returned {len(options)} exact offer row(s) for {origin}-{destination}.",
++        "Duffel prices are live offer signals but can expire; verify before booking.",
++    ]
++
++
++def _duffel_offer_request_payload(
++    ctx: ShortlistContext,
++    origin: str,
++    destination: str,
++    departure_date: date,
++    return_date: date,
++) -> dict[str, object]:
++    return {
++        "data": {
++            "slices": [
++                {
++                    "origin": origin,
++                    "destination": destination,
++                    "departure_date": departure_date.isoformat(),
++                },
++                {
++                    "origin": destination,
++                    "destination": origin,
++                    "departure_date": return_date.isoformat(),
++                },
++            ],
++            "passengers": _duffel_passengers(ctx),
++            "cabin_class": "economy",
++            "max_connections": 1,
++        }
++    }
++
++
++def _duffel_passengers(ctx: ShortlistContext) -> list[dict[str, object]]:
++    party = ctx.intake.party
++    passengers: list[dict[str, object]] = []
++    passengers.extend({"type": "adult"} for _ in range(max(1, party.adults or 1)))
++    child_ages = list(party.child_ages or [])
++    for index in range(max(0, party.children)):
++        if index < len(child_ages):
++            passengers.append({"age": int(child_ages[index])})
++        else:
++            passengers.append({"type": "child"})
++    total = ctx.intake.party.total_travelers or ctx.intake.travelers or len(passengers)
++    while len(passengers) < total:
++        passengers.append({"type": "adult"})
++    return passengers
++
++
++def _post_duffel_offer_request(token: str, payload: dict[str, object]) -> dict[str, object]:
++    body = json.dumps(payload).encode("utf-8")
++    request = Request(
++        "https://api.duffel.com/air/offer_requests?return_offers=true&supplier_timeout=10000",
++        data=body,
++        headers={
++            "Accept": "application/json",
++            "Content-Type": "application/json",
++            "Duffel-Version": "v2",
++            "Authorization": f"Bearer {token}",
++            "User-Agent": "Trippy/0.2 flight-offer-search",
++        },
++        method="POST",
++    )
++    with urlopen(request, timeout=max(15, config.SOURCE_RESEARCH_TIMEOUT_SECONDS)) as response:  # noqa: S310 - configured authenticated API endpoint
++        return json.loads(response.read().decode("utf-8"))
++
++
++def _duffel_offer_to_option(
++    offer: dict[str, object],
++    rank: int,
++    ctx: ShortlistContext,
++    origin: str,
++    destination: str,
++    comparison: dict[str, str],
++) -> FlightOption | None:
++    slices = [item for item in offer.get("slices", []) if isinstance(item, dict)]
++    if not slices:
++        return None
++    outbound = slices[0]
++    segments = [item for item in outbound.get("segments", []) if isinstance(item, dict)]
++    if not segments:
++        return None
++    first = segments[0]
++    last = segments[-1]
++    flight_numbers = [_segment_flight_number(segment) for segment in segments]
++    flight_numbers = [number for number in flight_numbers if number]
++    carriers = _segment_carriers(segments)
++    owner = offer.get("owner")
++    owner_name = str(owner.get("name") or "") if isinstance(owner, dict) else ""
++    airline = " / ".join(carriers) if carriers else owner_name or "Live flight offer"
++    departing_at = str(first.get("departing_at") or "")
++    arriving_at = str(last.get("arriving_at") or "")
++    departure_date, departure_time = _split_duffel_timestamp(departing_at)
++    arrival_date, arrival_time = _split_duffel_timestamp(arriving_at)
++    stops = max(0, len(segments) - 1)
++    layover_airports = [
++        str(destination.get("iata_code") or "")
++        for segment in segments[:-1]
++        if isinstance(destination := segment.get("destination"), dict)
++    ]
++    layover_airports = [airport for airport in layover_airports if airport]
++    layover_duration = _duffel_layover_duration(segments)
++    duration = _duffel_duration(outbound, first, last)
++    price = _duffel_price(offer)
++    google_link = _flight_source_url("Google Flights", origin, destination, ctx)
++    offer_id = str(offer.get("id") or f"duffel-offer-{rank}")
++    validation = SourceValidation(
++        source_name="Duffel",
++        source_type=SourceType.LIVE_SEARCH,
++        verified_at=datetime.utcnow(),
++        freshness_status=FreshnessStatus.CURRENT,
++        verification_status=VerificationStatus.LIVE_VERIFIED,
++        availability_status=AvailabilityStatus.AVAILABILITY_SIGNAL,
++        price_status=PriceStatus.LIVE_SIGNAL if price else PriceStatus.UNKNOWN,
++        confidence=0.86,
++        evidence_url=f"duffel:{offer_id}",
++        adapter_used="duffel",
++        extracted_fields={
++            "airline": airline,
++            "flight_numbers": flight_numbers,
++            "departure_date": departure_date,
++            "arrival_date": arrival_date,
++            "departure_time": departure_time,
++            "arrival_time": arrival_time,
++            "total_duration": duration,
++            "stops": stops,
++            "layover_airports": layover_airports,
++            "layover_duration": layover_duration or "",
++            "price_signal": price,
++            "availability_signal": "live offer returned",
++            "offer_id": offer_id,
++        },
++        notes=[
++            "Offer came from Duffel live flight search; fare and inventory can expire.",
++            "Cross-check public search links before booking if not purchasing through Duffel.",
++        ],
++        missing_fields=[],
++    )
++    friction = min(
++        90,
++        8 + stops * 16 + (8 if layover_duration and "overnight" in layover_duration.lower() else 0),
++    )
++    comfort = max(35, 94 - stops * 12)
++    return FlightOption(
++        option_id=f"duffel-flight-{rank}",
++        rank=rank,
++        airline=airline,
++        flight_numbers=flight_numbers,
++        departure_date=departure_date,
++        arrival_date=arrival_date,
++        departure_airport=_segment_airport(first, "origin") or origin,
++        arrival_airport=_segment_airport(last, "destination") or destination,
++        departure_time=departure_time,
++        arrival_time=arrival_time,
++        stops=stops,
++        layover_airports=layover_airports,
++        layover_duration=layover_duration,
++        total_travel_duration=duration,
++        timing_fit=_timing_fit(arrival_time, departure_time),
++        fare_estimate_cad=price,
++        price_band=price,
++        baggage_cabin_notes=_duffel_baggage_notes(offer),
++        booking_source="Duffel",
++        deep_link=google_link,
++        traveler_count=ctx.intake.party.total_travelers,
++        traveler_fit=f"Live offer for {ctx.intake.party.summary()}; verify fare expiry, baggage, seats, and booking channel.",
++        comparison_links={**comparison, "Duffel offer id": offer_id},
++        aeroplan_relevance="Verify earning by carrier and fare class before assuming Aeroplan value.",
++        friction_score=friction,
++        family_comfort_score=comfort,
++        recommendation_grade=RecommendationGrade.STRONG if stops == 0 else RecommendationGrade.GOOD,
++        tradeoffs=[
++            "Specific live offer with flight numbers, times, duration, and fare signal.",
++            "Offer may expire or reprice before booking.",
++        ],
++        friction_flags=_planning_timing_flags_for_values(stops, layover_duration),
++        confidence_notes=[
++            "Exact itinerary fields came from Duffel offer segments.",
++            f"Duffel offer id: {offer_id}",
++        ],
++        live_data_status=LiveDataStatus.LIVE_VERIFIED,
++        row_status=ShortlistRowStatus.VERIFIED_LIVE,
++        validation=validation,
++    )
++
++
+ def _user_candidate_option(
+     state: ResearchShortlistState,
+     ctx: ShortlistContext,
+@@ -329,6 +556,8 @@ def _user_candidate_option(
+     duration = _duration_from_notes(notes) or "duration not supplied"
+     departure = _time_from_notes(notes, ["depart", "departure", "leaves", "outbound"])
+     arrival = _time_from_notes(notes, ["arrive", "arrival", "lands"])
++    departure_date = _date_from_notes(notes, ["depart", "departure", "outbound", "leave", "leaves"])
++    arrival_date = _date_from_notes(notes, ["arrive", "arrival", "lands"])
+     price = _price_signal(notes) or "not supplied"
+     flags = []
+     if stops is None:
+@@ -360,6 +589,8 @@ def _user_candidate_option(
+         rank=rank,
+         airline=display_name,
+         flight_numbers=_flight_numbers(notes),
++        departure_date=departure_date,
++        arrival_date=arrival_date,
+         departure_airport=origin,
+         arrival_airport=destination,
+         departure_time=departure or "not supplied",
+@@ -446,22 +677,161 @@ def _flight_source_url(
+             f"{origin_code}-{destination_code}/{departure_date.isoformat()}/{return_date.isoformat()}"
+             f"/{total_travelers}adults?sort=bestflight_a"
+         )
+-    if source == "Expedia":
+-        return "https://www.expedia.ca/Flights-Search?" + urlencode(
+-            {
+-                "trip": "roundtrip",
+-                "leg1": f"from:{origin_code},to:{destination_code},departure:{departure_date.isoformat()}TANYT",
+-                "leg2": f"from:{destination_code},to:{origin_code},departure:{return_date.isoformat()}TANYT",
+-                "passengers": f"adults:{adults}",
+-                "mode": "search",
+-            }
+-        )
+-    query = trip_query(
+-        ctx.intake,
+-        f"flights {origin_code} to {destination_code} {total_travelers} travelers "
+-        f"{departure_date.isoformat()} return {return_date.isoformat()}",
++    return _flight_source_url("Google Flights", origin_code, destination_code, ctx)
++
++
++def _flight_comparison_links(
++    origin: str,
++    destination: str,
++    ctx: ShortlistContext,
++) -> dict[str, str]:
++    """Only expose providers with route URLs that reliably preserve search fields."""
++    return {
++        "Google Flights": _flight_source_url("Google Flights", origin, destination, ctx),
++        "Kayak.ca": _flight_source_url("Kayak.ca", origin, destination, ctx),
++    }
++
++
++def _looks_like_iata(value: str) -> bool:
++    return bool(re.fullmatch(r"[A-Z]{3}", value.strip().upper()))
++
++
++def _segment_flight_number(segment: dict[str, object]) -> str:
++    carrier = segment.get("marketing_carrier")
++    carrier_code = ""
++    if isinstance(carrier, dict):
++        carrier_code = str(carrier.get("iata_code") or "")
++    number = str(
++        segment.get("marketing_carrier_flight_number") or segment.get("flight_number") or ""
++    )
++    return f"{carrier_code}{number}".strip().upper() if number else ""
++
++
++def _segment_carriers(segments: list[dict[str, object]]) -> list[str]:
++    carriers: list[str] = []
++    for segment in segments:
++        carrier = segment.get("operating_carrier") or segment.get("marketing_carrier")
++        name = ""
++        if isinstance(carrier, dict):
++            name = str(carrier.get("name") or carrier.get("iata_code") or "")
++        if name and name not in carriers:
++            carriers.append(name)
++    return carriers
++
++
++def _segment_airport(segment: dict[str, object], key: str) -> str:
++    airport = segment.get(key)
++    if isinstance(airport, dict):
++        return str(airport.get("iata_code") or "")
++    return ""
++
++
++def _split_duffel_timestamp(value: str) -> tuple[str, str]:
++    if not value:
++        return "", ""
++    try:
++        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
++    except ValueError:
++        return value[:10], value[11:16] if len(value) >= 16 else ""
++    return parsed.date().isoformat(), parsed.strftime("%-I:%M %p")
++
++
++def _duffel_duration(
++    outbound_slice: dict[str, object],
++    first_segment: dict[str, object],
++    last_segment: dict[str, object],
++) -> str:
++    duration = str(outbound_slice.get("duration") or "")
++    if duration:
++        return _format_iso_duration(duration)
++    start = _parse_duffel_datetime(str(first_segment.get("departing_at") or ""))
++    end = _parse_duffel_datetime(str(last_segment.get("arriving_at") or ""))
++    if not start or not end:
++        return "duration unavailable"
++    return _format_minutes(int((end - start).total_seconds() // 60))
++
++
++def _duffel_layover_duration(segments: list[dict[str, object]]) -> str | None:
++    if len(segments) <= 1:
++        return None
++    pieces: list[str] = []
++    for previous, next_segment in zip(segments, segments[1:], strict=False):
++        arrival = _parse_duffel_datetime(str(previous.get("arriving_at") or ""))
++        departure = _parse_duffel_datetime(str(next_segment.get("departing_at") or ""))
++        airport = ""
++        destination = previous.get("destination")
++        if isinstance(destination, dict):
++            airport = str(destination.get("iata_code") or "")
++        if arrival and departure:
++            pieces.append(
++                f"{airport} {_format_minutes(int((departure - arrival).total_seconds() // 60))}".strip()
++            )
++    return ", ".join(pieces) or None
++
++
++def _parse_duffel_datetime(value: str) -> datetime | None:
++    if not value:
++        return None
++    try:
++        return datetime.fromisoformat(value.replace("Z", "+00:00"))
++    except ValueError:
++        return None
++
++
++def _format_iso_duration(value: str) -> str:
++    match = re.fullmatch(r"P(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?", value)
++    if not match:
++        return value
++    hours = int(match.group(1) or 0)
++    minutes = int(match.group(2) or 0)
++    return _format_minutes(hours * 60 + minutes)
++
++
++def _format_minutes(total_minutes: int) -> str:
++    if total_minutes <= 0:
++        return "duration unavailable"
++    hours, minutes = divmod(total_minutes, 60)
++    if hours and minutes:
++        return f"{hours}h {minutes}m"
++    if hours:
++        return f"{hours}h"
++    return f"{minutes}m"
++
++
++def _duffel_price(offer: dict[str, object]) -> str:
++    amount = str(offer.get("total_amount") or "")
++    currency = str(offer.get("total_currency") or "")
++    if not amount:
++        return "live fare returned; amount unavailable"
++    if currency.upper() == "CAD":
++        return f"CAD {amount} total"
++    return f"{currency} {amount} total".strip()
++
++
++def _duffel_baggage_notes(offer: dict[str, object]) -> str:
++    conditions = offer.get("conditions")
++    notes: list[str] = []
++    if isinstance(conditions, dict):
++        for key in ("refund_before_departure", "change_before_departure"):
++            value = conditions.get(key)
++            if isinstance(value, dict) and value.get("allowed") is not None:
++                notes.append(
++                    f"{key.replace('_', ' ')}: {'allowed' if value.get('allowed') else 'not allowed'}"
++                )
++    return (
++        "; ".join(notes) or "Validate bags, seats, fare rules, and family seating before booking."
+     )
+-    return source_search_url(source, query)
++
++
++def _planning_timing_flags_for_values(stops: int, layover_duration: str | None) -> list[str]:
++    flags: list[str] = []
++    if stops > 1:
++        flags.append("multiple connections increase travel-day friction")
++    elif stops == 1:
++        flags.append("connection timing must be checked against family luggage and delay risk")
++    if layover_duration and "overnight" in layover_duration.lower():
++        flags.append("overnight layover requires lodging plan")
++    return flags
+ 
+ 
+ def _flight_date_hint(ctx: ShortlistContext) -> str:
+@@ -969,6 +1339,19 @@ def _time_from_notes(notes: str, labels: list[str]) -> str:
+     return match.group(1).strip() if match else ""
+ 
+ 
++def _date_from_notes(notes: str, labels: list[str]) -> str:
++    label_pattern = "|".join(re.escape(label) for label in labels)
++    match = re.search(
++        rf"(?:{label_pattern})(?:ure|s|ing)?\s*(?:date)?\s*(?:on|:|-)?\s*"
++        r"((?:20\d{2}-\d{2}-\d{2})|(?:\d{4}-\d{2}-\d{2})|"
++        r"(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+20\d{2})|"
++        r"(?:\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+20\d{2}))",
++        notes,
++        flags=re.IGNORECASE,
++    )
++    return " ".join(match.group(1).replace(",", "").split()) if match else ""
++
++
+ def _layover_duration_from_notes(notes: str) -> str | None:
+     match = re.search(
+         r"(?:layover|connection)\s*(?:of|:|-)?\s*((?:\d+\s?h(?:ours?)?)\s*(?:\d+\s?m(?:in(?:utes?)?)?)?)",
+diff --git a/trippy/services/live_validation.py b/trippy/services/live_validation.py
+index 94a1bea..a2adcdc 100644
+--- a/trippy/services/live_validation.py
++++ b/trippy/services/live_validation.py
+@@ -67,18 +67,22 @@ class LiveValidationService:
+         validation = getattr(option, "validation", SourceValidation())
+         validation.source_name = source_name
+         validation.source_type = _source_type(option)
+-        validation.evidence_url = url
++        validation.evidence_url = validation.evidence_url or url
+         validation.missing_fields = _missing_fields(option, state, validation)
+         validation.notes = _dedupe_notes([*_base_notes(option, state), *validation.notes])
+         if not attempt_network:
+-            if validation.verification_status != VerificationStatus.LIVE_VERIFIED:
++            if validation.verification_status == VerificationStatus.LIVE_VERIFIED:
++                validation.freshness_status = FreshnessStatus.CURRENT
++                option.row_status = ShortlistRowStatus.VERIFIED_LIVE
++                option.live_data_status = LiveDataStatus.LIVE_VERIFIED
++            else:
+                 validation.verification_status = VerificationStatus.MANUAL_REQUIRED
+-            validation.freshness_status = FreshnessStatus.UNKNOWN
+-            validation.availability_status = AvailabilityStatus.UNKNOWN
+-            validation.price_status = _price_status(option)
+-            validation.confidence = min(validation.confidence, 0.55)
+-            option.row_status = ShortlistRowStatus.RESEARCHED
+-            option.live_data_status = LiveDataStatus.HANDOFF_REQUIRED
++                validation.freshness_status = FreshnessStatus.UNKNOWN
++                validation.availability_status = AvailabilityStatus.UNKNOWN
++                validation.price_status = _price_status(option)
++                validation.confidence = min(validation.confidence, 0.55)
++                option.row_status = ShortlistRowStatus.RESEARCHED
++                option.live_data_status = LiveDataStatus.HANDOFF_REQUIRED
+             option.validation = validation
+             return
+ 
+diff --git a/trippy/services/lodging_shortlist.py b/trippy/services/lodging_shortlist.py
+index 8b93e82..eafd4ab 100644
+--- a/trippy/services/lodging_shortlist.py
++++ b/trippy/services/lodging_shortlist.py
+@@ -2,7 +2,9 @@
+ 
+ from __future__ import annotations
+ 
+-from urllib.parse import urlparse
++import re
++from datetime import timedelta
++from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+ 
+ from trippy.models.shortlists import (
+     LiveDataStatus,
+@@ -17,6 +19,7 @@ from trippy.models.sources import TravelSourceCategory
+ from trippy.models.trip_planning import TripIntake, TripPlanOption
+ from trippy.services.destination_profiles import profile_for_intake
+ from trippy.services.live_validation import LiveValidationService
++from trippy.services.planning_advisor import PlanningAdvisorService
+ from trippy.services.shortlist_store import (
+     ShortlistContext,
+     ShortlistStore,
+@@ -118,6 +121,24 @@ class LodgingShortlistService:
+                 "lodging_structure": _lodging_structure_guidance(ctx.option, ctx.intake),
+             },
+         )
++        advisor = PlanningAdvisorService(enabled=False).advise_lodging_structure(
++            ctx.intake,
++            ctx.option,
++            state,
++        )
++        state.artifacts["planning_advisor"] = advisor.model_dump(mode="json")
++        structure = state.artifacts.get("lodging_structure")
++        if isinstance(structure, dict):
++            structure["options"] = _stay_structure_options(ctx.option, ctx.intake)
++            structure["recommended_structure_id"] = (
++                structure["options"][0]["structure_id"] if structure["options"] else ""
++            )
++            structure["advisor_status"] = advisor.status
++            structure["advisor_summary"] = advisor.summary
++            if advisor.stay_strategy in {"single_stay", "split_stay", "unclear"}:
++                structure["advisor_stay_strategy"] = advisor.stay_strategy
++            if advisor.night_plan:
++                structure["advisor_night_plan"] = advisor.night_plan
+         LiveValidationService().validate_state(state, attempt_network=validate_live)
+         if deep_research:
+             SourceResearchService().research_state(state, adapter_mode=adapter_mode)
+@@ -195,6 +216,10 @@ class LodgingShortlistService:
+         if notes:
+             reasoning.append(notes)
+         selected_lodging = state.recommended_option_id
++        previous_structure = state.artifacts.get("lodging_structure", {})
++        existing_options = (
++            previous_structure.get("options", []) if isinstance(previous_structure, dict) else []
++        )
+         state.artifacts["lodging_structure"] = {
+             "strategy": strategy_value,
+             "confidence": "manual",
+@@ -207,17 +232,65 @@ class LodgingShortlistService:
+             "lodging_strategy": ctx.option.lodging_strategy,
+             "selected_lodging_option_id": selected_lodging,
+             "manual_notes": notes,
++            "options": existing_options,
+             "tradeoffs": [
+                 ctx.option.island_region_movement_friction,
+                 "Manual split plans still need exact check-in/out, luggage, parking, and transfer validation.",
+             ],
+         }
++        _ensure_options_for_stay_regions(state, ctx.intake, normalized)
+         state.next_actions.insert(
+             0,
+             "Review the manual stay structure against flights, check-in/out times, driving burden, and activities.",
+         )
+         return self._store.save(state)
+ 
++    def suggest_stay_structures(
++        self,
++        trip_id: str,
++        *,
++        use_llm: bool = True,
++    ) -> ResearchShortlistState:
++        """Generate editable one-base and split-stay options for the selected plan."""
++        ctx = ShortlistContext(
++            trip_id,
++            intake_service=self._intakes,
++            planner_service=self._planner,
++        )
++        state = self._store.load(trip_id, ShortlistCategory.LODGING)
++        if state is None:
++            state = self.build(trip_id, validate_live=False)
++
++        structure = state.artifacts.setdefault(
++            "lodging_structure",
++            _lodging_structure_guidance(ctx.option, ctx.intake),
++        )
++        if not isinstance(structure, dict):
++            structure = _lodging_structure_guidance(ctx.option, ctx.intake)
++            state.artifacts["lodging_structure"] = structure
++
++        options = _stay_structure_options(ctx.option, ctx.intake)
++        advisor = PlanningAdvisorService(enabled=use_llm).advise_lodging_structure(
++            ctx.intake,
++            ctx.option,
++            state,
++        )
++        advisor_option = _advisor_stay_structure_option(advisor, ctx.option, ctx.intake)
++        if advisor_option:
++            options = _dedupe_structure_options([advisor_option, *options])
++
++        structure["options"] = options[:3]
++        structure["recommended_structure_id"] = options[0]["structure_id"] if options else ""
++        structure["advisor_status"] = advisor.status
++        structure["advisor_summary"] = advisor.summary
++        structure["advisor_recommendation"] = advisor.recommendation
++        structure["advisor_confidence"] = advisor.confidence
++        state.next_actions.insert(
++            0,
++            "Pick a stay-structure option or edit the night allocation before choosing exact lodging.",
++        )
++        return self._store.save(state)
++
+     def add_candidate(
+         self,
+         trip_id: str,
+@@ -297,8 +370,9 @@ def _options_from_profile(
+         query = _query_for_party(str(target["query"]), requires_three_beds)
+         validation = {
+             "Tripadvisor": source_search_url("Tripadvisor", query),
+-            "Booking.com": source_search_url("Booking.com", query),
++            "Booking.com": _lodging_source_url("Booking.com", query, intake),
+         }
++        deep_link = _lodging_source_url(source, query, intake)
+         is_private = target.get("lodging_type") == "private rental"
+         bed_fit_known = True if is_private else None
+         king_known = None
+@@ -359,14 +433,14 @@ def _options_from_profile(
+                 comfort_fit=_comfort_fit(fit_category, party.summary()),
+                 fit_category=fit_category,
+                 bed_layout_confidence=0.62 if is_private else 0.28,
+-                current_availability_signal="not live-checked yet",
+-                current_price_signal="estimated/search handoff only",
++                current_availability_signal="live availability required",
++                current_price_signal="live price required",
+                 parking_practicality=parking,
+                 driving_practicality="good only if roads, driveway, and loading access are clear",
+                 walkability="validate restaurants/groceries and whether driving is required every meal",
+                 cancellation_notes="live-verify free cancellation/refund deadline before handoff",
+                 price_band="live verify; compare total stay cost including taxes/fees",
+-                deep_link=source_search_url(source, query),
++                deep_link=deep_link,
+                 validation_links=validation,
+                 friction_score=score,
+                 family_comfort_score=comfort,
+@@ -406,6 +480,73 @@ def _query_for_party(query: str, requires_three_beds: bool) -> str:
+     return adjusted
+ 
+ 
++def _lodging_source_url(source: str, query: str, intake: TripIntake) -> str:
++    if source == "Booking.com":
++        return _booking_url(query, intake)
++    return source_search_url(source, query)
++
++
++def _normalize_lodging_link(link: str, intake: TripIntake) -> str:
++    parsed = urlparse(link)
++    if "booking.com" not in parsed.netloc.lower():
++        return link
++    return _booking_url("", intake, base_url=link)
++
++
++def _booking_url(query: str, intake: TripIntake, *, base_url: str = "") -> str:
++    parsed = urlparse(base_url or "https://www.booking.com/searchresults.html")
++    existing = dict(parse_qsl(parsed.query, keep_blank_values=True))
++    params: dict[str, object] = {
++        **existing,
++        "group_adults": max(1, intake.party.adults or intake.party.total_travelers or 1),
++        "group_children": max(0, intake.party.children or 0),
++        "no_rooms": 1,
++        "selected_currency": "CAD",
++    }
++    if query and not base_url:
++        params.update({"ss": query, "sb": 1, "src": "searchresults"})
++    checkin, checkout = _booking_dates(intake)
++    if checkin and checkout:
++        params["checkin"] = checkin
++        params["checkout"] = checkout
++    ages = _booking_child_ages(intake)
++    if ages:
++        params["age"] = ages
++    return urlunparse(
++        (
++            parsed.scheme or "https",
++            parsed.netloc or "www.booking.com",
++            parsed.path or "/searchresults.html",
++            parsed.params,
++            urlencode(params, doseq=True),
++            parsed.fragment,
++        )
++    )
++
++
++def _booking_dates(intake: TripIntake) -> tuple[str, str]:
++    start = intake.travel_window.start_date
++    if not start:
++        return "", ""
++    end = intake.travel_window.end_date
++    if end is None:
++        nights = max(1, (intake.duration_days or intake.duration_min_days or 2) - 1)
++        end = start + timedelta(days=nights)
++    if end <= start:
++        end = start + timedelta(days=1)
++    return start.isoformat(), end.isoformat()
++
++
++def _booking_child_ages(intake: TripIntake) -> list[int]:
++    child_count = max(0, intake.party.children or 0)
++    if child_count == 0:
++        return []
++    ages = list(intake.party.child_ages or [])[:child_count]
++    while len(ages) < child_count:
++        ages.append(10)
++    return [max(0, min(17, int(age))) for age in ages]
++
++
+ def _lodging_structure_guidance(
+     option: TripPlanOption,
+     intake: TripIntake,
+@@ -458,6 +599,323 @@ def _lodging_structure_guidance(
+     }
+ 
+ 
++def _stay_structure_options(
++    option: TripPlanOption,
++    intake: TripIntake,
++) -> list[dict[str, object]]:
++    total_nights = _structure_total_nights(option, intake)
++    selected_regions = [region for region in option.regions if region]
++    existing = [
++        {"region": region, "nights": nights}
++        for region, nights in option.nights_by_region.items()
++        if nights
++    ]
++    if len(existing) > 1:
++        return _multi_region_structure_options(option, total_nights, existing)
++    primary = (
++        existing[0]["region"]
++        if existing
++        else selected_regions[0]
++        if selected_regions
++        else "Main base"
++    )
++    return _single_region_structure_options(option, intake, str(primary), total_nights)
++
++
++def _single_region_structure_options(
++    option: TripPlanOption,
++    intake: TripIntake,
++    primary_region: str,
++    total_nights: int,
++) -> list[dict[str, object]]:
++    anchors = _same_region_stay_anchors(primary_region, intake)
++    split_a = _two_part_split(total_nights, short_second=True)
++    split_b = _two_part_split(total_nights, short_second=False)
++    return [
++        {
++            "structure_id": "stay-one-base",
++            "title": f"One base: {primary_region}",
++            "strategy": "single_stay",
++            "recommendation_label": "smoothest",
++            "confidence": "plan-based",
++            "summary": "Best default if one location keeps drives reasonable and protects unpacking ease.",
++            "night_plan": [
++                {
++                    "region": primary_region,
++                    "nights": total_nights,
++                    "lodging_option_id": "",
++                    "notes": "single base; lowest check-in/luggage friction",
++                }
++            ],
++            "reasoning": [
++                "One check-in and one bed-layout validation keeps the trip simpler.",
++                "Use this if daily drives from the base are acceptable and food access is strong.",
++            ],
++            "tradeoffs": [
++                option.island_region_movement_friction,
++                "May create backtracking if activities cluster far from the base.",
++            ],
++            "map_regions": [primary_region],
++            "thumbnail_variant": 1,
++        },
++        {
++            "structure_id": "stay-central-plus-scenic",
++            "title": f"{anchors[0]} + {anchors[1]}",
++            "strategy": "split_stay",
++            "recommendation_label": "balanced split",
++            "confidence": "planner-suggested",
++            "summary": "Tests whether a short second base cuts backtracking enough to justify repacking.",
++            "night_plan": [
++                {
++                    "region": anchors[0],
++                    "nights": split_a[0],
++                    "lodging_option_id": "",
++                    "notes": "arrival/food/airport-friendly base",
++                },
++                {
++                    "region": anchors[1],
++                    "nights": split_a[1],
++                    "lodging_option_id": "",
++                    "notes": "activity-side base; verify check-in and parking",
++                },
++            ],
++            "reasoning": [
++                "Keeps most nights in the practical base while giving the far side of the destination its own window.",
++                "Only worth it if the second location has a lodging win and activities nearby.",
++            ],
++            "tradeoffs": [
++                "Adds one checkout/check-in and luggage move.",
++                "Can reduce late-day driving after remote activities.",
++            ],
++            "map_regions": anchors[:2],
++            "thumbnail_variant": 2,
++        },
++        {
++            "structure_id": "stay-loop-split",
++            "title": f"{anchors[2]} + {anchors[0]}",
++            "strategy": "split_stay",
++            "recommendation_label": "route-first",
++            "confidence": "planner-suggested",
++            "summary": "Starts or ends near a different activity cluster so the route feels less repetitive.",
++            "night_plan": [
++                {
++                    "region": anchors[2],
++                    "nights": split_b[0],
++                    "lodging_option_id": "",
++                    "notes": "scenic/activity cluster first; validate road and parking comfort",
++                },
++                {
++                    "region": anchors[0],
++                    "nights": split_b[1],
++                    "lodging_option_id": "",
++                    "notes": "finish near food/airport logistics",
++                },
++            ],
++            "reasoning": [
++                "Useful if the best activities naturally form a loop instead of out-and-back drives.",
++                "Return to the practical base before departure if flight timing or airport access matters.",
++            ],
++            "tradeoffs": [
++                "More sequencing-dependent than the balanced split.",
++                "Reject if exact lodging options make the second base weaker or less comfortable.",
++            ],
++            "map_regions": [anchors[2], anchors[0]],
++            "thumbnail_variant": 3,
++        },
++    ]
++
++
++def _multi_region_structure_options(
++    option: TripPlanOption,
++    total_nights: int,
++    existing: list[dict[str, object]],
++) -> list[dict[str, object]]:
++    primary = str(existing[0]["region"])
++    secondary = str(existing[1]["region"]) if len(existing) > 1 else primary
++    consolidated_nights = max(1, total_nights - 2)
++    return [
++        {
++            "structure_id": "stay-plan-default",
++            "title": "Use selected trip shape",
++            "strategy": "split_stay",
++            "recommendation_label": "shape-based",
++            "confidence": "plan-based",
++            "summary": "Matches the chosen plan and avoids excessive backtracking between regions.",
++            "night_plan": [
++                {
++                    "region": str(item["region"]),
++                    "nights": int(str(item["nights"])),
++                    "lodging_option_id": "",
++                    "notes": "from selected plan shape",
++                }
++                for item in existing
++            ],
++            "reasoning": [
++                "The selected option already spans multiple regions.",
++                "Keep the split only if each base has strong lodging fit and protected transfer timing.",
++            ],
++            "tradeoffs": [option.island_region_movement_friction],
++            "map_regions": [str(item["region"]) for item in existing],
++            "thumbnail_variant": min(len(existing), 3),
++        },
++        {
++            "structure_id": "stay-reduced-moves",
++            "title": f"Reduce moves: {primary} + {secondary}",
++            "strategy": "split_stay",
++            "recommendation_label": "lower friction",
++            "confidence": "planner-suggested",
++            "summary": "Consolidates the trip into fewer bases if comfort beats complete coverage.",
++            "night_plan": [
++                {
++                    "region": primary,
++                    "nights": consolidated_nights,
++                    "lodging_option_id": "",
++                    "notes": "primary comfort base",
++                },
++                {
++                    "region": secondary,
++                    "nights": total_nights - consolidated_nights,
++                    "lodging_option_id": "",
++                    "notes": "secondary base only if transfer timing is clean",
++                },
++            ],
++            "reasoning": [
++                "Fewer lodging searches means fewer bed, parking, and check-in risks.",
++                "Use if the broader route starts to feel overcompressed.",
++            ],
++            "tradeoffs": ["May sacrifice coverage or create longer day trips."],
++            "map_regions": [primary, secondary],
++            "thumbnail_variant": 2,
++        },
++        {
++            "structure_id": "stay-one-base-test",
++            "title": f"Stress-test one base: {primary}",
++            "strategy": "single_stay",
++            "recommendation_label": "comfort test",
++            "confidence": "planner-suggested",
++            "summary": "Useful as a comparison baseline: only choose if drives/transfers stay comfortable.",
++            "night_plan": [
++                {
++                    "region": primary,
++                    "nights": total_nights,
++                    "lodging_option_id": "",
++                    "notes": "one-base stress test against selected multi-region shape",
++                }
++            ],
++            "reasoning": [
++                "Shows what the trip would feel like with maximum unpacking simplicity.",
++                "Reject if it creates wasted travel days or too much backtracking.",
++            ],
++            "tradeoffs": ["Likely weaker for genuinely multi-region trips."],
++            "map_regions": [primary],
++            "thumbnail_variant": 1,
++        },
++    ]
++
++
++def _advisor_stay_structure_option(
++    advisor: object,
++    option: TripPlanOption,
++    intake: TripIntake,
++) -> dict[str, object] | None:
++    night_plan = getattr(advisor, "night_plan", None) or []
++    normalized = _normalize_advisor_night_plan(night_plan)
++    if not normalized:
++        return None
++    strategy = getattr(advisor, "stay_strategy", "") or (
++        "split_stay" if len(normalized) > 1 else "single_stay"
++    )
++    return {
++        "structure_id": "stay-advisor",
++        "title": "Advisor pick",
++        "strategy": strategy if strategy in {"single_stay", "split_stay"} else "split_stay",
++        "recommendation_label": "agent call",
++        "confidence": f"advisor {getattr(advisor, 'confidence', 0.35):.0%}",
++        "summary": getattr(advisor, "recommendation", "")
++        or getattr(advisor, "summary", "")
++        or "Advisor-generated stay structure.",
++        "night_plan": normalized,
++        "reasoning": getattr(advisor, "rationale", []) or [option.lodging_strategy],
++        "tradeoffs": getattr(advisor, "warnings", []) or [option.island_region_movement_friction],
++        "map_regions": [str(item["region"]) for item in normalized],
++        "thumbnail_variant": min(max(len(normalized), 1), 3),
++        "advisor_status": getattr(advisor, "status", ""),
++        "advisor_prompt_version": getattr(advisor, "prompt_version", ""),
++        "duration_context": intake.duration_display(),
++    }
++
++
++def _normalize_advisor_night_plan(rows: list[object]) -> list[dict[str, object]]:
++    normalized: list[dict[str, object]] = []
++    for row in rows:
++        if not isinstance(row, dict):
++            continue
++        region = str(row.get("region") or row.get("location") or "").strip()
++        if not region:
++            continue
++        try:
++            nights = int(str(row.get("nights") or 0))
++        except ValueError:
++            continue
++        if nights < 1:
++            continue
++        normalized.append(
++            {
++                "region": region,
++                "nights": nights,
++                "lodging_option_id": str(row.get("lodging_option_id") or "").strip(),
++                "notes": str(row.get("reason") or row.get("notes") or "").strip(),
++            }
++        )
++    return normalized
++
++
++def _dedupe_structure_options(options: list[dict[str, object]]) -> list[dict[str, object]]:
++    seen: set[tuple[tuple[str, int], ...]] = set()
++    deduped: list[dict[str, object]] = []
++    for option in options:
++        raw_night_plan = option.get("night_plan", [])
++        night_plan = raw_night_plan if isinstance(raw_night_plan, list) else []
++        signature = tuple(
++            (str(item.get("region") or ""), int(item.get("nights") or 0))
++            for item in night_plan
++            if isinstance(item, dict)
++        )
++        if signature in seen:
++            continue
++        seen.add(signature)
++        deduped.append(option)
++    return deduped
++
++
++def _structure_total_nights(option: TripPlanOption, intake: TripIntake) -> int:
++    total = sum(int(nights) for nights in option.nights_by_region.values() if nights)
++    if total:
++        return total
++    return intake.duration_days or intake.duration_min_days or option.duration_days or 1
++
++
++def _same_region_stay_anchors(primary_region: str, intake: TripIntake) -> list[str]:
++    text = " ".join([primary_region, *intake.destination_seeds, intake.trip_name]).lower()
++    if "azores" in text or "sao miguel" in text or "são miguel" in text:
++        return ["Ponta Delgada / south coast", "Furnas / east side", "Ribeira Grande / north coast"]
++    destination = primary_region or ", ".join(intake.destination_seeds) or "destination"
++    return [
++        f"{destination} central base",
++        f"{destination} scenic/activity side",
++        f"{destination} arrival/departure-friendly base",
++    ]
++
++
++def _two_part_split(total_nights: int, *, short_second: bool) -> tuple[int, int]:
++    if total_nights <= 2:
++        return (1, max(1, total_nights - 1))
++    second = max(2, round(total_nights * 0.35)) if short_second else max(2, total_nights // 2)
++    second = min(second, total_nights - 1)
++    first = max(1, total_nights - second)
++    return (first, second)
++
++
+ def _normalize_night_plan(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+     normalized: list[dict[str, object]] = []
+     for index, row in enumerate(rows, start=1):
+@@ -484,6 +942,152 @@ def _normalize_night_plan(rows: list[dict[str, object]]) -> list[dict[str, objec
+     return normalized
+ 
+ 
++def _ensure_options_for_stay_regions(
++    state: ResearchShortlistState,
++    intake: TripIntake,
++    night_plan: list[dict[str, object]],
++) -> None:
++    next_rank = max((option.rank for option in state.lodging_options), default=0) + 1
++    for stay in night_plan:
++        region = str(stay.get("region") or "").strip()
++        if not region:
++            continue
++        if any(_lodging_option_matches_region(option, region) for option in state.lodging_options):
++            continue
++        state.lodging_options.append(
++            _stay_region_search_option(
++                state,
++                intake,
++                region=region,
++                rank=next_rank,
++            )
++        )
++        next_rank += 1
++    state.lodging_options.sort(key=lambda option: option.rank)
++
++
++def _lodging_option_matches_region(option: LodgingOption, region: str) -> bool:
++    tokens = _region_match_tokens(region)
++    if not tokens:
++        return False
++    haystack = " ".join(
++        [
++            option.name,
++            option.location_area,
++            option.island_or_region,
++            option.lodging_type,
++        ]
++    ).lower()
++    return any(token in haystack for token in tokens)
++
++
++def _stay_region_search_option(
++    state: ResearchShortlistState,
++    intake: TripIntake,
++    *,
++    region: str,
++    rank: int,
++) -> LodgingOption:
++    party = intake.party
++    traveler_count = party.total_travelers
++    requires_three_beds = traveler_count >= 5 or party.children >= 2
++    query = _query_for_party(f"{region} lodging parking walkable restaurants", requires_three_beds)
++    if requires_three_beds:
++        query = f"{query} 3 beds family"
++    option_id = f"stay-region-lodging-{_slug(region)}"
++    existing_ids = {option.option_id for option in state.lodging_options}
++    if option_id in existing_ids:
++        option_id = f"{option_id}-{rank}"
++    flags = [
++        "location-specific search seed; exact property still required",
++        "bed layout not proven",
++        "parking/access practicality not proven",
++    ]
++    return LodgingOption(
++        option_id=option_id,
++        rank=rank,
++        source="Booking.com",
++        name=f"{region} lodging search",
++        location_area=region,
++        island_or_region=", ".join(intake.destination_seeds) or region,
++        lodging_type="location-specific lodging search",
++        room_layout="search target for this stay base; choose exact property next",
++        bed_layout=(
++            "target 3+ beds; exact layout must be live-verified"
++            if requires_three_beds
++            else "king bed strongly preferred; exact layout must be verified"
++        ),
++        adult_child_fit=(
++            f"Validate {party.adults} adult(s), {party.children} child(ren), "
++            f"{traveler_count} traveler(s) total for this base."
++        ),
++        traveler_roster_supported=None,
++        min_three_beds_satisfied=None,
++        king_bed_preference_satisfied=None,
++        family_of_five_fit=None,
++        separate_room_privacy_fit=None,
++        occupancy_fit=f"Search seed only; exact occupancy for {traveler_count} traveler(s) is not proven.",
++        comfort_fit="Potential fit only after exact property, beds, cancellation, and access are verified.",
++        fit_category=LodgingFitCategory.TECHNICAL,
++        bed_layout_confidence=0.15,
++        current_availability_signal="live availability required",
++        current_price_signal="live price required",
++        parking_practicality="not proven",
++        driving_practicality="validate road access, driveway/loading, and daily route fit",
++        walkability="validate food/grocery/activity access from this base",
++        cancellation_notes="not supplied",
++        price_band="live verify; compare total stay cost including taxes/fees",
++        deep_link=_lodging_source_url("Booking.com", query, intake),
++        validation_links={
++            "Booking.com": _lodging_source_url("Booking.com", query, intake),
++            "Tripadvisor": source_search_url("Tripadvisor", f"{region} hotels lodging"),
++            "Airbnb": source_search_url("Airbnb", f"{region} vacation rental parking"),
++        },
++        friction_score=58,
++        family_comfort_score=52,
++        recommendation_grade=RecommendationGrade.CONDITIONAL,
++        tradeoffs=[
++            "Created because the chosen stay split needs lodging options for this specific base.",
++            "Promote only after exact property fit is verified.",
++        ],
++        friction_flags=flags,
++        confidence_notes=[
++            "This is a location-specific search seed, not a verified lodging recommendation."
++        ],
++        live_data_status=LiveDataStatus.SEARCH_LINK_ONLY,
++    )
++
++
++def _region_match_tokens(region: str) -> set[str]:
++    stopwords = {
++        "the",
++        "and",
++        "base",
++        "side",
++        "coast",
++        "area",
++        "near",
++        "central",
++        "north",
++        "south",
++        "east",
++        "west",
++        "sao",
++        "são",
++        "miguel",
++    }
++    return {
++        token
++        for token in re.split(r"[^a-z0-9]+", region.lower())
++        if len(token) >= 4 and token not in stopwords
++    }
++
++
++def _slug(value: str) -> str:
++    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
++    return slug or "base"
++
++
+ def _manual_structure_summary(
+     strategy: str,
+     night_plan: list[dict[str, object]],
+@@ -572,7 +1176,7 @@ def _user_candidate_option(
+         fit_category=fit_category,
+         bed_layout_confidence=0.68 if three_beds else 0.22,
+         current_availability_signal="user-supplied; live source still required",
+-        current_price_signal=price or "not supplied",
++        current_price_signal=price or "live price required",
+         parking_practicality="parking mentioned; verify exact access"
+         if parking_known
+         else "not proven",
+@@ -581,14 +1185,14 @@ def _user_candidate_option(
+         cancellation_notes="mentioned in notes; verify deadline"
+         if "cancel" in lower
+         else "not supplied",
+-        price_band=price or "not supplied",
+-        deep_link=link,
++        price_band=price or "live price required",
++        deep_link=_normalize_lodging_link(link, intake),
+         validation_links={
+             "Tripadvisor": source_search_url(
+                 "Tripadvisor", f"{display_name} {intake.travel_window.display()}"
+             ),
+-            "Booking.com": source_search_url(
+-                "Booking.com", f"{display_name} {intake.travel_window.display()}"
++            "Booking.com": _lodging_source_url(
++                "Booking.com", f"{display_name} {intake.travel_window.display()}", intake
+             ),
+         },
+         friction_score=friction,
+diff --git a/trippy/services/source_registry.py b/trippy/services/source_registry.py
+index 165e9a8..5debef8 100644
+--- a/trippy/services/source_registry.py
++++ b/trippy/services/source_registry.py
+@@ -74,7 +74,7 @@ _ROUTING: dict[TravelSourceCategory, dict[str, list[str]]] = {
+     },
+     TravelSourceCategory.TOURS: {
+         "primary": ["GetYourGuide"],
+-        "secondary": ["Airbnb Experiences"],
++        "secondary": [],
+         "validation": ["Tripadvisor"],
+     },
+     TravelSourceCategory.CAR_RENTALS: {
+diff --git a/trippy/services/source_research.py b/trippy/services/source_research.py
+index 789391e..1258a79 100644
+--- a/trippy/services/source_research.py
++++ b/trippy/services/source_research.py
+@@ -79,6 +79,7 @@ class SourceResearchService:
+             LinkResearchAdapter(),
+             PlaywrightFlightAdapter(),
+             PlaywrightLodgingAdapter(),
++            PlaywrightActivityAdapter(),
+             OpenClawResearchAdapter(),
+         ]
+ 
+@@ -97,28 +98,34 @@ class SourceResearchService:
+             "started_at": datetime.utcnow().isoformat(),
+             "category": state.category.value,
+         }
+-        if state.category not in {ShortlistCategory.LODGING, ShortlistCategory.FLIGHTS}:
++        if state.category not in {
++            ShortlistCategory.LODGING,
++            ShortlistCategory.FLIGHTS,
++            ShortlistCategory.ACTIVITIES,
++        }:
+             state.artifacts["deep_research"]["status"] = "skipped"
+             state.artifacts["deep_research"]["notes"] = [
+-                "Deep adapters are implemented for lodging and flights; other categories remain source-link validated."
++                "Deep adapters are implemented for lodging, flights, and activities; other categories remain source-link validated."
+             ]
+             return state
+ 
+         run_results: list[SourceResearchResult] = []
+         selected_option_ids = set(option_ids or [])
+-        options = (
+-            state.lodging_options
+-            if state.category == ShortlistCategory.LODGING
+-            else state.flight_options
+-        )
++        if state.category == ShortlistCategory.LODGING:
++            options = state.lodging_options
++        elif state.category == ShortlistCategory.FLIGHTS:
++            options = state.flight_options
++        else:
++            options = state.activity_options
+         for option in options:
+             if selected_option_ids and option.option_id not in selected_option_ids:
+                 continue
+-            request = (
+-                _request_for_lodging_option(state, option, mode)
+-                if state.category == ShortlistCategory.LODGING
+-                else _request_for_flight_option(state, option, mode)
+-            )
++            if state.category == ShortlistCategory.LODGING:
++                request = _request_for_lodging_option(state, option, mode)
++            elif state.category == ShortlistCategory.FLIGHTS:
++                request = _request_for_flight_option(state, option, mode)
++            else:
++                request = _request_for_activity_option(state, option, mode)
+             option_dir = (
+                 self._research_dir
+                 / state.trip_id
+@@ -129,8 +136,10 @@ class SourceResearchService:
+             result = self._research_request(request, mode=mode, artifact_dir=option_dir)
+             if state.category == ShortlistCategory.LODGING:
+                 _apply_lodging_observations(option, result, run_id=run_id)
+-            else:
++            elif state.category == ShortlistCategory.FLIGHTS:
+                 _apply_flight_observations(option, result, run_id=run_id)
++            else:
++                _apply_activity_observations(option, result, run_id=run_id)
+             run_results.append(result)
+ 
+         state.artifacts["deep_research"].update(
+@@ -151,7 +160,12 @@ class SourceResearchService:
+                 "or inventory as ready-to-click."
+             )
+             if state.category == ShortlistCategory.FLIGHTS
+-            else "Review deep-research evidence for lodging rows before treating any option as ready-to-click.",
++            else (
++                "Review deep-research evidence for activity rows before treating cost, time, duration, "
++                "or availability as ready-to-click."
++                if state.category == ShortlistCategory.ACTIVITIES
++                else "Review deep-research evidence for lodging rows before treating any option as ready-to-click."
++            ),
+         )
+         self._record_run_event(state, run_id, run_results)
+         return state
+@@ -475,6 +489,102 @@ class PlaywrightLodgingAdapter:
+         )
+ 
+ 
++class PlaywrightActivityAdapter:
++    """Browser-capable activity adapter for price, schedule, and inventory signals."""
++
++    capability = SourceAdapterCapability.PLAYWRIGHT
++
++    def __init__(
++        self,
++        *,
++        fetcher: HtmlFetcher | None = None,
++        timeout_seconds: float | None = None,
++    ) -> None:
++        self._fetcher = fetcher or _fetch_html
++        self._custom_fetcher = fetcher is not None
++        self._timeout = timeout_seconds or config.SOURCE_RESEARCH_TIMEOUT_SECONDS
++
++    def can_handle(self, request: SourceResearchRequest) -> bool:
++        return request.category == ShortlistCategory.ACTIVITIES.value and bool(request.source_url)
++
++    def research(
++        self,
++        request: SourceResearchRequest,
++        *,
++        artifact_dir: Path,
++    ) -> SourceResearchResult:
++        notes = [
++            "Read-only activity source extraction; no booking, login, payment, or cart action attempted."
++        ]
++        try:
++            if (
++                config.SOURCE_RESEARCH_PLAYWRIGHT_ENABLED
++                and not self._custom_fetcher
++                and shutil.which("npx") is not None
++            ):
++                html, final_url, fetch_notes = _fetch_html_with_playwright(
++                    request.source_url,
++                    self._timeout,
++                )
++            else:
++                html, final_url, fetch_notes = self._fetcher(request.source_url, self._timeout)
++        except (URLError, OSError, TimeoutError, ValueError) as exc:
++            return _result(
++                request,
++                adapter=self.capability,
++                status=SourceResearchStatus.BLOCKED,
++                confidence=0.2,
++                notes=[*notes, f"Activity source fetch was blocked: {exc}"],
++                missing_fields=_activity_missing_fields(),
++            )
++
++        notes.extend(fetch_notes)
++        artifact_dir.mkdir(parents=True, exist_ok=True)
++        html_path = artifact_dir / "source.html"
++        html_path.write_text(html[:500_000], encoding="utf-8")
++        text = _page_text(html)
++        text_path = artifact_dir / "source-text.txt"
++        text_path.write_text(text[:80_000], encoding="utf-8")
++        observations = _extract_activity_observations(
++            text,
++            request=request,
++            evidence_refs=[str(html_path), str(text_path), final_url],
++        )
++        missing = _remaining_activity_fields(observations)
++        confidence = _observation_confidence(observations)
++        status = (
++            SourceResearchStatus.SUCCESS
++            if confidence >= 0.62 and len(missing) <= 2
++            else SourceResearchStatus.PARTIAL
++            if observations
++            else SourceResearchStatus.BLOCKED
++        )
++        artifacts = [
++            EvidenceArtifact(
++                artifact_type="html",
++                label="Fetched activity source HTML snapshot",
++                path=str(html_path),
++                url=final_url,
++            ),
++            EvidenceArtifact(
++                artifact_type="text",
++                label="Extracted activity source visible text",
++                path=str(text_path),
++                url=final_url,
++            ),
++        ]
++        return _result(
++            request,
++            adapter=self.capability,
++            status=status,
++            confidence=confidence,
++            observations=observations,
++            evidence_artifacts=artifacts,
++            notes=notes,
++            missing_fields=missing,
++        )
++
++
+ class OpenClawResearchAdapter:
+     capability = SourceAdapterCapability.OPENCLAW
+ 
+@@ -493,7 +603,12 @@ class OpenClawResearchAdapter:
+ 
+     def can_handle(self, request: SourceResearchRequest) -> bool:
+         return (
+-            request.category in {ShortlistCategory.LODGING.value, ShortlistCategory.FLIGHTS.value}
++            request.category
++            in {
++                ShortlistCategory.LODGING.value,
++                ShortlistCategory.FLIGHTS.value,
++                ShortlistCategory.ACTIVITIES.value,
++            }
+             and self._enabled
+             and bool(request.source_url)
+             and shutil.which(self._command) is not None
+@@ -666,6 +781,36 @@ def _request_for_flight_option(
+     )
+ 
+ 
++def _request_for_activity_option(
++    state: ResearchShortlistState,
++    option: Any,
++    mode: SourceResearchMode,
++) -> SourceResearchRequest:
++    return SourceResearchRequest(
++        trip_id=state.trip_id,
++        category=state.category.value,
++        option_id=str(option.option_id),
++        source_name=str(option.source),
++        source_url=str(option.deep_link),
++        source_type=str(
++            option.validation.source_type.value if option.validation else "live_search"
++        ),
++        query=" ".join(
++            item
++            for item in [
++                str(option.activity_name),
++                str(option.island_location),
++                str(option.duration),
++                str(option.age_family_fit),
++            ]
++            if item
++        ),
++        candidate_name=str(option.activity_name),
++        adapter_mode=mode,
++        context=option.model_dump(mode="json"),
++    )
++
++
+ def _apply_lodging_observations(option: Any, result: SourceResearchResult, *, run_id: str) -> None:
+     validation: SourceValidation = option.validation or SourceValidation()
+     validation.adapter_used = result.adapter_used.value
+@@ -804,6 +949,10 @@ def _apply_flight_observations(option: Any, result: SourceResearchResult, *, run
+         option.airline = str(observations["airline"])
+     if isinstance(observations.get("flight_numbers"), list):
+         option.flight_numbers = [str(value) for value in observations["flight_numbers"]]
++    if isinstance(observations.get("departure_date"), str):
++        option.departure_date = str(observations["departure_date"])
++    if isinstance(observations.get("arrival_date"), str):
++        option.arrival_date = str(observations["arrival_date"])
+     if isinstance(observations.get("departure_time"), str):
+         option.departure_time = str(observations["departure_time"])
+     if isinstance(observations.get("arrival_time"), str):
+@@ -837,6 +986,80 @@ def _apply_flight_observations(option: Any, result: SourceResearchResult, *, run
+     option.validation = validation
+ 
+ 
++def _apply_activity_observations(option: Any, result: SourceResearchResult, *, run_id: str) -> None:
++    validation: SourceValidation = option.validation or SourceValidation()
++    validation.adapter_used = result.adapter_used.value
++    validation.research_run_id = run_id
++    validation.verified_at = result.ended_at
++    validation.evidence_url = result.request.source_url or validation.evidence_url
++    validation.evidence_artifacts = result.evidence_artifacts
++    validation.extracted_fields = {
++        observation.field: observation.value for observation in result.observations
++    }
++    validation.notes = _dedupe_notes(
++        [
++            *validation.notes,
++            *result.notes,
++            "Activity source research extracts evidence only; final times, inventory, pickup, and booking terms can change before purchase.",
++        ]
++    )
++    validation.missing_fields = sorted(set(result.missing_fields))
++    validation.confidence = max(validation.confidence, result.confidence)
++    validation.price_status = (
++        PriceStatus.LIVE_SIGNAL
++        if "price_signal" in validation.extracted_fields
++        else validation.price_status
++    )
++    validation.availability_status = (
++        AvailabilityStatus.AVAILABILITY_SIGNAL
++        if "availability_signal" in validation.extracted_fields
++        else validation.availability_status
++    )
++    if result.status == SourceResearchStatus.SUCCESS:
++        validation.verification_status = VerificationStatus.LIVE_VERIFIED
++        validation.freshness_status = FreshnessStatus.CURRENT
++        option.row_status = ShortlistRowStatus.VERIFIED_LIVE
++        option.live_data_status = LiveDataStatus.LIVE_VERIFIED
++    elif result.status == SourceResearchStatus.PARTIAL:
++        if result.adapter_used == SourceAdapterCapability.LINK:
++            validation.verification_status = VerificationStatus.MANUAL_REQUIRED
++            validation.freshness_status = FreshnessStatus.UNKNOWN
++            option.row_status = ShortlistRowStatus.RESEARCHED
++            option.live_data_status = LiveDataStatus.HANDOFF_REQUIRED
++        else:
++            validation.verification_status = VerificationStatus.PARTIAL
++            validation.freshness_status = FreshnessStatus.CURRENT
++            option.row_status = (
++                ShortlistRowStatus.VERIFIED_LIVE
++                if result.confidence >= 0.45
++                else ShortlistRowStatus.RESEARCHED
++            )
++            option.live_data_status = LiveDataStatus.PARTIAL
++    else:
++        validation.verification_status = VerificationStatus.FAILED
++        option.row_status = ShortlistRowStatus.RESEARCHED
++        option.live_data_status = LiveDataStatus.HANDOFF_REQUIRED
++
++    observations = validation.extracted_fields
++    if isinstance(observations.get("price_signal"), str):
++        option.price_band = str(observations["price_signal"])
++    if isinstance(observations.get("duration_signal"), str):
++        option.duration = str(observations["duration_signal"])
++    if isinstance(observations.get("start_time"), str):
++        option.suggested_start_time = str(observations["start_time"])
++    if isinstance(observations.get("end_time"), str):
++        option.suggested_end_time = str(observations["end_time"])
++    if isinstance(observations.get("rating_summary"), str):
++        option.review_safety_signal = str(observations["rating_summary"])
++    if isinstance(observations.get("group_size_signal"), str):
++        option.group_size_signal = str(observations["group_size_signal"])
++    if isinstance(observations.get("availability_signal"), str):
++        option.confidence_notes = _dedupe_notes(
++            [*option.confidence_notes, str(observations["availability_signal"])]
++        )
++    option.validation = validation
++
++
+ def _updated_fit_category(option: Any) -> LodgingFitCategory:
+     if (
+         option.min_three_beds_satisfied is True
+@@ -896,10 +1119,12 @@ const timeout = Number(process.argv[2] || 12000);
+   const browser = await chromium.launch({ headless: true });
+   const page = await browser.newPage();
+   await page.goto(url, { waitUntil: 'domcontentloaded', timeout });
+-  await page.waitForTimeout(1200);
++  await page.waitForLoadState('networkidle', { timeout }).catch(() => {});
++  await page.waitForTimeout(2500);
++  const visibleText = await page.evaluate(() => document.body ? document.body.innerText : '');
+   const html = await page.content();
+   await browser.close();
+-  process.stdout.write(html);
++  process.stdout.write(`${html}<pre id="trippy-visible-text">${visibleText}</pre>`);
+ })().catch((error) => {
+   console.error(error && error.stack ? error.stack : String(error));
+   process.exit(1);
+@@ -1079,10 +1304,22 @@ def _extract_flight_observations(
+         )
+     departure = _time_signal(cleaned, ["depart", "departure", "leaves", "outbound"])
+     arrival = _time_signal(cleaned, ["arrive", "arrival", "lands"])
++    departure_date = _date_signal(cleaned, ["depart", "departure", "outbound", "leaves"])
++    arrival_date = _date_signal(cleaned, ["arrive", "arrival", "lands"])
+     if not departure or not arrival:
+         paired_departure, paired_arrival = _time_pair_signal(cleaned)
+         departure = departure or paired_departure
+         arrival = arrival or paired_arrival
++    if not departure_date or not arrival_date:
++        paired_departure_date, paired_arrival_date = _date_pair_signal(cleaned)
++        departure_date = departure_date or paired_departure_date
++        arrival_date = arrival_date or paired_arrival_date
++    if departure_date:
++        observations.append(
++            _observation("departure_date", departure_date, 0.6, request, evidence_refs)
++        )
++    if arrival_date:
++        observations.append(_observation("arrival_date", arrival_date, 0.6, request, evidence_refs))
+     if departure:
+         observations.append(_observation("departure_time", departure, 0.56, request, evidence_refs))
+     if arrival:
+@@ -1112,6 +1349,61 @@ def _extract_flight_observations(
+     return observations
+ 
+ 
++def _extract_activity_observations(
++    text: str,
++    *,
++    request: SourceResearchRequest,
++    evidence_refs: list[str],
++) -> list[SourceObservation]:
++    cleaned = " ".join(text.split())
++    lower = cleaned.lower()
++    observations: list[SourceObservation] = []
++    price = _extract_price(cleaned)
++    if price:
++        observations.append(
++            _observation("price_signal", price, 0.64, request, evidence_refs, "Visible activity price text")
++        )
++    availability = _activity_availability_signal(lower)
++    if availability:
++        observations.append(
++            _observation(
++                "availability_signal",
++                availability,
++                0.55,
++                request,
++                evidence_refs,
++                "Visible activity booking/availability language",
++            )
++        )
++    start_time = _time_signal(cleaned, ["start", "starts", "departure", "meet", "meeting"])
++    end_time = _time_signal(cleaned, ["end", "ends", "return", "finish", "finishes"])
++    if not start_time or not end_time:
++        paired_start, paired_end = _time_pair_signal(cleaned)
++        start_time = start_time or paired_start
++        end_time = end_time or paired_end
++    if start_time:
++        observations.append(_observation("start_time", start_time, 0.56, request, evidence_refs))
++    if end_time:
++        observations.append(_observation("end_time", end_time, 0.52, request, evidence_refs))
++    duration = _duration_signal(cleaned)
++    if duration:
++        observations.append(_observation("duration_signal", duration, 0.58, request, evidence_refs))
++    cancellation = _cancellation_signal(lower)
++    if cancellation:
++        observations.append(
++            _observation("cancellation_signal", cancellation, 0.48, request, evidence_refs)
++        )
++    group_size = _group_size_signal(cleaned)
++    if group_size:
++        observations.append(
++            _observation("group_size_signal", group_size, 0.5, request, evidence_refs)
++        )
++    rating = _rating_signal(cleaned)
++    if rating:
++        observations.append(_observation("rating_summary", rating, 0.52, request, evidence_refs))
++    return observations
++
++
+ def _flight_context_observations(
+     request: SourceResearchRequest,
+     *,
+@@ -1160,6 +1452,19 @@ def _flight_context_observations(
+                 "Fallback from canonical candidate context, not live source evidence",
+             )
+         )
++    for field in ("departure_date", "arrival_date"):
++        value = str(context.get(field, "")).strip()
++        if value:
++            observations.append(
++                _observation(
++                    field,
++                    value,
++                    0.32,
++                    request,
++                    evidence_refs,
++                    "Fallback from canonical candidate context, not live source evidence",
++                )
++            )
+     price = _extract_price(query_text)
+     if price and not any(observation.field == "price_signal" for observation in observations):
+         observations.append(
+@@ -1256,6 +1561,27 @@ def _flight_availability_signal(lower: str) -> str:
+     return ""
+ 
+ 
++def _activity_availability_signal(lower: str) -> str:
++    if any(
++        term in lower
++        for term in ["sold out", "not available", "unavailable", "no availability", "no tours"]
++    ):
++        return "unavailable/sold-out signal visible; choose another time, date, or operator"
++    if any(
++        term in lower
++        for term in [
++            "check availability",
++            "select participants",
++            "reserve now",
++            "book now",
++            "available",
++            "free cancellation",
++        ]
++    ):
++        return "booking or availability signal visible; final inventory still needs source review"
++    return ""
++
++
+ def _time_signal(text: str, labels: list[str]) -> str:
+     label_pattern = "|".join(re.escape(label) for label in labels)
+     match = re.search(
+@@ -1279,6 +1605,42 @@ def _time_pair_signal(text: str) -> tuple[str, str]:
+     return "", ""
+ 
+ 
++def _date_signal(text: str, labels: list[str]) -> str:
++    label_pattern = "|".join(re.escape(label) for label in labels)
++    date_pattern = (
++        r"(?:20\d{2}-\d{2}-\d{2})|"
++        r"(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+20\d{2})|"
++        r"(?:\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+20\d{2})"
++    )
++    match = re.search(
++        rf"(?:{label_pattern})(?:ure|s|ing)?\s*(?:date)?\s*(?:on|:|-)?\s*({date_pattern})",
++        text,
++        flags=re.IGNORECASE,
++    )
++    return " ".join(match.group(1).replace(",", "").split()) if match else ""
++
++
++def _date_pair_signal(text: str) -> tuple[str, str]:
++    date_pattern = (
++        r"(?:20\d{2}-\d{2}-\d{2})|"
++        r"(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+20\d{2})|"
++        r"(?:\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+20\d{2})"
++    )
++    match = re.search(rf"\b({date_pattern})\s*(?:-|–|—|to|→)\s*({date_pattern})\b", text)
++    if match:
++        return (
++            " ".join(match.group(1).replace(",", "").split()),
++            " ".join(match.group(2).replace(",", "").split()),
++        )
++    dates = re.findall(date_pattern, text, flags=re.IGNORECASE)
++    if len(dates) >= 2:
++        return (
++            " ".join(str(dates[0]).replace(",", "").split()),
++            " ".join(str(dates[1]).replace(",", "").split()),
++        )
++    return "", ""
++
++
+ def _duration_signal(text: str) -> str:
+     match = re.search(
+         r"(?:total\s+duration|duration|travel\s+time)\s*(?:is|:|-)?\s*((?:\d+\s?(?:h|hr|hrs|hour|hours))\s*(?:\d+\s?(?:m|min|mins|minute|minutes))?)",
+@@ -1294,6 +1656,33 @@ def _duration_signal(text: str) -> str:
+     return " ".join(match.group(1).split()) if match and match.group(1).strip() else ""
+ 
+ 
++def _group_size_signal(text: str) -> str:
++    lower = text.lower()
++    if "private tour" in lower or "private group" in lower:
++        return "private tour/group signal visible"
++    match = re.search(
++        r"(?:small group|group size|limited to|max(?:imum)?(?: group)?)(?:\s*(?:of|to|:|-))?\s*(\d{1,2})",
++        text,
++        flags=re.IGNORECASE,
++    )
++    if match:
++        return f"group size signal visible: {match.group(0).strip()}"
++    if "small group" in lower:
++        return "small-group signal visible"
++    return ""
++
++
++def _rating_signal(text: str) -> str:
++    match = re.search(
++        r"\b(\d(?:\.\d)?)(?:\s*/\s*5|\s+out of\s+5)\b",
++        text,
++        flags=re.IGNORECASE,
++    )
++    if match:
++        return f"visible rating {match.group(1)}/5; read recent reviews before booking"
++    return ""
++
++
+ def _stops_signal(lower: str) -> int | None:
+     if "nonstop" in lower or "non-stop" in lower or "non stop" in lower or "direct flight" in lower:
+         return 0
+@@ -1352,7 +1741,10 @@ def _baggage_signal(lower: str) -> str:
+ 
+ 
+ def _availability_signal(lower: str) -> str:
+-    if any(term in lower for term in ["sold out", "not available", "unavailable"]):
++    if any(
++        term in lower
++        for term in ["sold out", "not available", "unavailable", "no properties found"]
++    ):
+         return "unavailable signal visible; do not advance without another date/property"
+     if any(term in lower for term in ["reserve", "book now", "availability", "available"]):
+         return (
+@@ -1438,6 +1830,8 @@ def _remaining_flight_fields(observations: Iterable[SourceObservation]) -> list[
+     found = {observation.field for observation in observations}
+     required = set(_flight_missing_fields())
+     mapping = {
++        "departure_date": "exact_departure_date",
++        "arrival_date": "exact_arrival_date",
+         "price_signal": "exact_fare",
+         "departure_time": "exact_departure_time",
+         "arrival_time": "exact_arrival_time",
+@@ -1452,6 +1846,24 @@ def _remaining_flight_fields(observations: Iterable[SourceObservation]) -> list[
+     return sorted(required)
+ 
+ 
++def _remaining_activity_fields(observations: Iterable[SourceObservation]) -> list[str]:
++    found = {observation.field for observation in observations}
++    required = set(_activity_missing_fields())
++    mapping = {
++        "price_signal": "current_price",
++        "availability_signal": "exact_availability",
++        "start_time": "bookable_time",
++        "end_time": "bookable_time",
++        "duration_signal": "duration",
++        "cancellation_signal": "cancellation_policy",
++        "group_size_signal": "group_size",
++    }
++    for observation_field, missing_field in mapping.items():
++        if observation_field in found:
++            required.discard(missing_field)
++    return sorted(required)
++
++
+ def _lodging_missing_fields() -> list[str]:
+     return [
+         "exact_availability",
+@@ -1466,6 +1878,8 @@ def _lodging_missing_fields() -> list[str]:
+ 
+ def _flight_missing_fields() -> list[str]:
+     return [
++        "exact_departure_date",
++        "exact_arrival_date",
+         "flight_numbers",
+         "exact_departure_time",
+         "exact_arrival_time",
+@@ -1476,18 +1890,39 @@ def _flight_missing_fields() -> list[str]:
+     ]
+ 
+ 
++def _activity_missing_fields() -> list[str]:
++    return [
++        "exact_availability",
++        "current_price",
++        "bookable_time",
++        "duration",
++        "cancellation_policy",
++        "group_size",
++    ]
++
++
+ def _missing_fields_for_category(category: str) -> list[str]:
+     if category == ShortlistCategory.FLIGHTS.value:
+         return _flight_missing_fields()
++    if category == ShortlistCategory.ACTIVITIES.value:
++        return _activity_missing_fields()
+     return _lodging_missing_fields()
+ 
+ 
+ def _missing_high_value_fields(result: SourceResearchResult) -> bool:
+     if result.request.category == ShortlistCategory.FLIGHTS.value:
+         return bool(
+-            {"exact_departure_time", "exact_arrival_time", "exact_fare"}
++            {
++                "exact_departure_date",
++                "exact_departure_time",
++                "exact_arrival_date",
++                "exact_arrival_time",
++                "exact_fare",
++            }
+             & set(result.missing_fields)
+         )
++    if result.request.category == ShortlistCategory.ACTIVITIES.value:
++        return bool({"current_price", "exact_availability", "bookable_time"} & set(result.missing_fields))
+     return bool(
+         {"final_total_price", "bed_layout", "min_three_beds_satisfied"} & set(result.missing_fields)
+     )
+@@ -1578,11 +2013,17 @@ def _dedupe_notes(notes: list[str]) -> list[str]:
+ def _openclaw_prompt(request: SourceResearchRequest) -> str:
+     if request.category == ShortlistCategory.FLIGHTS.value:
+         useful_fields = (
+-            "airline, flight_numbers, departure_time, arrival_time, total_duration, stops, "
+-            "layover_airports, layover_duration, price_signal, availability_signal, "
++            "airline, flight_numbers, departure_date, departure_time, arrival_date, arrival_time, "
++            "total_duration, stops, layover_airports, layover_duration, price_signal, availability_signal, "
+             "cabin_signal, baggage_signal"
+         )
+         category_note = "flight research"
++    elif request.category == ShortlistCategory.ACTIVITIES.value:
++        useful_fields = (
++            "price_signal, availability_signal, start_time, end_time, duration_signal, "
++            "cancellation_signal, group_size_signal, rating_summary"
++        )
++        category_note = "activity research"
+     else:
+         useful_fields = (
+             "price_signal, availability_signal, bed_layout_signal, "
+diff --git a/trippy/services/trip_ideation.py b/trippy/services/trip_ideation.py
+index 8f5a5eb..fd8749f 100644
+--- a/trippy/services/trip_ideation.py
++++ b/trippy/services/trip_ideation.py
+@@ -8,6 +8,7 @@ from trippy.memory.store import MemoryStore
+ from trippy.models.ideas import TripComparison, TripConcept, TripIdeaRequest
+ from trippy.models.preferences import FamilyTravelPreferences
+ from trippy.services.country_priors import CountryPriorService
++from trippy.services.planning_advisor import PlanningAdvisorService
+ 
+ 
+ @dataclass(frozen=True)
+@@ -44,7 +45,16 @@ _TEMPLATES = [
+         base_comfort=84,
+         food_score=78,
+         crowd_risk=36,
+-        tags={"nature", "food", "island", "short-flight", "low-crowd", "chill"},
++        tags={
++            "nature",
++            "food",
++            "island",
++            "azores",
++            "portugal",
++            "short-flight",
++            "low-crowd",
++            "chill",
++        },
+         risks=[
+             "Weather can disrupt outdoor plans; keep flexible hot springs, food, and scenic backup days."
+         ],
+@@ -101,9 +111,151 @@ _TEMPLATES = [
+         base_comfort=78,
+         food_score=76,
+         crowd_risk=42,
+-        tags={"beach", "nature", "adventure", "short-flight", "water", "chill"},
++        tags={
++            "belize",
++            "caribbean",
++            "beach",
++            "nature",
++            "adventure",
++            "short-flight",
++            "water",
++            "reef",
++            "snorkel",
++            "snorkeling",
++            "chill",
++        },
+         risks=["Extra hops to islands can eat time; keep the route simple for only six days."],
+     ),
++    _ConceptTemplate(
++        concept_id="cayman-reef-food-easy-week",
++        title="Cayman Reef + Food Easy Week",
++        countries=["Cayman Islands"],
++        destinations=["Seven Mile Beach", "West Bay", "Stingray City or Rum Point"],
++        recommended_duration_days=7,
++        best_season="winter or spring, including March break if prices are acceptable",
++        estimated_cost_band_cad="CAD 18k-32k for family of 5 before exact flights, lodging, and activities",
++        estimated_flight_hours=4.2,
++        direct_flight_friendliness=8,
++        base_family_fit=84,
++        base_comfort=86,
++        food_score=82,
++        crowd_risk=50,
++        tags={
++            "cayman",
++            "cayman islands",
++            "caribbean",
++            "beach",
++            "water",
++            "reef",
++            "snorkel",
++            "snorkeling",
++            "food",
++            "family",
++            "low-friction",
++            "short-flight",
++            "chill",
++        },
++        risks=[
++            "March break pricing can be high; value needs live validation.",
++            "Use smaller operators and beach timing to avoid crowded excursion windows.",
++        ],
++    ),
++    _ConceptTemplate(
++        concept_id="curacao-color-beach-drivable-short",
++        title="Curacao Color + Beach Base",
++        countries=["Curacao"],
++        destinations=["Willemstad", "Westpunt beaches", "Klein Curacao optional"],
++        recommended_duration_days=6,
++        best_season="winter, spring, or early fall outside peak holiday pricing",
++        estimated_cost_band_cad="CAD 9k-17k for a couple before final flights, lodging, and car",
++        estimated_flight_hours=5.8,
++        direct_flight_friendliness=7,
++        base_family_fit=78,
++        base_comfort=78,
++        food_score=76,
++        crowd_risk=40,
++        tags={
++            "curacao",
++            "curaçao",
++            "caribbean",
++            "beach",
++            "island",
++            "water",
++            "reef",
++            "snorkel",
++            "snorkeling",
++            "drivable",
++            "colorful",
++            "chill",
++            "rental",
++        },
++        risks=[
++            "Historical notes are mixed: colorful and drivable, but theft/safety, cost, and food consistency need careful validation.",
++            "Do not leave valuables in a car at beaches; lodging location and parking security matter.",
++        ],
++    ),
++    _ConceptTemplate(
++        concept_id="st-lucia-private-rental-food-short",
++        title="St Lucia Private Rental + Food Week",
++        countries=["St Lucia"],
++        destinations=["Soufriere", "Rodney Bay optional", "Marigot Bay optional"],
++        recommended_duration_days=6,
++        best_season="winter or spring shoulder windows",
++        estimated_cost_band_cad="CAD 10k-18k for a couple before exact villa/hotel and car choices",
++        estimated_flight_hours=5.4,
++        direct_flight_friendliness=6,
++        base_family_fit=76,
++        base_comfort=74,
++        food_score=84,
++        crowd_risk=42,
++        tags={
++            "st lucia",
++            "saint lucia",
++            "caribbean",
++            "beach",
++            "island",
++            "food",
++            "rental",
++            "scenery",
++            "chill",
++        },
++        risks=[
++            "Historical prior likes food and Airbnb/private-stay upside, but hard roads are a major caution.",
++            "This only works if transfers or driving routes avoid road-stress and night-driving friction.",
++        ],
++    ),
++    _ConceptTemplate(
++        concept_id="mexico-caribbean-food-beach-short",
++        title="Mexico Caribbean Food + Beach Base",
++        countries=["Mexico"],
++        destinations=["Isla Mujeres or Puerto Morelos", "Valladolid optional"],
++        recommended_duration_days=6,
++        best_season="winter or early spring before heavy heat and seaweed risk",
++        estimated_cost_band_cad="CAD 8k-16k for a couple depending on beach lodging and dining",
++        estimated_flight_hours=4.2,
++        direct_flight_friendliness=9,
++        base_family_fit=78,
++        base_comfort=76,
++        food_score=88,
++        crowd_risk=60,
++        tags={
++            "mexico",
++            "caribbean",
++            "beach",
++            "food",
++            "short-flight",
++            "water",
++            "reef",
++            "snorkel",
++            "snorkeling",
++            "chill",
++            "value",
++        },
++        risks=[
++            "Mexico is historically strong for food, value, and weather, but safety, crowding, and beach/seaweed conditions vary sharply by area.",
++            "Avoid overbuilt resort zones unless convenience clearly beats the crowd exposure.",
++        ],
++    ),
+     _ConceptTemplate(
+         concept_id="portugal-food-cities-coast",
+         title="Portugal Food Cities + Coast",
+@@ -207,7 +359,11 @@ class TripIdeationService:
+         self._country_priors = CountryPriorService()
+ 
+     def compare(self, request: TripIdeaRequest, *, limit: int = 5) -> TripComparison:
+-        concepts = [self._score_template(template, request) for template in _TEMPLATES]
++        region_intents = _explicit_region_intents(request)
++        experience_intents = _required_experience_intents(request)
++        templates = _region_filtered_templates(_TEMPLATES, region_intents)
++        templates = _experience_filtered_templates(templates, experience_intents)
++        concepts = [self._score_template(template, request) for template in templates]
+         filtered = _duration_filtered_concepts(concepts, request, limit)
+         if filtered:
+             concepts = filtered
+@@ -223,12 +379,32 @@ class TripIdeationService:
+                 0,
+                 f"Requested duration is {request.duration_days} day(s); suggestions are duration-fit first, not generic best trips.",
+             )
+-        return TripComparison(
++        if region_intents:
++            scoring_notes.insert(
++                0,
++                f"Explicit destination intent detected: {', '.join(sorted(region_intents))}. Off-region concepts are excluded before scoring.",
++            )
++        if experience_intents:
++            scoring_notes.insert(
++                0,
++                f"Required experience detected: {', '.join(sorted(experience_intents))}. Concepts without that experience are excluded before scoring.",
++            )
++        comparison = TripComparison(
+             request=request,
+             concepts=ranked,
+             recommended_concept_id=recommendation,
+             scoring_notes=scoring_notes,
+         )
++        comparison.advisor = (
++            PlanningAdvisorService(
++                preferences=self._prefs,
++                memory=self._memory,
++                enabled=False,
++            )
++            .advise_trip_ideas(request, comparison)
++            .model_dump(mode="json")
++        )
++        return comparison
+ 
+     def _score_template(self, template: _ConceptTemplate, request: TripIdeaRequest) -> TripConcept:
+         score = template.base_family_fit + template.base_comfort + template.food_score
+@@ -257,6 +433,17 @@ class TripIdeationService:
+         score += len(matched_goals) * 8
+         if matched_goals:
+             rationale.append(f"Matches requested goals: {', '.join(sorted(matched_goals))}.")
++        experience_intents = _required_experience_intents(request)
++        matched_experiences = {
++            intent
++            for intent in experience_intents
++            if _template_matches_experience(template, intent)
++        }
++        if matched_experiences:
++            score += len(matched_experiences) * 18
++            rationale.append(
++                f"Matches required experience: {', '.join(sorted(matched_experiences))}."
++            )
+ 
+         if request.duration_days:
+             diff = abs(request.duration_days - template.recommended_duration_days)
+@@ -345,6 +532,126 @@ def _travel_burden(flight_hours: float) -> str:
+     return "high"
+ 
+ 
++def _explicit_region_intents(request: TripIdeaRequest) -> set[str]:
++    text = _request_text(request)
++    intents: set[str] = set()
++    if any(
++        term in text
++        for term in (
++            "caribbean",
++            "carribean",
++            "carribbean",
++            "west indies",
++            "antilles",
++        )
++    ):
++        intents.add("caribbean")
++    if "azores" in text:
++        intents.add("azores")
++    if "portugal" in text:
++        intents.add("portugal")
++    return intents
++
++
++def _region_filtered_templates(
++    templates: list[_ConceptTemplate],
++    region_intents: set[str],
++) -> list[_ConceptTemplate]:
++    if not region_intents:
++        return templates
++    matched = [
++        template
++        for template in templates
++        if all(_template_matches_region(template, intent) for intent in region_intents)
++    ]
++    return matched or templates
++
++
++def _template_matches_region(template: _ConceptTemplate, intent: str) -> bool:
++    haystack = _template_text(template)
++    if intent == "caribbean":
++        return "caribbean" in template.tags or any(
++            term in haystack
++            for term in (
++                "belize",
++                "curacao",
++                "curaçao",
++                "st lucia",
++                "saint lucia",
++                "st maarten",
++                "saint martin",
++                "st kitts",
++                "st thomas",
++                "cuba",
++                "dominican",
++                "barbados",
++                "jamaica",
++                "aruba",
++                "bonaire",
++                "puerto rico",
++                "isla mujeres",
++                "cancun",
++                "riviera maya",
++            )
++        )
++    return intent in template.tags or intent in haystack
++
++
++def _required_experience_intents(request: TripIdeaRequest) -> set[str]:
++    text = _request_text(request)
++    intents: set[str] = set()
++    if any(term in text for term in ("snorkel", "snorkeling", "snorkelling", "snorkling", "reef")):
++        intents.add("snorkeling")
++    if any(term in text for term in ("beach", "water", "swim", "ocean")):
++        intents.add("beach_water")
++    return intents
++
++
++def _experience_filtered_templates(
++    templates: list[_ConceptTemplate],
++    experience_intents: set[str],
++) -> list[_ConceptTemplate]:
++    if not experience_intents:
++        return templates
++    matched = [
++        template
++        for template in templates
++        if all(_template_matches_experience(template, intent) for intent in experience_intents)
++    ]
++    return matched or templates
++
++
++def _template_matches_experience(template: _ConceptTemplate, intent: str) -> bool:
++    if intent == "snorkeling":
++        return bool(template.tags & {"snorkel", "snorkeling", "reef"})
++    if intent == "beach_water":
++        return bool(template.tags & {"beach", "water", "reef", "snorkel", "snorkeling"})
++    return intent in template.tags
++
++
++def _request_text(request: TripIdeaRequest) -> str:
++    parts = [
++        request.time_of_year or "",
++        request.desired_vibe or "",
++        request.activity_level or "",
++        request.party_type or "",
++        *request.goals,
++        *request.avoid,
++    ]
++    return " ".join(parts).lower()
++
++
++def _template_text(template: _ConceptTemplate) -> str:
++    return " ".join(
++        [
++            template.title,
++            *template.countries,
++            *template.destinations,
++            *template.tags,
++        ]
++    ).lower()
++
++
+ def _duration_filtered_concepts(
+     concepts: list[TripConcept],
+     request: TripIdeaRequest,
+diff --git a/trippy/services/trip_management.py b/trippy/services/trip_management.py
+index 76e4a85..c4ba3d0 100644
+--- a/trippy/services/trip_management.py
++++ b/trippy/services/trip_management.py
+@@ -8,6 +8,7 @@ from pathlib import Path
+ from trippy import config
+ from trippy.models.shortlists import ShortlistCategory
+ from trippy.services.shortlist_store import ShortlistStore
++from trippy.services.trip_execution import TripExecutionService
+ from trippy.services.trip_intake import TripIntakeService
+ from trippy.services.trip_planner import TripPlannerService
+ from trippy.services.trip_state import TripStateService
+@@ -29,12 +30,16 @@ class TripManagementService:
+         workspace_service: TripWorkspaceService | None = None,
+         trip_state: TripStateService | None = None,
+         shortlist_store: ShortlistStore | None = None,
++        execution_service: TripExecutionService | None = None,
+     ) -> None:
+         self._intakes = intake_service or TripIntakeService()
+         self._planner = planner_service or TripPlannerService(self._intakes)
+         self._workspace = workspace_service or TripWorkspaceService(self._intakes, self._planner)
+         self._trip_state = trip_state or TripStateService()
+         self._shortlists = shortlist_store or ShortlistStore()
++        self._execution = execution_service or TripExecutionService(
++            shortlist_store=self._shortlists
++        )
+ 
+     def delete_trip(self, trip_id: str) -> dict[str, object]:
+         """Delete local planning state for a trip and return a diagnostic summary."""
+@@ -44,6 +49,7 @@ class TripManagementService:
+         self._delete_path(self._intakes.path_for(trip_id), deleted, missing)
+         self._delete_path(self._planner.path_for(trip_id), deleted, missing)
+         self._delete_path(self._workspace.path_for(trip_id), deleted, missing)
++        self._delete_path(self._execution.path_for(trip_id), deleted, missing_if_absent=False)
+ 
+         canonical_path = config.TRIPS_PATH / f"{trip_id}.json"
+         if self._trip_state.delete(trip_id):
+diff --git a/trippy/services/trip_planner.py b/trippy/services/trip_planner.py
+index 445601d..c676dfd 100644
+--- a/trippy/services/trip_planner.py
++++ b/trippy/services/trip_planner.py
+@@ -13,6 +13,7 @@ from trippy.models.trip_planning import (
+     TripPlanOption,
+ )
+ from trippy.services.country_priors import CountryPriorService
++from trippy.services.planning_advisor import PlanningAdvisorService
+ from trippy.services.trip_ideation import TripIdeationService
+ from trippy.services.trip_intake import TripIntakeService
+ 
+@@ -40,6 +41,14 @@ class TripPlannerService:
+     def draft(self, trip_id: str) -> TripPlanDraft:
+         intake = self._intakes.require(trip_id)
+         draft = self._build_draft(intake)
++        draft.advisor = (
++            PlanningAdvisorService(enabled=False)
++            .advise_trip_shape(
++                intake,
++                draft,
++            )
++            .model_dump(mode="json")
++        )
+         self.save_draft(draft)
+         return draft
+ 
+@@ -53,7 +62,7 @@ class TripPlannerService:
+         if not path.exists():
+             return None
+         data = json.loads(path.read_text(encoding="utf-8"))
+-        return TripPlanDraft.model_validate(data)
++        return _normalize_loaded_draft(TripPlanDraft.model_validate(data))
+ 
+     def require_draft(self, trip_id: str) -> TripPlanDraft:
+         draft = self.load_draft(trip_id)
+@@ -111,6 +120,9 @@ class TripPlannerService:
+                 duration_days=intake.duration_days,
+                 budget_cad=intake.budget_cad,
+                 travelers=intake.party.total_travelers,
++                party_type=intake.party.party_type.value,
++                adults=intake.party.adults,
++                children=intake.party.children,
+                 max_flight_hours=intake.max_travel_time_hours,
+                 direct_flight_preferred=intake.flight_preferences.prefer_direct,
+                 goals=intake.goals,
+@@ -157,7 +169,11 @@ class TripPlannerService:
+ 
+     def _build_generic_selected_destination_draft(self, intake: TripIntake) -> TripPlanDraft:
+         duration = intake.duration_days or 8
+-        destination = ", ".join(intake.destination_seeds)
++        destination = ", ".join(intake.destination_seeds) or intake.trip_name or "Destination"
++        single_base_region = (
++            intake.destination_seeds[0] if intake.destination_seeds else destination
++        )
++        balanced_regions = intake.destination_seeds[:2] or [single_base_region]
+         signals = [
+             signal.rationale
+             for seed in intake.destination_seeds
+@@ -170,11 +186,11 @@ class TripPlannerService:
+         options = [
+             TripPlanOption(
+                 option_id="single-base-easy",
+-                title=f"{destination} Single-Base Easy Version",
++                title=f"{single_base_region} Single-Base Easy Version",
+                 summary="Minimize logistics by choosing one strong home base and doing selective day trips.",
+                 duration_days=duration,
+-                regions=intake.destination_seeds,
+-                nights_by_region=_even_nights(intake.destination_seeds, duration),
++                regions=[single_base_region],
++                nights_by_region={single_base_region: max(1, duration - 1)},
+                 rationale=[
+                     f"Lowest movement friction and easiest to make comfortable for {intake.party.summary()}.",
+                     "Best first draft when exact transport and lodging options are not yet validated.",
+@@ -202,10 +218,8 @@ class TripPlannerService:
+                 title=f"{destination} Two-Region Balanced Version",
+                 summary="Use two bases to improve coverage while preserving downtime.",
+                 duration_days=duration,
+-                regions=intake.destination_seeds,
+-                nights_by_region=_even_nights(
+-                    intake.destination_seeds[:2] or intake.destination_seeds, duration
+-                ),
++                regions=balanced_regions,
++                nights_by_region=_even_nights(balanced_regions, duration),
+                 rationale=[
+                     "Balances depth with a broader sense of place.",
+                     "Usually the best pattern if the trip is at least 8-10 days.",
+@@ -413,6 +427,24 @@ def _even_nights(regions: list[str], duration_days: int) -> dict[str, int]:
+     return {region: base + (1 if idx < extra else 0) for idx, region in enumerate(regions)}
+ 
+ 
++def _normalize_loaded_draft(draft: TripPlanDraft) -> TripPlanDraft:
++    """Repair older generic drafts whose labels and stay regions disagreed."""
++    for option in draft.options:
++        if option.option_id == "single-base-easy" and len(option.regions) > 1:
++            primary = option.regions[0]
++            total_nights = sum(option.nights_by_region.values()) or max(
++                1, option.duration_days - 1
++            )
++            option.title = option.title.replace(
++                ", ".join(option.regions), primary, 1
++            )
++            option.regions = [primary]
++            option.nights_by_region = {primary: total_nights}
++        if option.option_id == "two-region-balanced" and option.nights_by_region:
++            option.regions = list(option.nights_by_region)
++    return draft
++
++
+ def _required_research() -> list[str]:
+     return [
+         "Live flight options, total travel time, layovers, baggage, seats, and Aeroplan application.",
+diff --git a/trippy/services/trip_workspace.py b/trippy/services/trip_workspace.py
+index e0de33e..779019e 100644
+--- a/trippy/services/trip_workspace.py
++++ b/trippy/services/trip_workspace.py
+@@ -23,6 +23,12 @@ from trippy.models.trip import (
+     Trip,
+     TripStatus,
+ )
++from trippy.models.trip_execution import (
++    ExecutionCategory,
++    ExecutionStatus,
++    TripPacketItem,
++    TripPacketState,
++)
+ from trippy.models.trip_planning import (
+     TripIntake,
+     TripPlanDraft,
+@@ -94,6 +100,7 @@ class TripWorkspaceService:
+             self._planner,
+             validate_live=validate_live,
+         )
++        packet = _load_trip_packet(intake.trip_id)
+         trip = self._build_canonical_trip(intake, option, shortlists)
+         if existing_sync is not None:
+             trip.sync = existing_sync.model_copy(deep=True)
+@@ -111,6 +118,7 @@ class TripWorkspaceService:
+             trip,
+             validate_live=validate_live,
+             shortlists=shortlists,
++            packet=packet,
+         )
+ 
+         state = TripWorkspaceState(
+@@ -263,6 +271,7 @@ class TripWorkspaceService:
+         *,
+         validate_live: bool | None = None,
+         shortlists: dict[str, Any] | None = None,
++        packet: TripPacketState | None = None,
+     ) -> list[WorkspaceTab]:
+         if shortlists is None:
+             shortlists = _load_or_build_shortlists(
+@@ -272,11 +281,13 @@ class TripWorkspaceService:
+                 validate_live=validate_live,
+             )
+         map_artifact = _build_planning_map(intake.trip_id, self._intakes, self._planner)
++        if packet is None:
++            packet = _load_trip_packet(intake.trip_id)
+         return [
+             WorkspaceTab(
+                 name="Overview",
+                 headers=["Field", "Value"],
+-                rows=_overview_rows(intake, option, shortlists, trip),
++                rows=_overview_rows(intake, option, shortlists, trip, packet),
+             ),
+             WorkspaceTab(
+                 name="Master Timeline",
+@@ -302,7 +313,24 @@ class TripWorkspaceService:
+                     "Notes",
+                     "Link",
+                 ],
+-                rows=_timeline_rows(intake, option, shortlists),
++                rows=_timeline_rows(intake, option, shortlists, packet),
++            ),
++            WorkspaceTab(
++                name="Trip Packet",
++                headers=[
++                    "Category",
++                    "Status",
++                    "Title",
++                    "Provider",
++                    "Confirmation",
++                    "Date",
++                    "Time",
++                    "Address",
++                    "Cost CAD",
++                    "Booking Link",
++                    "Notes",
++                ],
++                rows=_trip_packet_rows(packet, shortlists),
+             ),
+             WorkspaceTab(
+                 name="Plan Options",
+@@ -340,8 +368,11 @@ class TripWorkspaceService:
+                     "Recommended",
+                     "Recommendation",
+                     "Airline",
+-                    "Departure",
+-                    "Arrival",
++                    "Flight Numbers",
++                    "Departure Date",
++                    "Departure Time",
++                    "Arrival Date",
++                    "Arrival Time",
+                     "Route",
+                     "Stops",
+                     "Layovers",
+@@ -901,6 +932,7 @@ def _overview_rows(
+     option: TripPlanOption,
+     shortlists: dict[str, Any],
+     trip: Trip,
++    packet: TripPacketState | None = None,
+ ) -> list[list[Any]]:
+     best_flight = _recommended_option(shortlists.get("flights"))
+     best_lodging = _recommended_option(shortlists.get("lodging"))
+@@ -915,6 +947,8 @@ def _overview_rows(
+         ["Selected Option", f"{option.option_id} - {option.title}"],
+         ["Selected Plan Summary", option.summary],
+         ["Planning Completeness", f"{_workspace_completeness(shortlists, trip)}%"],
++        ["Trip Packet Readiness", _packet_readiness(packet)],
++        ["Trip Packet Status", packet.status_label if packet else "not started"],
+         ["Destination Seeds", ", ".join(intake.destination_seeds)],
+         ["Travel Window", intake.travel_window.display()],
+         ["Duration", intake.duration_display()],
+@@ -936,6 +970,7 @@ def _overview_rows(
+         ["Best Activities", "; ".join(_option_summary(option) for option in activities)],
+         ["Top Friction Warnings", "; ".join(warnings[:4])],
+         ["Unresolved Blockers", "; ".join(unresolved[:5])],
++        ["Missing Confirmation Details", "; ".join((packet.missing_items if packet else [])[:5])],
+         ["Next Actions", "; ".join(_workspace_next_actions(shortlists, trip)[:5])],
+     ]
+ 
+@@ -951,7 +986,10 @@ def _flight_rows(state: Any | None) -> list[list[Any]]:
+                 _yes_no(option.option_id == recommended_id),
+                 option.recommendation_label,
+                 option.airline,
++                " + ".join(getattr(option, "flight_numbers", [])),
++                getattr(option, "departure_date", ""),
+                 option.departure_time,
++                getattr(option, "arrival_date", ""),
+                 option.arrival_time,
+                 f"{option.departure_airport} to {option.arrival_airport}",
+                 option.stops,
+@@ -1166,6 +1204,104 @@ def _evidence_summary(artifacts: list[Any]) -> str:
+     return "; ".join(value for value in values if value)
+ 
+ 
++def _load_trip_packet(trip_id: str) -> TripPacketState | None:
++    from trippy import config
++
++    path = config.WORKSPACES_PATH / "trip_packets" / f"{trip_id}.packet.json"
++    if not path.exists():
++        return None
++    data = json.loads(path.read_text(encoding="utf-8"))
++    return TripPacketState.model_validate(data)
++
++
++def _trip_packet_rows(
++    packet: TripPacketState | None,
++    shortlists: dict[str, Any],
++) -> list[list[Any]]:
++    items = list(packet.items if packet else [])
++    if not items:
++        for state in shortlists.values():
++            for option in _typed_options(state):
++                row_status = getattr(getattr(option, "row_status", ""), "value", "")
++                if row_status in {"approved", "booked", "confirmed"}:
++                    items.append(
++                        TripPacketItem(
++                            item_id=f"{state.category.value}:{getattr(option, 'option_id', '')}",
++                            category=_packet_category_for_state(state),
++                            option_id=str(getattr(option, "option_id", "")),
++                            title=_option_summary(option),
++                            provider=str(
++                                getattr(option, "booking_source", "")
++                                or getattr(option, "source", "")
++                            ),
++                            status=(
++                                ExecutionStatus.CONFIRMED
++                                if row_status == "confirmed"
++                                else ExecutionStatus.BOOKED
++                                if row_status == "booked"
++                                else ExecutionStatus.SELECTED
++                            ),
++                            source_url=str(getattr(option, "deep_link", "") or ""),
++                            booking_link=str(getattr(option, "deep_link", "") or ""),
++                        )
++                    )
++    rows = [
++        [
++            item.category.value,
++            item.status.value,
++            item.title,
++            item.provider,
++            item.confirmation_code,
++            item.date,
++            _time_range(item.start_time, item.end_time),
++            item.address,
++            item.cost_cad or "",
++            item.booking_link or item.source_url,
++            item.notes,
++        ]
++        for item in items
++    ]
++    return rows or [
++        [
++            "flight",
++            "missing",
++            "No selected flight yet",
++            "",
++            "",
++            "",
++            "",
++            "",
++            "",
++            "",
++            "Select and book a flight, then add the confirmation code.",
++        ],
++        [
++            "lodging",
++            "missing",
++            "No selected lodging yet",
++            "",
++            "",
++            "",
++            "",
++            "",
++            "",
++            "",
++            "Select and book lodging, then add confirmation and check-in details.",
++        ],
++    ]
++
++
++def _packet_category_for_state(state: Any) -> ExecutionCategory:
++    category = getattr(state, "category", "")
++    value = getattr(category, "value", category)
++    return {
++        "flights": ExecutionCategory.FLIGHT,
++        "lodging": ExecutionCategory.LODGING,
++        "cars": ExecutionCategory.CAR,
++        "activities": ExecutionCategory.ACTIVITY,
++    }.get(str(value), ExecutionCategory.OTHER)
++
++
+ def _car_rows(state: Any | None) -> list[list[Any]]:
+     rows = []
+     recommended_id = getattr(state, "recommended_option_id", None)
+@@ -1380,12 +1516,16 @@ def _timeline_rows(
+     intake: TripIntake,
+     option: TripPlanOption,
+     shortlists: dict[str, Any],
++    packet: TripPacketState | None = None,
+ ) -> list[list[Any]]:
+     rows: list[list[Any]] = []
+     start = intake.travel_window.start_date
+     best_flight = _recommended_option(shortlists.get("flights"))
+     best_car = _recommended_option(shortlists.get("cars"))
+     best_lodging = _recommended_option(shortlists.get("lodging"))
++    flight_packet = _packet_item_for(packet, ExecutionCategory.FLIGHT, best_flight)
++    car_packet = _packet_item_for(packet, ExecutionCategory.CAR, best_car)
++    lodging_packet = _packet_item_for(packet, ExecutionCategory.LODGING, best_lodging)
+     activities = _timeline_activity_options(shortlists.get("activities"), limit=4)
+     rows.append(
+         _timeline_row(
+@@ -1400,11 +1540,17 @@ def _timeline_rows(
+             to_value=best_flight.arrival_airport
+             if best_flight is not None
+             else "destination gateway",
+-            provider=getattr(best_flight, "booking_source", ""),
+-            status="recommended" if best_flight is not None else "seeded",
+-            fixed="flexible",
+-            start_time=getattr(best_flight, "departure_time", ""),
+-            end_time=getattr(best_flight, "arrival_time", ""),
++            provider=_packet_provider(best_flight, flight_packet),
++            status=_packet_status(
++                "recommended" if best_flight is not None else "seeded", flight_packet
++            ),
++            fixed="fixed" if flight_packet and flight_packet.is_booked else "flexible",
++            start_time=flight_packet.start_time
++            if flight_packet
++            else getattr(best_flight, "departure_time", ""),
++            end_time=flight_packet.end_time
++            if flight_packet
++            else getattr(best_flight, "arrival_time", ""),
+             travel_time=getattr(best_flight, "total_travel_duration", ""),
+             buffer_after="same-day lodging/car buffer required",
+             friction_flags=_combine_flags(
+@@ -1416,8 +1562,9 @@ def _timeline_rows(
+                 [getattr(best_flight, "recommendation_rationale", "")],
+                 [getattr(best_flight, "timing_implication", "")],
+                 [getattr(best_flight, "date_viability_signal", "")],
++                [_packet_notes(flight_packet)],
+             ),
+-            link=getattr(best_flight, "deep_link", ""),
++            link=_packet_link(best_flight, flight_packet),
+         )
+     )
+     if best_car is not None:
+@@ -1428,17 +1575,19 @@ def _timeline_rows(
+                 event_type="car pickup",
+                 title=f"Pick up {best_car.vehicle_class}",
+                 location=best_car.pickup_location,
+-                provider=best_car.booking_source,
+-                status=_row_status(shortlists.get("cars"), best_car.option_id),
+-                fixed="flexible",
++                provider=_packet_provider(best_car, car_packet),
++                status=_packet_status(
++                    _row_status(shortlists.get("cars"), best_car.option_id), car_packet
++                ),
++                fixed="fixed" if car_packet and car_packet.is_booked else "flexible",
+                 buffer_before="after baggage/arrival",
+                 friction_flags=_combine_flags(
+                     best_car.friction_flags,
+                     ["pickup timing must account for baggage and arrival delay"],
+                 ),
+                 confidence=_option_confidence(best_car),
+-                notes=best_car.passenger_fit,
+-                link=best_car.deep_link,
++                notes=_notes([best_car.passenger_fit], [_packet_notes(car_packet)]),
++                link=_packet_link(best_car, car_packet),
+             )
+         )
+     cursor_day = 1
+@@ -1447,6 +1596,9 @@ def _timeline_rows(
+         region = str(stay["region"])
+         nights = int(stay["nights"])
+         linked_lodging = _lodging_for_stay(shortlists.get("lodging"), stay) or best_lodging
++        linked_packet = (
++            _packet_item_for(packet, ExecutionCategory.LODGING, linked_lodging) or lodging_packet
++        )
+         rows.append(
+             _timeline_row(
+                 day=cursor_day,
+@@ -1454,9 +1606,11 @@ def _timeline_rows(
+                 event_type="lodging",
+                 title=f"Check in: {region}",
+                 location=region,
+-                provider=_option_summary(linked_lodging),
+-                status="recommended" if linked_lodging is not None else "seeded",
+-                fixed="flexible",
++                provider=_packet_provider(linked_lodging, linked_packet),
++                status=_packet_status(
++                    "recommended" if linked_lodging is not None else "seeded", linked_packet
++                ),
++                fixed="fixed" if linked_packet and linked_packet.is_booked else "flexible",
+                 buffer_before="avoid late-arrival access risk",
+                 buffer_after=f"{nights} night(s)",
+                 friction_flags=_combine_flags(
+@@ -1464,11 +1618,16 @@ def _timeline_rows(
+                     ["check-in time must be aligned to arrival"],
+                 ),
+                 confidence=_option_confidence(linked_lodging),
+-                notes=str(
+-                    stay.get("notes")
+-                    or getattr(linked_lodging, "adult_child_fit", option.lodging_strategy)
++                notes=_notes(
++                    [
++                        str(
++                            stay.get("notes")
++                            or getattr(linked_lodging, "adult_child_fit", option.lodging_strategy)
++                        )
++                    ],
++                    [_packet_notes(linked_packet)],
+                 ),
+-                link=getattr(linked_lodging, "deep_link", ""),
++                link=_packet_link(linked_lodging, linked_packet),
+             )
+         )
+         cursor_day += max(1, nights)
+@@ -1494,6 +1653,7 @@ def _timeline_rows(
+             activity.scheduled_date or activity.suggested_date
+         ) or _add_days(start, activity_day - 1)
+         activity_status = _row_status(shortlists.get("activities"), activity.option_id)
++        activity_packet = _packet_item_for(packet, ExecutionCategory.ACTIVITY, activity)
+         is_scheduled = activity.row_status.value in {"approved", "booked"} or bool(
+             activity.scheduled_day
+         )
+@@ -1506,9 +1666,13 @@ def _timeline_rows(
+                 event_type="activity",
+                 title=activity.activity_name,
+                 location=activity.island_location,
+-                provider=activity.source,
+-                status=activity_status,
+-                fixed=activity.scheduled_flexibility if is_scheduled else "flexible",
++                provider=_packet_provider(activity, activity_packet) or activity.source,
++                status=_packet_status(activity_status, activity_packet),
++                fixed="fixed"
++                if activity_packet and activity_packet.is_booked
++                else activity.scheduled_flexibility
++                if is_scheduled
++                else "flexible",
+                 travel_time=activity.duration,
+                 buffer_before="half-day slack",
+                 buffer_after="downtime / meal buffer",
+@@ -1523,8 +1687,9 @@ def _timeline_rows(
+                     [activity.scheduling_notes],
+                     [activity.scheduling_rationale],
+                     [activity.age_family_fit],
++                    [_packet_notes(activity_packet)],
+                 ),
+-                link=activity.deep_link,
++                link=_packet_link(activity, activity_packet),
+             )
+         )
+     rows.append(
+@@ -1692,7 +1857,8 @@ def _timeline_activity_options(state: Any | None, *, limit: int) -> list[Any]:
+     approved = [
+         option
+         for option in options
+-        if getattr(getattr(option, "row_status", ""), "value", "") in {"approved", "booked"}
++        if getattr(getattr(option, "row_status", ""), "value", "")
++        in {"approved", "booked", "confirmed"}
+         or getattr(option, "scheduled_day", None)
+     ]
+     if approved:
+@@ -1719,7 +1885,8 @@ def _approved_activities(state: Any | None) -> list[Any]:
+     return [
+         option
+         for option in getattr(state, "activity_options", [])
+-        if getattr(getattr(option, "row_status", ""), "value", "") in {"approved", "booked"}
++        if getattr(getattr(option, "row_status", ""), "value", "")
++        in {"approved", "booked", "confirmed"}
+         or getattr(option, "scheduled_day", None)
+     ]
+ 
+@@ -1759,6 +1926,66 @@ def _option_confidence(option: Any | None) -> str:
+     return f"{validation.confidence:.0%}"
+ 
+ 
++def _packet_item_for(
++    packet: TripPacketState | None,
++    category: ExecutionCategory,
++    option: Any | None,
++) -> TripPacketItem | None:
++    if packet is None or option is None:
++        return None
++    option_id = str(getattr(option, "option_id", ""))
++    return next(
++        (
++            item
++            for item in packet.items
++            if item.category == category and item.option_id == option_id
++        ),
++        None,
++    )
++
++
++def _packet_provider(option: Any | None, packet_item: TripPacketItem | None) -> str:
++    if packet_item is not None:
++        pieces = [packet_item.provider or _option_summary(option)]
++        if packet_item.confirmation_code:
++            pieces.append(f"confirmation {packet_item.confirmation_code}")
++        return " · ".join(piece for piece in pieces if piece)
++    return (
++        str(getattr(option, "booking_source", "") or getattr(option, "source", ""))
++        if option is not None
++        else ""
++    )
++
++
++def _packet_status(default: str, packet_item: TripPacketItem | None) -> str:
++    return packet_item.status.value if packet_item is not None else default
++
++
++def _packet_notes(packet_item: TripPacketItem | None) -> str:
++    if packet_item is None:
++        return ""
++    notes = []
++    if packet_item.confirmation_code:
++        notes.append(f"confirmation {packet_item.confirmation_code}")
++    if packet_item.address:
++        notes.append(f"address {packet_item.address}")
++    if packet_item.notes:
++        notes.append(packet_item.notes)
++    return "; ".join(notes)
++
++
++def _packet_link(option: Any | None, packet_item: TripPacketItem | None) -> str:
++    if packet_item is not None:
++        return packet_item.booking_link or packet_item.source_url
++    return str(getattr(option, "deep_link", "") or "")
++
++
++def _packet_readiness(packet: TripPacketState | None) -> str:
++    if packet is None:
++        return "0% - confirmations not started"
++    return f"{packet.readiness_percent}% - {packet.status_label}"
++
++
+ def _combine_flags(existing: list[str], extra: list[str]) -> str:
+     return ", ".join([*existing, *extra])
+ 
+@@ -1775,7 +2002,7 @@ def _row_status(state: Any | None, option_id: str) -> str:
+             None,
+         )
+     row_status = getattr(getattr(option, "row_status", None), "value", "")
+-    if row_status in {"approved", "booked", "rejected", "verified_live", "stale"}:
++    if row_status in {"approved", "booked", "confirmed", "rejected", "verified_live", "stale"}:
+         return row_status
+     if state is not None and option_id == getattr(state, "recommended_option_id", None):
+         return "recommended"
+@@ -1834,28 +2061,40 @@ def _party_lodging_notes(intake: TripIntake) -> str:
+ 
+ 
+ def _workspace_completeness(shortlists: dict[str, Any], trip: Trip) -> int:
++    flight = _recommended_option(shortlists.get("flights"))
++    lodging = _recommended_option(shortlists.get("lodging"))
+     checks = [
+         bool(trip.travelers),
+-        bool(trip.segments),
+-        bool(trip.stays),
+-        all(category in shortlists for category in ("flights", "lodging", "cars", "activities")),
+-        any(
+-            item.category in {"document", "logistics", "health", "money"} for item in trip.checklist
+-        ),
+-        bool(trip.risk_flags),
++        all(category in shortlists for category in ("flights", "lodging")),
++        _status_at_least(flight, {"approved", "booked", "confirmed"}),
++        _status_at_least(lodging, {"approved", "booked", "confirmed"}),
++        _status_at_least(flight, {"booked", "confirmed"}),
++        _status_at_least(lodging, {"booked", "confirmed"}),
++        _status_at_least(flight, {"confirmed"}),
++        _status_at_least(lodging, {"confirmed"}),
+     ]
+     return int(sum(1 for item in checks if item) / len(checks) * 100)
+ 
+ 
++def _status_at_least(option: Any | None, accepted: set[str]) -> bool:
++    return getattr(getattr(option, "row_status", ""), "value", "") in accepted
++
++
+ def _unresolved_blockers(shortlists: dict[str, Any], trip: Trip) -> list[str]:
+     blockers: list[str] = []
+     for category in ("flights", "lodging", "cars", "activities"):
+         if category not in shortlists:
+             blockers.append(f"{category} shortlist missing")
+-    if trip.unconfirmed_segments:
+-        blockers.append("flight confirmations not booked")
+-    if trip.unconfirmed_stays:
+-        blockers.append("lodging confirmations not booked")
++    flight = _recommended_option(shortlists.get("flights"))
++    lodging = _recommended_option(shortlists.get("lodging"))
++    if not _status_at_least(flight, {"booked", "confirmed"}):
++        blockers.append("selected flight not marked booked")
++    if not _status_at_least(lodging, {"booked", "confirmed"}):
++        blockers.append("selected lodging not marked booked")
++    if not _status_at_least(flight, {"confirmed"}):
++        blockers.append("flight confirmation details missing")
++    if not _status_at_least(lodging, {"confirmed"}):
++        blockers.append("lodging confirmation details missing")
+     blockers.append("live prices/availability still need human verification")
+     return blockers
+ 
+@@ -1874,11 +2113,17 @@ def _workspace_next_actions(shortlists: dict[str, Any], trip: Trip) -> list[str]
+         if state is None:
+             actions.append(f"Generate {category} shortlist")
+         elif getattr(state, "recommended_option_id", None):
+-            actions.append(
+-                f"Open and live-verify recommended {category}: {state.recommended_option_id}"
+-            )
+-    if trip.unconfirmed_segments or trip.unconfirmed_stays:
+-        actions.append("Promote selected recommendations to approved/booked once human confirms.")
++            selected = _recommended_option(state)
++            if not _status_at_least(selected, {"approved", "booked", "confirmed"}):
++                actions.append(f"Choose preferred {category}: {state.recommended_option_id}")
++            elif not _status_at_least(selected, {"booked", "confirmed"}):
++                actions.append(
++                    f"Book selected {category} externally, then add confirmation details."
++                )
++            elif not _status_at_least(selected, {"confirmed"}):
++                actions.append(f"Add {category} confirmation code and exact trip-day details.")
++    if not actions:
++        actions.append("Review the trip packet, map, and chronological timeline.")
+     return actions
+ 
+ 
+diff --git a/trippy/ui/server.py b/trippy/ui/server.py
+index fa665ef..ebb3268 100644
+--- a/trippy/ui/server.py
++++ b/trippy/ui/server.py
+@@ -2,6 +2,7 @@
+ 
+ from __future__ import annotations
+ 
++import errno
+ import json
+ import mimetypes
+ import webbrowser
+@@ -43,7 +44,9 @@ from trippy.services.learning import (
+     WorkflowStatus,
+ )
+ from trippy.services.lodging_shortlist import LodgingShortlistService
++from trippy.services.planning_advisor import PlanningAdvisorService
+ from trippy.services.shortlist_store import ShortlistStore
++from trippy.services.trip_execution import TripExecutionService
+ from trippy.services.trip_ideation import TripIdeationService
+ from trippy.services.trip_intake import TripIntakeService
+ from trippy.services.trip_management import TripManagementService
+@@ -89,6 +92,7 @@ class TrippyUIService:
+         intake = self._intakes.load(trip_id)
+         draft = self._planner.load_draft(trip_id)
+         workspace = TripWorkspaceService(self._intakes, self._planner).load(trip_id)
++        trip_packet = TripExecutionService().build(trip_id, save=False) if intake else None
+         shortlists = ShortlistStore().load_all(trip_id)
+         workflows = [
+             workflow for workflow in self._learning.list_workflows() if workflow.trip_id == trip_id
+@@ -100,6 +104,7 @@ class TrippyUIService:
+             "draft": draft.model_dump(mode="json") if draft else None,
+             "workspace": workspace.model_dump(mode="json") if workspace else None,
+             "map_artifact": _load_map_artifact(trip_id),
++            "trip_packet": trip_packet.model_dump(mode="json") if trip_packet else None,
+             "shortlists": [shortlist.model_dump(mode="json") for shortlist in shortlists],
+             "recent_workflows": [workflow.model_dump(mode="json") for workflow in workflows],
+             "run_log": logs["events"],
+@@ -140,6 +145,9 @@ class TrippyUIService:
+             duration_days=_int_or_none(payload.get("duration_days")),
+             budget_cad=_float_or_none(payload.get("budget_cad")),
+             travelers=_int(payload.get("travelers"), 5),
++            party_type=_optional_str(payload.get("party_type")),
++            adults=_int_or_none(payload.get("adults")),
++            children=_int_or_none(payload.get("children")),
+             max_flight_hours=_float_or_none(
+                 payload.get("max_flight_hours") or payload.get("max_travel_time_hours")
+             ),
+@@ -343,7 +351,7 @@ class TrippyUIService:
+         state = FlightShortlistService(self._intakes, self._planner).add_candidate(
+             trip_id,
+             link=str(payload.get("link") or ""),
+-            notes=str(payload.get("notes") or ""),
++            notes=_flight_candidate_notes(payload),
+             name=str(payload.get("name") or ""),
+             validate_live=bool(payload.get("validate_live", False)),
+             deep_research=bool(payload.get("deep_research", False)),
+@@ -423,6 +431,75 @@ class TrippyUIService:
+             "next_step": "Build or refresh the workspace so the Master Timeline uses this stay structure.",
+         }
+ 
++    def suggest_lodging_structures(self, payload: dict[str, Any]) -> dict[str, Any]:
++        trip_id = _trip_id(payload)
++        state = LodgingShortlistService(self._intakes, self._planner).suggest_stay_structures(
++            trip_id,
++            use_llm=bool(payload.get("use_llm", True)),
++        )
++        workflow = self._record_workflow(
++            workflow_name="ui-trip-plan-lodging-structure-suggest",
++            skill_name="trippy-family-itinerary-builder",
++            trip_id=trip_id,
++            summary="Generated stay-structure options for review",
++            result=state.model_dump(mode="json"),
++        )
++        structure = state.artifacts.get("lodging_structure", {})
++        option_count = len(structure.get("options", [])) if isinstance(structure, dict) else 0
++        return {
++            "workflow_id": workflow.id,
++            "shortlist": state.model_dump(mode="json"),
++            "option_count": option_count,
++            "next_step": "Pick a stay option or edit the night split before selecting exact lodging.",
++        }
++
++    def planning_advice(self, payload: dict[str, Any]) -> dict[str, Any]:
++        from trippy.models.planning_advice import PlanningAdviceKind
++
++        trip_id = _optional_str(payload.get("trip_id"))
++        kind = PlanningAdviceKind(str(payload.get("planning_question") or "next_steps"))
++        intake = self._intakes.load(trip_id) if trip_id else None
++        draft = self._planner.load_draft(trip_id) if trip_id else None
++        advisor = PlanningAdvisorService()
++        if kind == PlanningAdviceKind.LODGING_STRUCTURE and intake is not None and draft:
++            option = draft.get_option()
++            lodging_state = (
++                ShortlistStore().load(trip_id, ShortlistCategory.LODGING) if trip_id else None
++            )
++            result = (
++                advisor.advise_lodging_structure(intake, option, lodging_state)
++                if option is not None
++                else advisor.advise_next_steps(
++                    intake,
++                    draft,
++                    ShortlistStore().load_all(trip_id) if trip_id else [],
++                    user_question=str(payload.get("notes") or ""),
++                )
++            )
++        elif kind == PlanningAdviceKind.ISLAND_EXPERIENCE and intake is not None and draft:
++            result = advisor.advise_island_experience(intake, draft)
++        elif kind == PlanningAdviceKind.TRIP_SHAPE and intake is not None and draft:
++            result = advisor.advise_trip_shape(intake, draft)
++        else:
++            result = advisor.advise_next_steps(
++                intake,
++                draft,
++                ShortlistStore().load_all(trip_id) if trip_id else [],
++                user_question=str(payload.get("notes") or ""),
++            )
++        workflow = self._record_workflow(
++            workflow_name="ui-planning-advice",
++            skill_name="trippy-family-itinerary-builder",
++            trip_id=trip_id,
++            summary=f"Generated planning-advisor guidance for {kind.value}",
++            result=result.model_dump(mode="json"),
++        )
++        return {
++            "workflow_id": workflow.id,
++            "advice": result.model_dump(mode="json"),
++            "next_step": "Use this guidance to choose the next planning action; do not treat missing evidence as verified.",
++        }
++
+     def select_activity(self, payload: dict[str, Any]) -> dict[str, Any]:
+         trip_id = _trip_id(payload)
+         option_id = str(payload.get("option_id") or "")
+@@ -489,6 +566,38 @@ class TrippyUIService:
+             "next_step": "Review pickup/dropoff timing, luggage fit, fees, and driving/parking friction.",
+         }
+ 
++    def update_trip_packet_item(self, payload: dict[str, Any]) -> dict[str, Any]:
++        trip_id = _trip_id(payload)
++        packet = TripExecutionService().update_item(
++            trip_id,
++            category=str(payload.get("category") or ""),
++            option_id=str(payload.get("option_id") or ""),
++            status=str(payload.get("status") or "booked"),
++            provider=str(payload.get("provider") or ""),
++            booking_link=str(payload.get("booking_link") or payload.get("source_url") or ""),
++            confirmation_code=str(payload.get("confirmation_code") or ""),
++            date=str(payload.get("date") or ""),
++            start_time=str(payload.get("start_time") or ""),
++            end_time=str(payload.get("end_time") or ""),
++            address=str(payload.get("address") or ""),
++            cost_cad=_float_or_none(payload.get("cost_cad")),
++            notes=str(payload.get("notes") or ""),
++        )
++        workflow = self._record_workflow(
++            workflow_name="ui-trip-packet-update",
++            trip_id=trip_id,
++            summary=(
++                f"Updated {payload.get('category') or 'trip'} booking packet "
++                f"item {payload.get('option_id') or ''}"
++            ),
++            result=packet.model_dump(mode="json"),
++        )
++        return {
++            "workflow_id": workflow.id,
++            "trip_packet": packet.model_dump(mode="json"),
++            "next_step": "Refresh the timeline, map, and Google Sheet so confirmations are visible.",
++        }
++
+     def delete_trip(self, trip_id: str) -> dict[str, Any]:
+         result = TripManagementService(
+             intake_service=self._intakes,
+@@ -741,6 +850,12 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
+             if path == "/api/lodging-structure":
+                 self._send_json(self._ui.update_lodging_structure(payload))
+                 return
++            if path == "/api/lodging-structure-suggestions":
++                self._send_json(self._ui.suggest_lodging_structures(payload))
++                return
++            if path == "/api/planning-advice":
++                self._send_json(self._ui.planning_advice(payload))
++                return
+             if path == "/api/select-activity":
+                 self._send_json(self._ui.select_activity(payload))
+                 return
+@@ -750,6 +865,9 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
+             if path == "/api/select-car":
+                 self._send_json(self._ui.select_car(payload))
+                 return
++            if path == "/api/trip-packet/item":
++                self._send_json(self._ui.update_trip_packet_item(payload))
++                return
+             if path == "/api/workspace":
+                 self._send_json(
+                     self._ui.build_workspace(
+@@ -818,6 +936,29 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
+         self._send_file(candidate)
+ 
+ 
++def _create_ui_server(
++    host: str,
++    port: int,
++    handler: Any,
++    *,
++    port_retries: int = 10,
++) -> ThreadingHTTPServer:
++    """Bind the UI server, falling forward when the preferred port is busy."""
++    candidates = [0] if port == 0 else range(port, port + port_retries + 1)
++    for candidate in candidates:
++        try:
++            server = ThreadingHTTPServer((host, candidate), handler)
++        except OSError as exc:
++            if exc.errno != errno.EADDRINUSE or candidate == port + port_retries:
++                raise
++            continue
++        if port != 0 and server.server_port != port:
++            print(f"Port {port} is in use; using {server.server_port} instead.")
++        return server
++    msg = f"No available UI port found from {port} to {port + port_retries}."
++    raise OSError(errno.EADDRINUSE, msg)
++
++
+ def serve_ui(host: str = "127.0.0.1", port: int = 8787, *, open_browser: bool = True) -> None:
+     """Serve the local Trippy UI until interrupted."""
+     service = TrippyUIService()
+@@ -827,7 +968,7 @@ def serve_ui(host: str = "127.0.0.1", port: int = 8787, *, open_browser: bool =
+         static_dir=STATIC_DIR,
+         template_dir=TEMPLATE_DIR,
+     )
+-    server = ThreadingHTTPServer((host, port), handler)
++    server = _create_ui_server(host, port, handler)
+     url = f"http://{host}:{server.server_port}"
+     print(f"Trippy UI running at {url}")
+     if open_browser:
+@@ -1034,6 +1175,31 @@ def _parse_roster(value: object) -> list[TripTraveler]:
+     return travelers
+ 
+ 
++def _flight_candidate_notes(payload: dict[str, Any]) -> str:
++    parts = []
++    notes = _optional_str(payload.get("notes"))
++    if notes:
++        parts.append(notes)
++    field_labels = {
++        "flight_numbers": "flight numbers",
++        "departure_date": "departure date",
++        "departure_time": "depart",
++        "arrival_date": "arrival date",
++        "arrival_time": "arrive",
++        "total_duration": "duration",
++        "stops": "stops",
++        "layover_airports": "via",
++        "layover_duration": "layover",
++        "price_band": "price",
++        "baggage_notes": "baggage",
++    }
++    for key, label in field_labels.items():
++        value = _optional_str(payload.get(key))
++        if value:
++            parts.append(f"{label}: {value}")
++    return ". ".join(parts)
++
++
+ def _trip_id(payload: dict[str, Any]) -> str:
+     trip_id = str(payload.get("trip_id") or "").strip()
+     if not trip_id:
+diff --git a/trippy/ui/static/app.css b/trippy/ui/static/app.css
+index 40b6e0b..67ff14c 100644
+--- a/trippy/ui/static/app.css
++++ b/trippy/ui/static/app.css
+@@ -603,6 +603,26 @@ textarea {
+   color: var(--muted);
+ }
+ 
++.guided-notice {
++  display: flex;
++  flex-wrap: wrap;
++  gap: 8px 12px;
++  align-items: center;
++  padding: 12px 14px;
++  border: 1px solid rgba(45, 185, 111, 0.28);
++  border-radius: 8px;
++  background: linear-gradient(135deg, #edfff5 0%, #e4fbff 100%);
++  color: var(--ink);
++}
++
++.guided-notice strong {
++  color: #10613b;
++}
++
++.guided-notice span {
++  color: var(--muted);
++}
++
+ .idea-action-grid,
+ .suggestion-grid {
+   display: grid;
+@@ -708,6 +728,18 @@ textarea {
+   justify-content: flex-end;
+ }
+ 
++.inline-toolbar {
++  display: flex;
++  align-items: center;
++  justify-content: flex-end;
++  gap: 12px;
++  min-height: 42px;
++}
++
++.inline-toolbar .inline-result {
++  margin: 0;
++}
++
+ .flight-candidate-form {
+   border-left-color: var(--ocean);
+ }
+@@ -729,6 +761,30 @@ textarea {
+   gap: 16px;
+ }
+ 
++.comparison-head.compact-head {
++  align-items: center;
++  padding: 10px 12px;
++}
++
++.recommended-inline {
++  display: flex;
++  align-items: center;
++  gap: 10px;
++  min-width: 0;
++}
++
++.recommended-inline strong,
++.recommended-inline small {
++  min-width: 0;
++}
++
++.recommended-inline small {
++  color: var(--muted);
++  overflow: hidden;
++  text-overflow: ellipsis;
++  white-space: nowrap;
++}
++
+ .comparison-head p {
+   max-width: 820px;
+   margin-bottom: 0;
+@@ -941,6 +997,121 @@ textarea {
+   font-size: 12px;
+ }
+ 
++.booking-details {
++  margin-top: 8px;
++}
++
++.booking-details summary {
++  cursor: pointer;
++  color: var(--ocean-dark);
++  font-size: 12px;
++  font-weight: 850;
++}
++
++.booking-form {
++  display: grid;
++  gap: 8px;
++  min-width: 250px;
++  margin-top: 8px;
++  padding: 10px;
++  border: 1px solid rgba(0, 141, 163, 0.2);
++  border-radius: 8px;
++  background: #f8fdff;
++}
++
++.booking-form label {
++  font-size: 12px;
++}
++
++.inline-two {
++  display: grid;
++  grid-template-columns: repeat(2, minmax(0, 1fr));
++  gap: 8px;
++}
++
++.packet-hero {
++  display: flex;
++  align-items: center;
++  justify-content: space-between;
++  gap: 18px;
++  background: linear-gradient(135deg, #e4fbff 0%, #fff8df 68%, #ffe8f2 100%);
++}
++
++.readiness-meter {
++  display: grid;
++  place-items: center;
++  min-width: 170px;
++  min-height: 112px;
++  border: 1px solid rgba(0, 141, 163, 0.22);
++  border-radius: 8px;
++  background: #ffffff;
++}
++
++.readiness-meter strong {
++  font-size: 36px;
++  line-height: 1;
++}
++
++.readiness-meter span {
++  color: var(--muted);
++  font-weight: 800;
++}
++
++.blocker-card {
++  border-left: 6px solid var(--sun);
++}
++
++.blocker-card.is-clear {
++  border-left-color: var(--leaf);
++  background: #f0fff6;
++}
++
++.packet-grid {
++  display: grid;
++  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
++  gap: 12px;
++  padding: 14px;
++}
++
++.packet-item-card {
++  display: grid;
++  gap: 12px;
++  padding: 12px;
++  border: 1px solid var(--line);
++  border-radius: 8px;
++  background: #ffffff;
++}
++
++.packet-item-card.confirmed {
++  border-color: rgba(45, 185, 111, 0.55);
++  background: #f3fff7;
++}
++
++.packet-item-card.booked {
++  border-color: rgba(255, 201, 40, 0.65);
++  background: #fff9df;
++}
++
++.status-badge.confirmed,
++.truth-chip.confirmed {
++  background: #e4fff0;
++  color: #0d6b3e;
++}
++
++.status-badge.booked,
++.truth-chip.booked,
++.truth-chip.selected,
++.status-badge.selected {
++  background: #fff3ce;
++  color: #6b4200;
++}
++
++.truth-chip.idea,
++.status-badge.idea {
++  background: #eef5ff;
++  color: #174a85;
++}
++
+ .compact-card-grid {
+   display: grid;
+   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+@@ -1004,6 +1175,116 @@ textarea {
+   font-size: 12px;
+ }
+ 
++.stay-option-grid {
++  display: grid;
++  grid-column: 1 / -1;
++  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
++  gap: 12px;
++}
++
++.stay-option-card {
++  overflow: hidden;
++  border: 1px solid rgba(0, 141, 163, 0.18);
++  border-radius: 8px;
++  background: rgba(255, 255, 255, 0.9);
++}
++
++.stay-option-card.recommended-row {
++  outline-width: 2px;
++}
++
++.stay-map-thumb {
++  min-height: 118px;
++  padding: 12px;
++}
++
++.stay-map-thumb .map-route-line {
++  inset: 42px 28px auto;
++}
++
++.stay-map-thumb .map-pin {
++  max-width: 48%;
++  font-size: 11px;
++}
++
++.stay-option-body {
++  display: grid;
++  gap: 10px;
++  padding: 12px;
++}
++
++.stay-option-body h4,
++.stay-option-body p,
++.stay-option-body ul {
++  margin: 0;
++}
++
++.stay-option-actions {
++  display: flex;
++  gap: 8px;
++}
++
++.stay-option-actions button {
++  min-height: 38px;
++  padding: 8px 12px;
++}
++
++.lodging-group-stack {
++  display: grid;
++  gap: 14px;
++  padding: 14px;
++}
++
++.lodging-region-panel {
++  overflow: hidden;
++  border: 1px solid rgba(0, 141, 163, 0.2);
++  border-radius: 8px;
++  background:
++    linear-gradient(135deg, rgba(232, 249, 252, 0.62), rgba(255, 248, 223, 0.5)),
++    #ffffff;
++}
++
++.lodging-region-panel.secondary-region {
++  background: #ffffff;
++}
++
++.lodging-region-head {
++  display: flex;
++  justify-content: space-between;
++  gap: 14px;
++  align-items: flex-start;
++  padding: 12px 14px;
++  border-bottom: 1px solid rgba(215, 230, 236, 0.9);
++}
++
++.lodging-region-head h4,
++.lodging-region-head p {
++  margin: 0;
++}
++
++.lodging-region-head h4 {
++  font-size: 20px;
++}
++
++.lodging-region-head span {
++  color: var(--muted);
++  font-weight: 850;
++}
++
++.lodging-region-head > p {
++  max-width: 460px;
++  color: var(--muted);
++}
++
++.lodging-region-panel .comparison-table-wrap {
++  border: 0;
++  border-radius: 0;
++}
++
++.lodging-region-panel .comparison-table {
++  margin: 0;
++}
++
+ .stay-structure-form {
+   display: grid;
+   grid-column: 1 / -1;
+@@ -1478,7 +1759,7 @@ h3 {
+ 
+ .app-shell {
+   display: grid;
+-  grid-template-columns: 104px minmax(0, 1fr);
++  grid-template-columns: 156px minmax(0, 1fr);
+   min-height: 100vh;
+ }
+ 
+@@ -1491,8 +1772,8 @@ h3 {
+   height: 100vh;
+   flex-direction: column;
+   justify-content: flex-start;
+-  gap: 18px;
+-  padding: 22px 10px;
++  gap: 10px;
++  padding: 14px 8px;
+   background:
+     linear-gradient(180deg, rgba(50, 83, 101, 0.5), transparent 190px),
+     var(--sidebar);
+@@ -1504,12 +1785,12 @@ h3 {
+ .brand-lockup {
+   display: grid;
+   justify-items: center;
+-  gap: 8px;
++  gap: 6px;
+ }
+ 
+ .brand-logo {
+-  width: 66px;
+-  height: 66px;
++  width: 62px;
++  height: 62px;
+   border: 1px solid rgba(255, 255, 255, 0.18);
+   border-radius: 8px;
+   background: rgba(255, 255, 255, 0.08);
+@@ -1529,15 +1810,15 @@ h3 {
+   margin: 0;
+   color: #ffffff;
+   font-family: Georgia, "Times New Roman", serif;
+-  font-size: 19px;
++  font-size: 17px;
+   line-height: 1;
+ }
+ 
+ .brand-copy span {
+   display: block;
+-  margin-top: 4px;
++  margin-top: 3px;
+   color: rgba(255, 255, 255, 0.56);
+-  font-size: 10px;
++  font-size: 8px;
+   font-weight: 800;
+   letter-spacing: 0.08em;
+   text-transform: uppercase;
+@@ -1545,9 +1826,10 @@ h3 {
+ 
+ .top-actions {
+   display: grid;
+-  gap: 10px;
++  grid-template-columns: 1fr;
++  gap: 6px;
+   width: 100%;
+-  margin-top: 10px;
++  margin-top: 4px;
+ }
+ 
+ button,
+@@ -1560,14 +1842,14 @@ a.button,
+ .top-actions button,
+ .top-actions a {
+   display: grid;
+-  min-height: 46px;
++  min-height: 32px;
+   place-items: center;
+-  padding: 8px 6px;
++  padding: 6px;
+   border: 1px solid rgba(255, 255, 255, 0.1);
+   background: rgba(95, 209, 207, 0.14);
+   color: rgba(255, 255, 255, 0.78);
+   box-shadow: none;
+-  font-size: 12px;
++  font-size: 10px;
+   font-weight: 850;
+ }
+ 
+@@ -1779,7 +2061,7 @@ main {
+ 
+ .layout {
+   display: grid;
+-  grid-template-columns: minmax(236px, 296px) minmax(0, 1fr);
++  grid-template-columns: minmax(0, 1fr);
+   gap: 18px;
+   margin-top: 18px;
+ }
+@@ -1796,11 +2078,17 @@ main {
+ 
+ .trip-rail {
+   position: sticky;
+-  top: 26px;
++  top: 12px;
+   display: grid;
+-  gap: 12px;
++  gap: 8px;
+   align-self: start;
+-  padding: 18px;
++  max-height: calc(100vh - 160px);
++  overflow-y: auto;
++  padding: 0;
++  border: 0;
++  background: transparent;
++  box-shadow: none;
++  backdrop-filter: none;
+ }
+ 
+ .rail-head h2,
+@@ -1817,15 +2105,15 @@ main {
+ 
+ .rail-actions {
+   display: grid;
+-  grid-template-columns: 1fr 1fr;
+-  gap: 8px;
++  grid-template-columns: 1fr;
++  gap: 6px;
+   width: 100%;
+ }
+ 
+ .rail-actions button {
+-  min-height: 44px;
+-  padding: 10px 12px;
+-  font-size: 15px;
++  min-height: 32px;
++  padding: 7px 8px;
++  font-size: 11px;
+ }
+ 
+ .rail-head .eyebrow,
+@@ -1835,40 +2123,69 @@ main {
+ }
+ 
+ .trip-list {
+-  gap: 8px;
++  display: grid;
++  gap: 6px;
+   margin-top: 0;
+ }
+ 
+ .trip-list-item {
+-  grid-template-columns: minmax(0, 1fr) 42px;
+-  gap: 8px;
++  grid-template-columns: minmax(0, 1fr) 28px;
++  gap: 5px;
+ }
+ 
+ .trip-button {
+-  padding: 12px 14px;
++  min-height: 38px;
++  padding: 7px 8px;
+   border: 1px solid transparent;
+-  background: transparent;
+-  color: var(--ink);
++  background: rgba(255, 255, 255, 0.08);
++  color: rgba(255, 255, 255, 0.88);
+   box-shadow: none;
++  font-size: 11px;
++  line-height: 1.15;
+ }
+ 
+ .trip-button:hover {
+-  background: rgba(5, 138, 160, 0.08);
+-  color: var(--ink);
++  background: rgba(95, 209, 207, 0.18);
++  color: #ffffff;
+   box-shadow: none;
+ }
+ 
+ .trip-list-item.active .trip-button {
+   border-color: rgba(5, 138, 160, 0.44);
+   background: rgba(223, 247, 251, 0.75);
+-  box-shadow: inset 4px 0 0 var(--ocean);
++  color: var(--ink);
++  box-shadow: inset 3px 0 0 var(--ocean);
++}
++
++.trip-button small {
++  overflow: hidden;
++  color: rgba(255, 255, 255, 0.54);
++  text-overflow: ellipsis;
++  white-space: nowrap;
++}
++
++.trip-list-item.active .trip-button small {
++  color: var(--muted);
+ }
+ 
+ .trip-menu-button {
+-  min-height: 48px;
++  width: 28px;
++  min-height: 38px;
++  padding: 0;
+   border-color: rgba(215, 230, 236, 0.9);
+   background: rgba(255, 255, 255, 0.72);
+   color: var(--muted);
++  font-size: 13px;
++}
++
++.rail-empty {
++  padding: 8px;
++  border: 1px dashed rgba(255, 255, 255, 0.18);
++  border-radius: 8px;
++  color: rgba(255, 255, 255, 0.58);
++  font-size: 11px;
++  font-weight: 750;
++  text-align: center;
+ }
+ 
+ .trip-menu-button:hover {
+@@ -2170,6 +2487,7 @@ button.secondary {
+     min-height: auto;
+     height: auto;
+     flex-direction: row;
++    flex-wrap: wrap;
+     align-items: center;
+     justify-content: space-between;
+     padding: 12px 18px;
+@@ -2208,6 +2526,16 @@ button.secondary {
+ 
+   .trip-rail {
+     position: static;
++    flex-basis: 100%;
++    max-height: none;
++  }
++
++  .rail-actions {
++    grid-template-columns: 1fr 1fr;
++  }
++
++  .trip-list {
++    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+   }
+ }
+ 
+@@ -2615,3 +2943,305 @@ button.secondary {
+ #stageTabs {
+   display: none;
+ }
++
++/* Final usability pass: wider rail, data-first compare tables, sheet-first planning surface. */
++:root {
++  --rail-width: 232px;
++}
++
++.app-shell {
++  grid-template-columns: var(--rail-width) minmax(0, 1fr);
++}
++
++.app-header {
++  position: sticky;
++  min-width: var(--rail-width);
++  width: var(--rail-width);
++  padding: 18px 12px;
++  gap: 12px;
++}
++
++.rail-resize-handle {
++  position: absolute;
++  top: 0;
++  right: -6px;
++  width: 12px;
++  height: 100%;
++  cursor: col-resize;
++  touch-action: none;
++}
++
++.rail-resize-handle::after {
++  content: "";
++  position: absolute;
++  top: 50%;
++  right: 2px;
++  width: 3px;
++  height: 64px;
++  border-radius: 999px;
++  background: rgba(255, 255, 255, 0.18);
++  transform: translateY(-50%);
++}
++
++body.is-resizing-rail {
++  cursor: col-resize;
++  user-select: none;
++}
++
++.brand-lockup {
++  gap: 10px;
++}
++
++.brand-logo {
++  width: clamp(78px, calc(var(--rail-width) * 0.42), 118px);
++  height: clamp(78px, calc(var(--rail-width) * 0.42), 118px);
++}
++
++.brand-copy h1 {
++  font-size: clamp(26px, calc(var(--rail-width) * 0.16), 42px);
++}
++
++.brand-copy span {
++  font-size: 11px;
++}
++
++.top-actions button,
++.top-actions a,
++.rail-actions button {
++  min-height: 42px;
++  font-size: 15px;
++}
++
++.trip-button,
++.trip-menu-button {
++  min-height: 54px;
++  font-size: 14px;
++}
++
++.trip-button {
++  padding: 10px 12px;
++}
++
++.trip-button small {
++  font-size: 11px;
++}
++
++.compare-header-tight {
++  align-items: center;
++}
++
++.compare-header-tight p {
++  max-width: 720px;
++}
++
++.comparison-table.flight-table th,
++.comparison-table.flight-table td,
++.comparison-table.lodging-table th,
++.comparison-table.lodging-table td {
++  vertical-align: top;
++}
++
++.flight-table th:nth-child(1),
++.lodging-table th:nth-child(1) {
++  width: 110px;
++}
++
++.flight-table th:nth-child(2) {
++  width: 250px;
++}
++
++.flight-table th:nth-child(3),
++.flight-table th:nth-child(4) {
++  width: 170px;
++}
++
++.flight-table th:nth-child(5) {
++  width: 160px;
++}
++
++.flight-table th:nth-child(6) {
++  width: 170px;
++}
++
++.lodging-table th:nth-child(2) {
++  width: 270px;
++}
++
++.lodging-table th:nth-child(3) {
++  width: 160px;
++}
++
++.lodging-table th:nth-child(4) {
++  width: 190px;
++}
++
++.lodging-table th:nth-child(5) {
++  width: 180px;
++}
++
++.lodging-table th:nth-child(6) {
++  width: 220px;
++}
++
++.action-stack {
++  display: grid;
++  gap: 8px;
++  justify-items: start;
++}
++
++.sheet-frame-panel {
++  padding: 16px 18px 18px;
++}
++
++.sheet-frame-wrap {
++  overflow: hidden;
++  border: 1px solid rgba(215, 230, 236, 0.9);
++  border-radius: 8px;
++  background: rgba(255, 255, 255, 0.94);
++}
++
++.sheet-frame-wrap iframe {
++  width: 100%;
++  min-height: 820px;
++  border: 0;
++}
++
++.compact-stage-actions p {
++  max-width: 760px;
++}
++
++.packet-summary-strip {
++  padding: 16px 18px;
++}
++
++.packet-mini-grid {
++  display: grid;
++  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
++  gap: 12px;
++}
++
++.packet-item-card.compact {
++  min-height: auto;
++}
++
++.activity-card-stack {
++  display: grid;
++  gap: 14px;
++  padding: 0 14px 14px;
++}
++
++.activity-card {
++  display: grid;
++  grid-template-columns: 180px minmax(0, 1fr);
++  gap: 16px;
++  padding: 14px;
++  border-top: 1px solid rgba(215, 230, 236, 0.9);
++  background: rgba(255, 255, 255, 0.74);
++}
++
++.activity-card-image .image-wrap {
++  height: 100%;
++  min-height: 140px;
++  border-radius: 8px;
++}
++
++.activity-card-head {
++  display: flex;
++  justify-content: space-between;
++  gap: 16px;
++  align-items: flex-start;
++}
++
++.activity-card-head h4 {
++  margin: 2px 0 4px;
++}
++
++.activity-card-head p {
++  margin: 0;
++  color: var(--muted);
++}
++
++.activity-data-grid {
++  display: grid;
++  grid-template-columns: repeat(4, minmax(0, 1fr));
++  gap: 12px;
++  margin-top: 12px;
++}
++
++.activity-data-grid strong,
++.activity-data-grid small {
++  display: block;
++}
++
++.activity-link-row {
++  display: flex;
++  flex-wrap: wrap;
++  gap: 8px;
++  margin-top: 12px;
++}
++
++.activity-card-actions {
++  display: grid;
++  grid-template-columns: auto 1fr;
++  gap: 14px;
++  margin-top: 14px;
++  align-items: start;
++}
++
++.inline-schedule-form.compact {
++  display: grid;
++  grid-template-columns: repeat(4, minmax(0, 1fr));
++  gap: 8px 10px;
++  align-items: end;
++}
++
++.inline-schedule-form.compact .checkbox-line {
++  align-self: center;
++}
++
++.inline-schedule-form.compact input[name="notes"] {
++  grid-column: span 2;
++}
++
++.lodging-region-head span {
++  display: inline-block;
++  margin-top: 4px;
++}
++
++@media (max-width: 1100px) {
++  .app-shell {
++    grid-template-columns: 1fr;
++  }
++
++  .app-header {
++    width: auto;
++    min-width: 0;
++  }
++
++  .rail-resize-handle {
++    display: none;
++  }
++
++  .activity-card {
++    grid-template-columns: 1fr;
++  }
++
++  .activity-data-grid {
++    grid-template-columns: repeat(2, minmax(0, 1fr));
++  }
++
++  .activity-card-actions {
++    grid-template-columns: 1fr;
++  }
++}
++
++@media (max-width: 760px) {
++  .sheet-frame-wrap iframe {
++    min-height: 640px;
++  }
++
++  .activity-data-grid,
++  .inline-schedule-form.compact {
++    grid-template-columns: 1fr;
++  }
++}
+diff --git a/trippy/ui/static/app.js b/trippy/ui/static/app.js
+index b6f2e48..9824efe 100644
+--- a/trippy/ui/static/app.js
++++ b/trippy/ui/static/app.js
+@@ -13,6 +13,10 @@ const state = {
+   showSuggestForm: false,
+   openTripMenuId: null,
+   flightSort: "best",
++  guidedNotice: null,
++  isAutoDrafting: false,
++  isAutoBuildingLodging: false,
++  pendingScrollTarget: null,
+ };
+ 
+ const stages = [
+@@ -23,7 +27,7 @@ const stages = [
+   { id: "lodging", label: "Lodging" },
+   { id: "activities", label: "Activities" },
+   { id: "plan", label: "Plan" },
+-  { id: "review", label: "Review" },
++  { id: "packet", label: "Packet" },
+ ];
+ 
+ const partyOptions = [
+@@ -36,6 +40,7 @@ const partyOptions = [
+ ];
+ 
+ document.addEventListener("DOMContentLoaded", () => {
++  initRailResize();
+   document.getElementById("refreshButton").addEventListener("click", refresh);
+   document.getElementById("generateTripButton").addEventListener("click", () => startGenerateIdeas());
+   document.getElementById("newTripButton").addEventListener("click", () => startNewTrip());
+@@ -49,6 +54,55 @@ document.addEventListener("DOMContentLoaded", () => {
+   refresh();
+ });
+ 
++function initRailResize() {
++  const handle = document.getElementById("railResizeHandle");
++  const savedWidth = Number(window.localStorage.getItem("trippyRailWidth"));
++  if (savedWidth) {
++    setRailWidth(savedWidth);
++  }
++  if (!handle) {
++    return;
++  }
++  let startX = 0;
++  let startWidth = 0;
++  const onPointerMove = (event) => {
++    const next = startWidth + (event.clientX - startX);
++    setRailWidth(next);
++  };
++  const onPointerUp = () => {
++    document.body.classList.remove("is-resizing-rail");
++    window.removeEventListener("mousemove", onPointerMove);
++    window.removeEventListener("mouseup", onPointerUp);
++    const currentWidth = Number.parseInt(
++      getComputedStyle(document.documentElement).getPropertyValue("--rail-width"),
++      10,
++    );
++    if (currentWidth) {
++      window.localStorage.setItem("trippyRailWidth", String(currentWidth));
++    }
++  };
++  handle.addEventListener("mousedown", (event) => {
++    startX = event.clientX;
++    startWidth =
++      Number.parseInt(
++        getComputedStyle(document.documentElement).getPropertyValue("--rail-width"),
++        10,
++      ) || 232;
++    document.body.classList.add("is-resizing-rail");
++    window.addEventListener("mousemove", onPointerMove);
++    window.addEventListener("mouseup", onPointerUp);
++  });
++  handle.addEventListener("dblclick", () => {
++    setRailWidth(232);
++    window.localStorage.setItem("trippyRailWidth", "232");
++  });
++}
++
++function setRailWidth(width) {
++  const clamped = Math.max(188, Math.min(320, Math.round(Number(width) || 232)));
++  document.documentElement.style.setProperty("--rail-width", `${clamped}px`);
++}
++
+ async function refresh() {
+   state.app = await apiGet("/api/state");
+   if (!state.activeTripId && !state.isCreatingTrip) {
+@@ -72,7 +126,9 @@ async function loadTrip(tripId, options = {}) {
+   state.openTripMenuId = null;
+   state.activeTripId = tripId;
+   state.trip = await apiGet(`/api/trip?trip_id=${encodeURIComponent(tripId)}`);
+-  if (options.gotoNext) {
++  if (options.stage) {
++    state.activeStage = options.stage;
++  } else if (options.gotoNext) {
+     state.activeStage = nextUnlockedStage();
+   }
+   render();
+@@ -133,6 +189,25 @@ function render() {
+   renderPicks();
+   renderRunLog();
+   wireProgressBar();
++  scrollToPendingTarget();
++}
++
++function scrollToPendingTarget() {
++  if (!state.pendingScrollTarget) {
++    return;
++  }
++  const selector = state.pendingScrollTarget;
++  state.pendingScrollTarget = null;
++  window.requestAnimationFrame(() => {
++    const target = document.querySelector(selector);
++    if (!target) {
++      return;
++    }
++    target.scrollIntoView({ behavior: "smooth", block: "start" });
++    if (typeof target.focus === "function") {
++      target.focus({ preventScroll: true });
++    }
++  });
+ }
+ 
+ function renderHeader() {
+@@ -156,7 +231,8 @@ function normalizeActiveStage() {
+     research: "flights",
+     workspace: "plan",
+     maps: "plan",
+-    feedback: "review",
++    feedback: "packet",
++    review: "packet",
+   };
+   state.activeStage = legacyStageMap[state.activeStage] || state.activeStage;
+   if (!stages.some((stage) => stage.id === state.activeStage)) {
+@@ -175,7 +251,7 @@ function isStageUnlocked(stageId) {
+   if (stageId === "intake") return state.isCreatingTrip || hasTrip;
+   if (stageId === "options") return hasIntake;
+   if (["flights", "lodging", "activities", "plan"].includes(stageId)) return hasSelectedPlan;
+-  if (stageId === "review") return hasTrip || Boolean(state.trip?.recent_workflows?.length);
++  if (stageId === "packet") return hasSelectedPlan;
+   return false;
+ }
+ 
+@@ -192,7 +268,8 @@ function isStageComplete(stageId) {
+     );
+   }
+   if (stageId === "plan") return Boolean(state.trip?.workspace || state.trip?.map_artifact);
+-  return Boolean(state.trip?.recent_workflows?.length);
++  if (stageId === "packet") return tripPacketReadiness() >= 100;
++  return false;
+ }
+ 
+ function nextUnlockedStage() {
+@@ -203,7 +280,8 @@ function nextUnlockedStage() {
+   if (!shortlistByCategory("flights")?.flight_options?.length) return "flights";
+   if (!shortlistByCategory("lodging")?.lodging_options?.length) return "lodging";
+   if (!shortlistByCategory("activities")?.activity_options?.length) return "activities";
+-  return "plan";
++  if (!state.trip?.workspace && !state.trip?.map_artifact) return "plan";
++  return "packet";
+ }
+ 
+ function guidedNextStep() {
+@@ -216,7 +294,7 @@ function guidedNextStep() {
+     lodging: "Decide one stay vs split stays, then compare places that fit the party.",
+     activities: "Pick activities and car logic that fit the chosen trip shape.",
+     plan: "Build the timeline, map, risks, and planning workspace.",
+-    review: "Send feedback only when a workflow should teach Trippy.",
++    packet: "Add booking confirmations and review what is still missing before departure.",
+   };
+   return state.trip?.next_step || messages[stage] || messages.start;
+ }
+@@ -278,35 +356,38 @@ function shortlistMilestone(category, icon, label) {
+     return { key: category, icon, label, state: "todo", detail: "needed" };
+   }
+   const options = shortlistOptions(shortlist);
+-  const approved = options.some((option) => option.row_status === "approved" || option.row_status === "booked");
+-  const booked = options.some((option) => option.row_status === "booked");
++  const approved = options.some((option) =>
++    ["approved", "booked", "confirmed"].includes(option.row_status),
++  );
++  const booked = options.some((option) => ["booked", "confirmed"].includes(option.row_status));
++  const confirmed = options.some((option) => option.row_status === "confirmed");
+   return {
+     key: category,
+     icon,
+     label,
+-    state: booked || approved ? "done" : options.length ? "active" : "todo",
+-    detail: booked ? "booked" : approved ? "approved" : `${options.length} found`,
++    state: confirmed || booked || approved ? "done" : options.length ? "active" : "todo",
++    detail: confirmed ? "confirmed" : booked ? "booked" : approved ? "selected" : `${options.length} found`,
+   };
+ }
+ 
+ function bookingMilestoneState() {
+-  const options = (state.trip?.shortlists || []).flatMap(shortlistOptions);
+-  const flightBooked = options.some((option) => option.row_status === "booked" && option.airline);
+-  const lodgingBooked = options.some((option) => option.row_status === "booked" && option.name);
+-  const workspaceRows = state.trip?.workspace?.tabs || [];
+-  const hasConfirmation = JSON.stringify(workspaceRows).toLowerCase().includes("confirmation");
+-  return flightBooked && lodgingBooked && hasConfirmation ? "done" : "todo";
++  const readiness = tripPacketReadiness();
++  if (readiness >= 100) return "done";
++  if (readiness > 0) return "active";
++  return "todo";
+ }
+ 
+ function bookingMilestoneDetail() {
+-  return bookingMilestoneState() === "done" ? "confirmed" : "confirmations needed";
++  const packet = state.trip?.trip_packet;
++  if (!packet) return "confirmations needed";
++  return `${packet.readiness_percent || 0}% ${packet.status_label || ""}`.trim();
+ }
+ 
+ function renderTripList() {
+   const trips = collectTrips();
+   const list = document.getElementById("tripList");
+   if (!trips.length) {
+-    list.innerHTML = `<div class="empty-state">No trip state yet.</div>`;
++    list.innerHTML = `<div class="rail-empty">No trips yet</div>`;
+     return;
+   }
+   list.innerHTML = trips
+@@ -419,7 +500,7 @@ function progressStageForMilestone(key) {
+     cars: "activities",
+     activities: "activities",
+     workspace: "plan",
+-    booked: "plan",
++    booked: "packet",
+   };
+   return map[key] || "start";
+ }
+@@ -447,6 +528,9 @@ function renderStage() {
+   } else if (state.activeStage === "plan") {
+     body.innerHTML = planStage();
+     wirePlanStage(body);
++  } else if (state.activeStage === "packet") {
++    body.innerHTML = packetStage();
++    wirePacketStage(body);
+   } else {
+     body.innerHTML = learningStage();
+     wireFeedbackForms(body, "review");
+@@ -560,8 +644,7 @@ function intakeStage() {
+       </section>
+ 
+       <div class="button-row">
+-        <button type="submit">Save intake</button>
+-        <button type="button" class="secondary" id="draftFromIntake">Save and build options</button>
++        <button type="submit">Save and start planning</button>
+       </div>
+       <p class="inline-result"></p>
+     </form>
+@@ -575,19 +658,12 @@ function draftStage() {
+     return `<div class="empty-state">Create or select a trip first.</div>`;
+   }
+   const options = draft?.options || [];
+-  const buttonLabel = options.length ? "Refresh from intake" : "Build options";
+   return `
+-    <div class="stage-card action-card">
+-      <div>
+-        <h3>${options.length ? "Planning shapes are deterministic from the saved intake" : "Build planning shapes"}</h3>
+-        <p>${options.length ? "Refresh only after changing constraints. Choosing one shape moves directly into flights." : "Trippy will build a small set of planning shapes from the saved intake."}</p>
+-      </div>
+-      <button id="draftButton" type="button">${buttonLabel}</button>
+-      <p class="inline-result"></p>
+-    </div>
++    ${stageNotice("options")}
+     <div class="option-grid">
+-      ${options.length ? options.map(planOptionCard).join("") : `<div class="empty-state">No options yet.</div>`}
++      ${options.length ? options.map(planOptionCard).join("") : `<div class="empty-state">Building planning shapes...</div>`}
+     </div>
++    <p class="inline-result"></p>
+     ${feedbackBlock("draft")}
+   `;
+ }
+@@ -627,7 +703,18 @@ function flightCandidateForm() {
+     <div class="form-grid">
+       ${input("name", "Airline / label", "", "text")}
+       ${input("link", "Link", "", "url")}
+-      ${textarea("notes", "Flight notes", "", "Example: Air Canada AC123 + TAP TP1861, depart 9:15 PM, arrive 2:20 PM, duration 10h 35m, 1 stop via LIS, layover 2h 20m, CAD 1180 pp, checked bag included.")}
++      ${input("flight_numbers", "Flight number(s)", "", "text")}
++      ${input("departure_date", "Depart date", "", "date")}
++      ${input("departure_time", "Depart time", "", "text")}
++      ${input("arrival_date", "Arrive date", "", "date")}
++      ${input("arrival_time", "Arrive time", "", "text")}
++      ${input("total_duration", "Total duration", "", "text")}
++      ${input("stops", "Stops", "", "number")}
++      ${input("layover_airports", "Layover airport(s)", "", "text")}
++      ${input("layover_duration", "Layover duration", "", "text")}
++      ${input("price_band", "Price", "", "text")}
++      ${input("baggage_notes", "Baggage / cabin", "", "text")}
++      ${textarea("notes", "Flight notes", "", "Paste exact itinerary text if you have it. Example: AC880 + TP1861, depart 2026-08-24 9:15 PM, arrive 2026-08-25 2:20 PM, duration 10h 35m, 1 stop via LIS, layover 2h 20m, CAD 1180 pp.")}
+     </div>
+     <div class="button-row">
+       <button type="submit">Evaluate flight</button>
+@@ -662,18 +749,10 @@ function flightsStage() {
+   const shortlist = shortlistByCategory("flights");
+   return `
+     <div class="guided-step-layout">
+-      <section class="stage-card action-card">
+-        <div>
+-          <p class="eyebrow">Step 4</p>
+-          <h3>Find the best flight fit</h3>
+-          <p>Compare timing, route pain, price bands, and source confidence. Trippy recommends the lowest-friction option from current evidence.</p>
+-          ${truthLegend()}
+-        </div>
+-        <div class="button-row compact-buttons">
+-          <button data-shortlist="flights" data-auto-research="true" type="button">${shortlist ? "Refresh flights" : "Find flights"}</button>
+-        </div>
++      <div class="inline-toolbar">
++        <button data-shortlist="flights" data-auto-research="true" type="button">${shortlist ? "Refresh flights" : "Find flights"}</button>
+         <p class="inline-result"></p>
+-      </section>
++      </div>
+       ${shortlist ? flightComparison(shortlist) : `<div class="empty-state">Flight suggestions appear here after you choose a trip shape.</div>`}
+       <details class="stage-card quiet-details">
+         <summary>Add a flight you found</summary>
+@@ -702,9 +781,6 @@ function lodgingStage() {
+           <p>Trippy checks whether one base or split stays better matches the chosen trip shape, then compares properties against party fit.</p>
+           ${truthLegend()}
+         </div>
+-        <div class="button-row compact-buttons">
+-          <button data-shortlist="lodging" data-auto-research="true" type="button">${shortlist ? "Refresh lodging" : "Find lodging"}</button>
+-        </div>
+         <p class="inline-result"></p>
+       </section>
+       ${lodgingStructurePanel(shortlist)}
+@@ -737,7 +813,7 @@ function activitiesStage() {
+           <p>Keep the days balanced: safe, well-reviewed activities, practical driving, and enough downtime.</p>
+         </div>
+         <div class="button-row compact-buttons">
+-          <button data-shortlist="activities" type="button">${activities ? "Refresh activities" : "Find activities"}</button>
++          <button data-shortlist="activities" data-auto-research="true" type="button">${activities ? "Research activities" : "Find activities"}</button>
+           <button data-shortlist="cars" type="button">${cars ? "Refresh cars" : "Find cars"}</button>
+         </div>
+         <p class="inline-result"></p>
+@@ -767,12 +843,11 @@ function planStage() {
+   const sheetButtonLabel = hasGoogleSheet ? "Update Google Sheet" : "Create Google Sheet";
+   return `
+     <div class="guided-step-layout">
+-      ${structureGuidancePanel()}
+-      <section class="stage-card action-card">
++      <section class="stage-card action-card compact-stage-actions">
+         <div>
+           <p class="eyebrow">Step 7</p>
+-          <h3>Google Sheet and custom map</h3>
+-          <p>Keep the planning sheet, timeline, map anchors, risks, and next actions current.</p>
++          <h3>Google Sheet and trip map</h3>
++          <p>Use the sheet as the real planning surface. Keep the map aligned to the chosen flight, stay plan, and activity sequence.</p>
+         </div>
+         <div class="button-row compact-buttons">
+           <button id="googleWorkspaceButton" type="button">${sheetButtonLabel}</button>
+@@ -780,17 +855,94 @@ function planStage() {
+         </div>
+         <p class="inline-result"></p>
+       </section>
+-      ${workspace ? workspaceSummary(workspace) : `<div class="empty-state">Create the Google Sheet to build the Master Timeline, map anchors, and risks.</div>`}
++      ${
++        workspace?.google_sheet_url
++          ? googleSheetPanel(workspace, "Trip planning workspace", "The live sheet should stay ahead of this UI for timeline, links, confirmations, and logistics.")
++          : `<div class="empty-state">Create the Google Sheet to make the trip timeline, confirmations, and logistics editable in one place.</div>`
++      }
+       ${artifact ? embeddedMapPanel(artifact) : fallbackMapPanel(mapRows)}
+       <div class="button-row step-forward-row">
+         <button type="button" class="secondary" data-next-stage="activities">Back to activities</button>
+-        <button type="button" data-next-stage="review">Next: feedback</button>
++        <button type="button" data-next-stage="packet">Next: trip packet</button>
+       </div>
+     </div>
+     ${feedbackBlock("plan")}
+   `;
+ }
+ 
++function packetStage() {
++  if (!state.activeTripId) {
++    return `<div class="empty-state">Create or select a trip first.</div>`;
++  }
++  const packet = state.trip?.trip_packet || {};
++  const items = packet.items || [];
++  const workspace = state.trip?.workspace;
++  return `
++    <div class="guided-step-layout">
++      <section class="stage-card packet-hero compact-packet-hero">
++        <div>
++          <p class="eyebrow">Trip packet</p>
++          <h3>${escapeHtml(packet.status_label || "Still needs confirmations")}</h3>
++          <p>${escapeHtml(packet.summary || "Use the sheet to capture booking details, confirmations, check-in instructions, and the final day-by-day operating plan.")}</p>
++        </div>
++        <div class="readiness-meter" aria-label="Trip packet readiness">
++          <strong>${escapeHtml(packet.readiness_percent || 0)}%</strong>
++          <span>confirmed readiness</span>
++        </div>
++      </section>
++      ${
++        (packet.missing_items || []).length
++          ? `<section class="stage-card blocker-card">
++              <p class="eyebrow">Still missing</p>
++              <ul class="tight-list">${packet.missing_items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
++            </section>`
++          : `<section class="stage-card blocker-card is-clear"><p class="eyebrow">Ready packet</p><p>Core confirmations are captured. Review the sheet, map, and timeline before departure.</p></section>`
++      }
++      ${
++        workspace?.google_sheet_url
++          ? googleSheetPanel(workspace, "Bookings and confirmations", "Best place to track real confirmation numbers, links, check-in details, and day-of notes.")
++          : `<div class="empty-state">Create the Google Sheet first so confirmations and logistics have one canonical home.</div>`
++      }
++      ${
++        items.length
++          ? `<section class="stage-card packet-summary-strip">
++              <div class="section-head compact-head">
++                <div>
++                  <p class="eyebrow">Selected now</p>
++                  <h3>Current chosen items</h3>
++                </div>
++              </div>
++              <div class="packet-mini-grid">${items.map(packetItemCard).join("")}</div>
++            </section>`
++          : ""
++      }
++      <div class="button-row step-forward-row">
++        <button type="button" class="secondary" data-next-stage="plan">Back to timeline + map</button>
++        <button type="button" id="refreshPacketWorkspace">Update Google Sheet</button>
++      </div>
++    </div>
++    ${feedbackBlock("review")}
++  `;
++}
++
++function packetItemCard(item) {
++  const time = [item.date, timeRange(item.start_time, item.end_time)].filter(Boolean).join(" · ");
++  return `<article class="packet-item-card compact ${escapeHtml(item.status)}">
++    <div>
++      <p class="eyebrow">${escapeHtml(item.category)}</p>
++      <h4>${escapeHtml(item.title)}</h4>
++      <p>${escapeHtml([item.provider, item.confirmation_code ? `Confirmation ${item.confirmation_code}` : ""].filter(Boolean).join(" · "))}</p>
++      <div class="metric-row">
++        <span class="metric ${item.status === "confirmed" ? "live" : item.status === "booked" ? "warn" : ""}">${escapeHtml(truthLabel({ row_status: item.status }))}</span>
++        ${time ? `<span class="metric">${escapeHtml(time)}</span>` : ""}
++      </div>
++      ${item.address ? `<small>${escapeHtml(item.address)}</small>` : ""}
++      ${item.notes ? `<small>${escapeHtml(item.notes)}</small>` : ""}
++      ${externalLink(item.booking_link || item.source_url, "Open booking")}
++    </div>
++  </article>`;
++}
++
+ function workspaceStage() {
+   const workspace = state.trip?.workspace;
+   return `
+@@ -856,17 +1008,7 @@ function wireIntakeStage(root) {
+   form.querySelector("[name=party_type]").addEventListener("change", () => adaptPartyFields(form, true));
+   form.addEventListener("submit", async (event) => {
+     event.preventDefault();
+-    await saveIntake(form, result);
+-  });
+-  root.querySelector("#draftFromIntake").addEventListener("click", async () => {
+-    const response = await saveIntake(form, result);
+-    if (response?.intake?.trip_id) {
+-      const draft = await apiPost("/api/draft", { trip_id: response.intake.trip_id });
+-      state.lastWorkflowByStage.draft = draft.workflow_id;
+-      state.activeStage = "options";
+-      await loadTrip(response.intake.trip_id);
+-      render();
+-    }
++    await saveIntake(form, result, { continuePlanning: true });
+   });
+   wireFeedbackForms(root, "intake");
+ }
+@@ -916,17 +1058,30 @@ function setFormValue(form, name, value) {
+   }
+ }
+ 
+-async function saveIntake(form, result) {
++async function saveIntake(form, result, options = {}) {
+   try {
+-    setWorking(result, "Saving intake");
++    const continuePlanning = options.continuePlanning === true;
++    setWorking(result, continuePlanning ? "Saving intake..." : "Saving intake");
+     const payload = formPayload(form);
+     const response = await apiPost("/api/intake", payload);
+     state.lastWorkflowByStage.intake = response.workflow_id;
+     state.activeTripId = response.intake.trip_id;
+     state.isCreatingTrip = false;
+     state.suggestedIntake = null;
+-    await loadTrip(response.intake.trip_id);
+-    result.textContent = `Saved ${response.intake.trip_id}`;
++    if (continuePlanning) {
++      setWorking(result, "Saved. Building trip options...");
++      const draft = await apiPost("/api/draft", { trip_id: response.intake.trip_id });
++      state.lastWorkflowByStage.draft = draft.workflow_id;
++      state.guidedNotice = {
++        stage: "options",
++        title: "Intake saved. Next: choose the trip shape.",
++        message:
++          "Pick one option below; Trippy will then walk you into flights, lodging, activities, the timeline, and the trip packet.",
++      };
++      await loadTrip(response.intake.trip_id, { stage: "options" });
++    } else {
++      await loadTrip(response.intake.trip_id, { gotoNext: true });
++    }
+     return response;
+   } catch (error) {
+     result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+@@ -934,13 +1089,18 @@ async function saveIntake(form, result) {
+   }
+ }
+ 
+-function wireDraftStage(root) {
+-  const button = root.querySelector("#draftButton");
+-  if (button) {
+-    button.addEventListener("click", async () => {
+-      await runStage(root, "draft", "/api/draft", { trip_id: state.activeTripId });
+-    });
++function stageNotice(stage) {
++  if (state.guidedNotice?.stage !== stage) {
++    return "";
+   }
++  return `<div class="guided-notice">
++    <strong>${escapeHtml(state.guidedNotice.title || "Next step")}</strong>
++    <span>${escapeHtml(state.guidedNotice.message || guidedNextStep())}</span>
++  </div>`;
++}
++
++function wireDraftStage(root) {
++  ensureDraftOptions(root);
+   root.querySelectorAll("[data-select-option]").forEach((selectButton) => {
+     selectButton.addEventListener("click", async () => {
+       await selectOptionAndStartResearch(root, selectButton.dataset.selectOption);
+@@ -949,6 +1109,24 @@ function wireDraftStage(root) {
+   wireFeedbackForms(root, "draft");
+ }
+ 
++async function ensureDraftOptions(root) {
++  if (!state.activeTripId || state.trip?.draft?.options?.length || state.isAutoDrafting) {
++    return;
++  }
++  const result = root.querySelector(".inline-result");
++  try {
++    state.isAutoDrafting = true;
++    setWorking(result, "Building trip options...");
++    const response = await apiPost("/api/draft", { trip_id: state.activeTripId });
++    state.lastWorkflowByStage.draft = response.workflow_id;
++    await loadTrip(state.activeTripId, { stage: "options" });
++  } catch (error) {
++    result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
++  } finally {
++    state.isAutoDrafting = false;
++  }
++}
++
+ async function selectOptionAndStartResearch(root, optionId) {
+   const result = root.querySelector(".inline-result");
+   try {
+@@ -1108,12 +1286,13 @@ function wireFlightsStage(root) {
+       }
+     });
+   });
++  wireBookingForms(root);
+   wireStageNavigation(root);
+   wireFeedbackForms(root, "flights");
+ }
+ 
+ function wireLodgingStage(root) {
+-  wireShortlistButtons(root, "lodging");
++  ensureLodgingOptions(root);
+   const structureForm = root.querySelector("#stayStructureForm");
+   if (structureForm) {
+     structureForm.addEventListener("submit", async (event) => {
+@@ -1129,6 +1308,27 @@ function wireLodgingStage(root) {
+           notes: payload.notes || "",
+         });
+         state.lastWorkflowByStage.lodging = response.workflow_id;
++        state.pendingScrollTarget = "#lodgingComparison";
++        await loadTrip(state.activeTripId, { stage: "lodging" });
++      } catch (error) {
++        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
++      }
++    });
++  }
++  root.querySelectorAll("[data-use-stay-option]").forEach((button) => {
++    button.addEventListener("click", async () => {
++      const result = root.querySelector(".inline-result");
++      const option = stayStructureOptionById(button.dataset.useStayOption);
++      if (!option) return;
++      try {
++        setWorking(result, "Saving selected stay structure");
++        const response = await apiPost("/api/lodging-structure", {
++          trip_id: state.activeTripId,
++          strategy: option.strategy || "split_stay",
++          night_plan: option.night_plan || [],
++          notes: `Selected ${option.title || "stay structure"}: ${option.summary || ""}`,
++        });
++        state.lastWorkflowByStage.lodging = response.workflow_id;
+         await loadTrip(state.activeTripId);
+         state.activeStage = "lodging";
+         render();
+@@ -1136,7 +1336,21 @@ function wireLodgingStage(root) {
+         result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+       }
+     });
+-  }
++  });
++  root.querySelectorAll("[data-edit-stay-option]").forEach((button) => {
++    button.addEventListener("click", () => {
++      const option = stayStructureOptionById(button.dataset.editStayOption);
++      if (!option || !structureForm) return;
++      const strategy = structureForm.querySelector("[name=strategy]");
++      const nightPlan = structureForm.querySelector("[name=night_plan_text]");
++      const notes = structureForm.querySelector("[name=notes]");
++      if (strategy) strategy.value = option.strategy || "split_stay";
++      if (nightPlan) nightPlan.value = stayStructureText(option.night_plan || []);
++      if (notes) notes.value = `${option.title || "Stay option"}: ${option.summary || ""}`;
++      structureForm.scrollIntoView({ behavior: "smooth", block: "center" });
++      nightPlan?.focus();
++    });
++  });
+   const candidate = root.querySelector("#lodgingCandidateForm");
+   if (candidate) {
+     candidate.addEventListener("submit", async (event) => {
+@@ -1177,10 +1391,42 @@ function wireLodgingStage(root) {
+       }
+     });
+   });
++  wireBookingForms(root);
+   wireStageNavigation(root);
+   wireFeedbackForms(root, "lodging");
+ }
+ 
++async function ensureLodgingOptions(root) {
++  const shortlist = shortlistByCategory("lodging");
++  if (!state.activeTripId || shortlist?.lodging_options?.length || state.isAutoBuildingLodging) {
++    return;
++  }
++  const result = root.querySelector(".inline-result");
++  try {
++    state.isAutoBuildingLodging = true;
++    setWorking(result, "Building lodging options...");
++    const lodging = await apiPost("/api/shortlist", {
++      trip_id: state.activeTripId,
++      category: "lodging",
++      validate_live: true,
++      deep_research: true,
++      adapter: "auto",
++    });
++    state.lastWorkflowByStage.lodging = lodging.workflow_id;
++    setWorking(result, "Thinking through stay structure options...");
++    const structure = await apiPost("/api/lodging-structure-suggestions", {
++      trip_id: state.activeTripId,
++      use_llm: true,
++    });
++    state.lastWorkflowByStage.lodging = structure.workflow_id;
++    await loadTrip(state.activeTripId, { stage: "lodging" });
++  } catch (error) {
++    result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
++  } finally {
++    state.isAutoBuildingLodging = false;
++  }
++}
++
+ function wireActivitiesStage(root) {
+   wireShortlistButtons(root, "activities");
+   root.querySelectorAll("[data-select-car]").forEach((button) => {
+@@ -1245,6 +1491,7 @@ function wireActivitiesStage(root) {
+       }
+     });
+   });
++  wireBookingForms(root);
+   wireStageNavigation(root);
+   wireFeedbackForms(root, "activities");
+ }
+@@ -1274,6 +1521,21 @@ function wirePlanStage(root) {
+   wireFeedbackForms(root, "plan");
+ }
+ 
++function wirePacketStage(root) {
++  wireBookingForms(root);
++  root.querySelector("#refreshPacketWorkspace")?.addEventListener("click", async () => {
++    await runStage(root, "plan", "/api/workspace", {
++      trip_id: state.activeTripId,
++      validate_live: true,
++      create_google_sheet: true,
++    });
++    state.activeStage = "packet";
++    render();
++  });
++  wireStageNavigation(root);
++  wireFeedbackForms(root, "review");
++}
++
+ function wireShortlistButtons(root, stage) {
+   root.querySelectorAll("[data-shortlist]").forEach((button) => {
+     button.addEventListener("click", async () => {
+@@ -1302,6 +1564,27 @@ function wireStageNavigation(root) {
+   });
+ }
+ 
++function wireBookingForms(root) {
++  root.querySelectorAll("[data-booking-form]").forEach((form) => {
++    form.addEventListener("submit", async (event) => {
++      event.preventDefault();
++      const result = form.querySelector(".inline-result");
++      try {
++        setWorking(result, "Saving booking details");
++        const payload = formPayload(form);
++        payload.trip_id = state.activeTripId;
++        const response = await apiPost("/api/trip-packet/item", payload);
++        state.lastWorkflowByStage.packet = response.workflow_id;
++        await loadTrip(state.activeTripId);
++        state.activeStage = state.activeStage === "packet" ? "packet" : state.activeStage;
++        render();
++      } catch (error) {
++        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
++      }
++    });
++  });
++}
++
+ function wireWorkspaceStage(root) {
+   const button = root.querySelector("#workspaceButton");
+   if (button) {
+@@ -1838,17 +2121,14 @@ function renderShortlistPanel(shortlist) {
+ 
+ function flightComparison(shortlist) {
+   const rows = sortedFlights(shortlist.flight_options || []);
+-  const recommended = (shortlist.flight_options || []).find((option) => option.option_id === shortlist.recommended_option_id) || rows[0];
+-  const runner = rows.find((option) => option.option_id !== recommended?.option_id);
+   return `<section class="comparison-panel">
+-    <div class="comparison-head">
++    <div class="comparison-head compact-head compare-header-tight">
+       <div>
+         <p class="eyebrow">Flights</p>
+-        <h3>Routing and timing comparison</h3>
+-        <p>${escapeHtml(shortlist.recommendation_summary || "")}</p>
++        <h3>Exact compare</h3>
++        <p>Choose on airline, flight number, takeoff, landing, duration, and price. Everything else is secondary.</p>
+       </div>
+       <div class="compare-tools">
+-        <span class="metric live">Recommended ${escapeHtml(shortlist.recommended_option_id || "TBD")}</span>
+         <label>Sort
+           <select id="flightSort">
+             ${["best", "cheapest", "shortest", "lowest-friction"].map((value) => `<option value="${value}" ${state.flightSort === value ? "selected" : ""}>${escapeHtml(labelForSort(value))}</option>`).join("")}
+@@ -1856,19 +2136,17 @@ function flightComparison(shortlist) {
+         </label>
+       </div>
+     </div>
+-    ${recommended ? flightRecommendationPanel(recommended, runner) : ""}
+     <div class="comparison-table-wrap">
+       <table class="comparison-table flight-table">
+         <thead>
+           <tr>
+             <th>Pick</th>
+-            <th>Airline / source</th>
+-            <th>Timing</th>
+-            <th>Route</th>
++            <th>Airline / flight #</th>
++            <th>Takeoff</th>
++            <th>Landing</th>
+             <th>Duration</th>
+             <th>Price</th>
+-            <th>Friction</th>
+-            <th></th>
++            <th>Link</th>
+           </tr>
+         </thead>
+         <tbody>
+@@ -1881,57 +2159,107 @@ function flightComparison(shortlist) {
+ 
+ function flightRow(option) {
+   const isRecommended = option.option_id === recommendedId("flights");
+-  const layover = (option.layover_airports || []).length
+-    ? `${option.layover_airports.join(", ")} · ${option.layover_duration || "duration TBD"}`
+-    : "Nonstop";
++  const timingMissing = !specificFlightValue(option.departure_time) || !specificFlightValue(option.arrival_time);
++  const numberMissing = !(option.flight_numbers || []).length;
++  const truth = truthLabel(option);
+   return `<tr class="${isRecommended ? "recommended-row" : ""}">
+     <td>
+       <span class="flight-label ${isRecommended ? "is-recommended" : ""}">${escapeHtml(option.recommendation_label || option.recommendation_grade || "")}</span>
+       <button class="mini-button" type="button" data-select-flight="${escapeHtml(option.option_id)}">${isRecommended ? "Use" : "Choose"}</button>
++      ${(timingMissing || numberMissing) ? `<small>${escapeHtml([numberMissing ? "flight # pending" : "", timingMissing ? "times pending" : ""].filter(Boolean).join(" · "))}</small>` : `<small>${escapeHtml(truth)}</small>`}
+     </td>
+     <td>
+       <strong>${escapeHtml(option.airline)}</strong>
+-      <small>${escapeHtml(option.booking_source)} · ${statusSummary(option)}</small>
++      <small>${escapeHtml(formatFlightNumbers(option))} · ${escapeHtml(option.booking_source)}</small>
+     </td>
+     <td>
+-      <strong>${escapeHtml(option.departure_time || "Live verify departure")}</strong>
+-      <small>${escapeHtml(option.arrival_time || "Live verify arrival")}</small>
++      <strong>${escapeHtml(formatFlightTiming(option))}</strong>
++      <small>${escapeHtml(option.departure_airport || "")}</small>
+     </td>
+     <td>
+-      <strong>${escapeHtml(option.departure_airport)} to ${escapeHtml(option.arrival_airport)}</strong>
+-      <small>${escapeHtml(option.stops === 0 ? "Nonstop" : `${option.stops} stop(s)`)} · ${escapeHtml(layover)}</small>
++      <strong>${escapeHtml(formatFlightArrival(option))}</strong>
++      <small>${escapeHtml(option.arrival_airport || "")}</small>
+     </td>
+     <td>
+       <strong>${escapeHtml(option.total_travel_duration)}</strong>
+-      <small>${escapeHtml(option.timing_implication || option.timing_fit || option.traveler_fit || "")}</small>
++      <small>${escapeHtml(flightDurationNote(option))}</small>
+     </td>
+     <td>
+-      <strong>${escapeHtml(option.price_band)}</strong>
+-      <small>${escapeHtml(option.fare_estimate_cad || "")}</small>
++      <strong>${escapeHtml(option.validation?.extracted_fields?.price_signal || option.price_band)}</strong>
++      <small>${escapeHtml(option.fare_estimate_cad || option.validation?.price_status?.replaceAll("_", " ") || "")}</small>
+     </td>
+     <td>
+-      <span class="score-pill">${escapeHtml(option.friction_score)} friction</span>
+-      <small>${escapeHtml(option.recommendation_rationale || (option.friction_flags || [])[0] || option.recommendation_grade || "")}</small>
+-      ${evidenceDetails(option)}
++      <div class="action-stack">
++        ${externalLink(option.deep_link, "Open search")}
++        ${bookingForm("flight", option)}
++      </div>
+     </td>
+-    <td>${externalLink(option.deep_link, "Open")}</td>
+   </tr>`;
+ }
+ 
+-function flightRecommendationPanel(recommended, runner) {
+-  return `<div class="recommendation-panel">
+-    <div>
+-      <p class="eyebrow">${escapeHtml(recommended.recommendation_label || "Recommended")}</p>
+-      <h4>${escapeHtml(recommended.airline)}</h4>
+-      <p>${escapeHtml(recommended.recommendation_rationale || recommended.timing_fit || "")}</p>
+-      <p class="subtle">${escapeHtml(recommended.date_viability_signal || "")}</p>
+-    </div>
+-    ${runner ? `<div>
+-      <p class="eyebrow">Runner-up</p>
+-      <strong>${escapeHtml(runner.airline)}</strong>
+-      <p>${escapeHtml(runner.recommendation_rationale || runner.timing_fit || "")}</p>
+-    </div>` : ""}
+-  </div>`;
++function formatFlightNumbers(option) {
++  const numbers = option.flight_numbers || [];
++  return numbers.length ? numbers.join(" + ") : "Flight # pending";
++}
++
++function formatFlightTiming(option) {
++  const date = option.departure_date || "";
++  const time = specificFlightValue(option.departure_time) || "";
++  if (date || time) {
++    return [date, time].filter(Boolean).join(" · ");
++  }
++  return "Takeoff pending";
++}
++
++function formatFlightArrival(option) {
++  const date = option.arrival_date || "";
++  const time = specificFlightValue(option.arrival_time) || "";
++  if (date || time) {
++    return [date, time].filter(Boolean).join(" · ");
++  }
++  return "Landing pending";
++}
++
++function flightDurationNote(option) {
++  const stops = Number(option.stops || 0);
++  if (!stops) {
++    return "Nonstop";
++  }
++  const layover = (option.layover_airports || []).length
++    ? `${option.layover_airports.join(", ")}${option.layover_duration ? ` · ${option.layover_duration}` : ""}`
++    : `${stops} stop(s)`;
++  return layover;
++}
++
++function flightExactness(option) {
++  const missing = new Set(option.validation?.missing_fields || []);
++  const hasNumbers = (option.flight_numbers || []).length > 0;
++  const hasSpecificTimes = Boolean(specificFlightValue(option.departure_time) && specificFlightValue(option.arrival_time));
++  const hasDates = Boolean(option.departure_date && option.arrival_date);
++  const hasPrice = option.validation?.price_status === "live_signal" || !String(option.price_band || "").toLowerCase().includes("live-verify");
++  if (hasNumbers && hasSpecificTimes && hasDates && hasPrice && missing.size <= 2) {
++    return "exact itinerary";
++  }
++  if (hasNumbers && hasSpecificTimes) {
++    return "partial itinerary";
++  }
++  return "needs exact itinerary";
++}
++
++function specificFlightValue(value) {
++  const text = String(value || "").trim();
++  if (!text) return "";
++  const lower = text.toLowerCase();
++  if (
++    lower.includes("target ") ||
++    lower.includes("variable") ||
++    lower.includes("live verify") ||
++    lower.includes("verify ") ||
++    lower.includes("not supplied")
++  ) {
++    return "";
++  }
++  return text;
+ }
+ 
+ function sortedFlights(rows) {
+@@ -1964,18 +2292,55 @@ function labelForSort(value) {
+ 
+ function truthLegend() {
+   return `<div class="truth-legend" aria-label="Data confidence guide">
+-    <span class="truth-chip verified">Verified from source</span>
+-    <span class="truth-chip partial">Partial / approximate</span>
+-    <span class="truth-chip review">Needs manual check</span>
++    <span class="truth-chip idea">Idea</span>
++    <span class="truth-chip partial">Estimate</span>
++    <span class="truth-chip verified">Checked</span>
++    <span class="truth-chip selected">Selected</span>
++    <span class="truth-chip booked">Booked</span>
++    <span class="truth-chip confirmed">Confirmed</span>
+   </div>`;
+ }
+ 
++function bookingForm(category, option, existing = null) {
++  const title = option.airline || option.name || option.vehicle_class || option.activity_name || option.title || "";
++  const provider = existing?.provider || option.booking_source || option.source || "";
++  const link = existing?.booking_link || existing?.source_url || option.deep_link || "";
++  const status = existing?.status || (option.row_status === "confirmed" ? "confirmed" : option.row_status === "booked" ? "booked" : "booked");
++  return `<details class="booking-details">
++    <summary>${existing?.confirmation_code ? "Edit confirmation" : "Book / confirm"}</summary>
++    <form data-booking-form class="booking-form">
++      <input type="hidden" name="category" value="${escapeHtml(category)}" />
++      <input type="hidden" name="option_id" value="${escapeHtml(option.option_id || existing?.option_id || "")}" />
++      <label>Status
++        <select name="status">
++          <option value="booked" ${status === "booked" ? "selected" : ""}>Booked</option>
++          <option value="confirmed" ${status === "confirmed" ? "selected" : ""}>Confirmed</option>
++        </select>
++      </label>
++      ${input("provider", "Provider", provider)}
++      ${input("confirmation_code", "Confirmation code", existing?.confirmation_code || "")}
++      ${input("booking_link", "Booking link", link, "url")}
++      ${input("date", "Date", existing?.date || "", "date")}
++      <div class="inline-two">
++        ${input("start_time", "Start", existing?.start_time || option.departure_time || option.scheduled_start_time || "", "text")}
++        ${input("end_time", "End", existing?.end_time || option.arrival_time || option.scheduled_end_time || "", "text")}
++      </div>
++      ${input("address", "Address", existing?.address || "")}
++      ${input("cost_cad", "Cost CAD", existing?.cost_cad || "", "number")}
++      ${textarea("notes", "Trip-day notes", existing?.notes || "", `${title} check-in, seats, access, baggage, pickup, or voucher notes.`)}
++      <button class="mini-button" type="submit">Save packet detail</button>
++      <small class="inline-result"></small>
++    </form>
++  </details>`;
++}
++
+ function lodgingStructurePanel(shortlist) {
+   const structure = shortlist?.artifacts?.lodging_structure || inferredLodgingStructure();
+   if (!structure) {
+     return `<div class="empty-state">Choose a trip shape to see one-stay vs split-stay guidance.</div>`;
+   }
+   const nightPlan = structure.night_plan || [];
++  const options = structure.options || [];
+   const label = structure.strategy === "split_stay" ? "Split stays" : "One stay";
+   const selectedLodging = structure.selected_lodging_option_id
+     ? `Selected lodging: ${structure.selected_lodging_option_id}`
+@@ -1984,7 +2349,7 @@ function lodgingStructurePanel(shortlist) {
+     <div>
+       <p class="eyebrow">Stay structure</p>
+       <h3>${escapeHtml(label)} ${structure.confidence ? `<span>${escapeHtml(structure.confidence)}</span>` : ""}</h3>
+-      <p>${escapeHtml(structure.summary || "")}</p>
++      <p>${escapeHtml(structure.summary || "Pick a stay approach, then edit the night split if needed.")}</p>
+       <p class="subtle">${escapeHtml(selectedLodging)} · ${escapeHtml(structure.data_status || "plan-based")}</p>
+     </div>
+     <div class="night-plan">
+@@ -1993,11 +2358,54 @@ function lodgingStructurePanel(shortlist) {
+         <span>${escapeHtml(item.nights)} night(s)</span>
+       </article>`).join("")}
+     </div>
+-    ${(structure.reasoning || []).length ? `<ul class="tight-list">${structure.reasoning.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : ""}
++    ${options.length ? stayStructureOptionsGrid(options, structure.recommended_structure_id) : ""}
+     ${stayStructureForm(structure)}
+   </section>`;
+ }
+ 
++function stayStructureOptionsGrid(options, recommendedId) {
++  return `<div class="stay-option-grid">
++    ${options.slice(0, 3).map((option, index) => stayStructureOptionCard(option, index, recommendedId)).join("")}
++  </div>`;
++}
++
++function stayStructureOptionCard(option, index, recommendedId) {
++  const isRecommended = option.structure_id === recommendedId || (!recommendedId && index === 0);
++  const nightPlan = option.night_plan || [];
++  const reasons = (option.reasoning || []).slice(0, 2);
++  return `<article class="stay-option-card ${isRecommended ? "recommended-row" : ""}">
++    ${stayStructureMapThumb(option, index)}
++    <div class="stay-option-body">
++      <div class="option-head">
++        <h4>${escapeHtml(option.title || "Stay option")}</h4>
++        <span class="metric ${isRecommended ? "live" : ""}">${escapeHtml(option.recommendation_label || "option")}</span>
++      </div>
++      <p>${escapeHtml(option.summary || "")}</p>
++      <div class="night-plan mini">
++        ${nightPlan.map((item) => `<article><strong>${escapeHtml(item.region)}</strong><span>${escapeHtml(item.nights)}n</span></article>`).join("")}
++      </div>
++      ${reasons.length ? `<ul class="tight-list">${reasons.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : ""}
++      <div class="stay-option-actions">
++        <button type="button" data-use-stay-option="${escapeHtml(option.structure_id)}">Use</button>
++        <button type="button" class="secondary" data-edit-stay-option="${escapeHtml(option.structure_id)}">Edit</button>
++      </div>
++    </div>
++  </article>`;
++}
++
++function stayStructureMapThumb(option, index) {
++  const regions = option.map_regions?.length
++    ? option.map_regions
++    : (option.night_plan || []).map((item) => item.region);
++  const variant = Number(option.thumbnail_variant || index + 1);
++  return `<div class="option-map-thumb stay-map-thumb option-${Math.min(Math.max(variant, 1), 3)}">
++    <div class="map-route-line"></div>
++    <div class="map-pin-row">
++      ${regions.slice(0, 4).map((region, pinIndex) => `<span class="map-pin" style="--pin-index:${pinIndex}">${escapeHtml(region)}</span>`).join("")}
++    </div>
++  </div>`;
++}
++
+ function stayStructureForm(structure) {
+   const strategy = structure.strategy || "single_stay";
+   const text = stayStructureText(structure.night_plan || []);
+@@ -2010,7 +2418,7 @@ function stayStructureForm(structure) {
+         </select>
+       </label>
+     </div>
+-    <label>Move nights around
++    <label>Edit nights
+       <textarea name="night_plan_text" rows="4" placeholder="Ponta Delgada | 4 | lodging-1 | central base&#10;Furnas | 3 | lodging-2 | hot springs side">${escapeHtml(text)}</textarea>
+     </label>
+     <label>Why this structure?
+@@ -2024,6 +2432,11 @@ function stayStructureForm(structure) {
+   </form>`;
+ }
+ 
++function stayStructureOptionById(optionId) {
++  const structure = shortlistByCategory("lodging")?.artifacts?.lodging_structure;
++  return (structure?.options || []).find((option) => option.structure_id === optionId);
++}
++
+ function stayStructureText(nightPlan) {
+   return nightPlan
+     .map((item) =>
+@@ -2097,15 +2510,13 @@ function durationHours(value) {
+ 
+ function statusSummary(option) {
+   const validation = option.validation || {};
+-  const status = validation.verification_status || option.row_status || "researched";
+-  const freshness = validation.freshness_status && validation.freshness_status !== "unknown" ? validation.freshness_status : "";
+-  const confidence = validation.confidence ? `${Math.round(Number(validation.confidence) * 100)}%` : "";
+-  const adapter = validation.adapter_used ? `${validation.adapter_used}` : "";
++  const truth = truthLabel(option);
++  const freshness = displayFreshnessStatus(validation.freshness_status);
++  const confidence = validation.confidence ? `${Math.round(Number(validation.confidence) * 100)}% confidence` : "";
+   return `<span class="status-badges">
+-    <span class="status-badge ${status === "live_verified" || option.row_status === "verified_live" ? "ok" : "partial"}">${escapeHtml(status)}</span>
++    <span class="status-badge ${truthClass(option)}">${escapeHtml(truth)}</span>
+     ${freshness ? `<span class="status-badge">${escapeHtml(freshness)}</span>` : ""}
+     ${confidence ? `<span class="status-badge">${escapeHtml(confidence)}</span>` : ""}
+-    ${adapter ? `<span class="status-badge">${escapeHtml(adapter)}</span>` : ""}
+   </span>`;
+ }
+ 
+@@ -2125,76 +2536,181 @@ function evidenceDetails(option) {
+ 
+ function lodgingComparison(shortlist) {
+   const rows = shortlist.lodging_options || [];
+-  return `<section class="comparison-panel">
+-    <div class="comparison-head">
++  const structure = shortlist.artifacts?.lodging_structure;
++  const stayPlan = lodgingStayPlan(structure);
++  const grouped = structure?.strategy === "split_stay" && stayPlan.length > 1;
++  return `<section id="lodgingComparison" class="comparison-panel" tabindex="-1">
++    <div class="comparison-head compact-head compare-header-tight">
+       <div>
+         <p class="eyebrow">Lodging</p>
+-        <h3>Fit, location, beds, and value</h3>
+-        <p>${escapeHtml(shortlist.recommendation_summary || "")}</p>
++        <h3>${grouped ? "Choose one place per stay base" : "Choose the best place to stay"}</h3>
++        <p>${escapeHtml(grouped ? "The saved stay split now drives the comparison. Each list below is tied to one stay window and one area." : "Focus on place, cost, dates, location, and the reason it earned its score.")}</p>
+       </div>
+-      <span class="metric live">Recommended ${escapeHtml(shortlist.recommended_option_id || "TBD")}</span>
++      <span class="metric live">${escapeHtml(shortlist.recommended_option_id ? `Top pick ${shortlist.recommended_option_id}` : "Compare")}</span>
+     </div>
++    ${grouped ? lodgingGroupedLists(rows, stayPlan) : lodgingTable(rows, stayPlan[0] || defaultTripStay())}
++  </section>`;
++}
++
++function lodgingTable(rows, stay = null) {
++  return `
+     <div class="comparison-table-wrap">
+       <table class="comparison-table lodging-table">
+         <thead>
+           <tr>
+-            <th>Property / source</th>
+-            <th>Area</th>
+-            <th>Beds / party fit</th>
+-            <th>Cost / flexibility</th>
+-            <th>Access</th>
+-            <th>Score</th>
+-            <th></th>
++            <th>Pick</th>
++            <th>Place</th>
++            <th>Dates</th>
++            <th>Location</th>
++            <th>Cost</th>
++            <th>Score / why</th>
++            <th>Link</th>
+           </tr>
+         </thead>
+         <tbody>
+-          ${rows.map(lodgingRow).join("")}
++          ${rows.map((option) => lodgingRow(option, stay)).join("")}
+         </tbody>
+       </table>
++    </div>`;
++}
++
++function lodgingGroupedLists(rows, stayPlan) {
++  const assigned = new Set();
++  const groups = stayPlan.map((stay) => {
++    const matches = rows.filter((option) => lodgingOptionMatchesStay(option, stay.region));
++    matches.forEach((option) => assigned.add(option.option_id));
++    return { stay, matches };
++  });
++  const otherRows = rows.filter((option) => !assigned.has(option.option_id));
++  return `<div class="lodging-group-stack">
++    ${groups.map(({ stay, matches }, index) => lodgingRegionGroup(stay, matches, index)).join("")}
++    ${otherRows.length ? lodgingRegionGroup({ region: "Other candidates", nights: "" }, otherRows, groups.length, true) : ""}
++  </div>`;
++}
++
++function lodgingRegionGroup(stay, rows, index, secondary = false) {
++  return `<section class="lodging-region-panel ${secondary ? "secondary-region" : ""}">
++    <div class="lodging-region-head">
++      <div>
++        <p class="eyebrow">${secondary ? "Also compare" : `Stay ${index + 1}`}</p>
++        <h4>${escapeHtml(stay.region || "Base")}</h4>
++        ${stay.nights ? `<span>${escapeHtml(stay.nights)} night(s)${stay.dateLabel ? ` · ${escapeHtml(stay.dateLabel)}` : ""}</span>` : ""}
++      </div>
++      ${stay.notes ? `<p>${escapeHtml(stay.notes)}</p>` : ""}
+     </div>
++    ${rows.length ? lodgingTable(rows, stay) : `<div class="empty-state">No lodging options match this base yet. Add a candidate for ${escapeHtml(stay.region || "this location")}.</div>`}
+   </section>`;
+ }
+ 
+-function lodgingRow(option) {
++function lodgingStayPlan(structure) {
++  let cursor = 1;
++  return (structure?.night_plan || [])
++    .filter((stay) => stay?.region && Number(stay.nights || 0) > 0)
++    .map((stay) => {
++      const nights = Number(stay.nights || 0);
++      const startDay = cursor;
++      const endDay = cursor + nights - 1;
++      cursor += nights;
++      return {
++        ...stay,
++        region: String(stay.region || ""),
++        startDay,
++        endDay,
++        dateLabel: stayDateLabel(startDay, endDay),
++        summaryLabel: `Day ${startDay}${endDay > startDay ? `-${endDay}` : ""}`,
++      };
++    });
++}
++
++function defaultTripStay() {
++  const draftOption = selectedPlanOption();
++  const duration = Number(state.trip?.intake?.duration_days || draftOption?.duration_days || 0);
++  return {
++    region: state.trip?.intake?.destination_seeds?.[0] || "",
++    nights: duration || "",
++    startDay: 1,
++    endDay: duration || 1,
++    dateLabel: duration ? stayDateLabel(1, duration) : "",
++  };
++}
++
++function lodgingOptionMatchesStay(option, region) {
++  const tokens = regionTokens(region);
++  if (!tokens.length) return false;
++  const haystack = [
++    option.name,
++    option.location_area,
++    option.island_or_region,
++    option.lodging_type,
++  ].join(" ").toLowerCase();
++  return tokens.some((token) => haystack.includes(token));
++}
++
++function regionTokens(region) {
++  const stopwords = new Set([
++    "the",
++    "and",
++    "base",
++    "side",
++    "coast",
++    "area",
++    "near",
++    "central",
++    "north",
++    "south",
++    "east",
++    "west",
++    "sao",
++    "são",
++    "miguel",
++  ]);
++  return String(region || "")
++    .toLowerCase()
++    .split(/[^a-z0-9]+/)
++    .filter((token) => token.length >= 4 && !stopwords.has(token));
++}
++
++function lodgingRow(option, stay = null) {
+   const needsThreeBeds = requiresThreeBeds();
+   const isRecommended = option.option_id === recommendedId("lodging");
+-  const bedFit = [
+-    needsThreeBeds
+-      ? option.min_three_beds_satisfied === true
+-        ? "3+ beds"
+-        : "3+ beds unproven"
+-      : "party fit to verify",
+-    option.king_bed_preference_satisfied === true ? "king" : "king unproven",
+-    option.fit_category || "",
++  const cost = option.current_price_signal || option.price_band;
++  const reason = option.comfort_fit || evidenceSummary(option) || (option.friction_flags || [])[0] || option.occupancy_fit || "";
++  const scoreLabel = `${option.family_comfort_score} comfort`;
++  const stayDates = stay?.dateLabel || "";
++  const placeNotes = [
++    option.source,
++    option.king_bed_preference_satisfied === true ? "king confirmed" : needsThreeBeds ? "beds must be proven" : "",
++    displayFreshnessStatus(option.validation?.freshness_status),
+   ].filter(Boolean).join(" · ");
+   return `<tr class="${isRecommended ? "recommended-row" : ""}">
+     <td>
+-      <strong>${escapeHtml(option.name)}</strong>
+-      <small>${escapeHtml(option.source)} · ${escapeHtml(option.lodging_type)} · ${escapeHtml(validationSummary(option))}</small>
++      <button class="mini-button" type="button" data-select-lodging="${escapeHtml(option.option_id)}">${isRecommended ? "Use" : "Choose"}</button>
+     </td>
+     <td>
+-      <strong>${escapeHtml(option.location_area)}</strong>
+-      <small>${escapeHtml(option.island_or_region || "")}</small>
++      <strong>${escapeHtml(option.name)}</strong>
++      <small>${escapeHtml(placeNotes || option.lodging_type || "")}</small>
+     </td>
+     <td>
+-      <strong>${escapeHtml(bedFit)}</strong>
+-      <small>${escapeHtml(option.occupancy_fit || option.adult_child_fit || "")}</small>
++      <strong>${escapeHtml(stayDates || tripDateRangeLabel())}</strong>
++      <small>${escapeHtml(stay?.summaryLabel || "whole-trip stay window")}</small>
+     </td>
+     <td>
+-      <strong>${escapeHtml(option.current_price_signal || option.price_band)}</strong>
+-      <small>${escapeHtml(option.cancellation_notes || "")}</small>
++      <strong>${escapeHtml(option.location_area)}</strong>
++      <small>${escapeHtml(option.island_or_region || "")}</small>
+     </td>
+     <td>
+-      <strong>${escapeHtml(option.parking_practicality)}</strong>
+-      <small>${escapeHtml(option.walkability || option.driving_practicality || "")}</small>
++      <strong>${escapeHtml(cost)}</strong>
++      <small>${escapeHtml(option.cancellation_notes || "flexibility check needed")}</small>
+     </td>
+     <td>
+-      <span class="score-pill">${escapeHtml(option.family_comfort_score)} comfort</span>
+-      <small>${escapeHtml(evidenceSummary(option) || (option.friction_flags || [])[0] || option.comfort_fit || "")}</small>
++      <span class="score-pill">${escapeHtml(scoreLabel)}</span>
++      <small>${escapeHtml(reason)}</small>
+     </td>
+     <td>
+-      <button class="mini-button" type="button" data-select-lodging="${escapeHtml(option.option_id)}">${isRecommended ? "Use" : "Choose"}</button>
+-      ${externalLink(option.deep_link, "Open")}
++      <div class="action-stack">
++        ${externalLink(option.deep_link, "Open listing")}
++        ${bookingForm("lodging", option)}
++      </div>
+     </td>
+   </tr>`;
+ }
+@@ -2209,13 +2725,42 @@ function requiresThreeBeds() {
+ function validationSummary(option) {
+   const validation = option.validation || {};
+   return [
+-    validation.verification_status || "manual_required",
+-    validation.freshness_status && validation.freshness_status !== "unknown" ? validation.freshness_status : "",
+-    validation.adapter_used,
++    truthLabel(option),
++    displayFreshnessStatus(validation.freshness_status),
+     validation.confidence ? `${Math.round(Number(validation.confidence) * 100)}%` : "",
+   ].filter(Boolean).join(" · ");
+ }
+ 
++function displayFreshnessStatus(value) {
++  const status = String(value || "");
++  if (!status || status === "unknown") return "";
++  if (status === "fresh") return "recent";
++  if (status === "stale") return "needs refresh";
++  if (status === "current") return "current";
++  return status.replaceAll("_", " ");
++}
++
++function truthLabel(option) {
++  const rowStatus = option?.row_status || option?.status || "";
++  const verification = option?.validation?.verification_status || "";
++  if (rowStatus === "confirmed") return "Confirmed";
++  if (rowStatus === "booked") return "Booked";
++  if (rowStatus === "approved" || rowStatus === "selected") return "Selected";
++  if (rowStatus === "verified_live" || verification === "live_verified" || verification === "link_validated") return "Checked";
++  if (rowStatus === "seeded") return "Idea";
++  return "Estimate";
++}
++
++function truthClass(option) {
++  const label = truthLabel(option).toLowerCase();
++  if (label === "confirmed") return "confirmed";
++  if (label === "booked") return "booked";
++  if (label === "selected") return "selected";
++  if (label === "checked") return "ok";
++  if (label === "idea") return "idea";
++  return "partial";
++}
++
+ function evidenceSummary(option) {
+   const validation = option.validation || {};
+   const artifacts = validation.evidence_artifacts || [];
+@@ -2225,9 +2770,90 @@ function evidenceSummary(option) {
+   return [extracted ? `extracted ${extracted}` : "", artifact ? `evidence ${artifact}` : ""].filter(Boolean).join(" · ");
+ }
+ 
++function sortedActivityScheduleEntries(entries) {
++  return [...entries].sort((a, b) => {
++    const aDay = Number(a.scheduled_day || a.suggested_day || 999);
++    const bDay = Number(b.scheduled_day || b.suggested_day || 999);
++    if (aDay !== bDay) return aDay - bDay;
++    return timeSortKey(a.scheduled_start_time || a.suggested_start_time || "")
++      - timeSortKey(b.scheduled_start_time || b.suggested_start_time || "");
++  });
++}
++
++function sortedActivityOptions(rows) {
++  return [...rows].sort((a, b) => {
++    const aDay = Number(a.scheduled_day || a.suggested_day || 999);
++    const bDay = Number(b.scheduled_day || b.suggested_day || 999);
++    if (aDay !== bDay) return aDay - bDay;
++    return timeSortKey(a.scheduled_start_time || a.suggested_start_time || "")
++      - timeSortKey(b.scheduled_start_time || b.suggested_start_time || "");
++  });
++}
++
++function timeSortKey(value) {
++  const match = String(value || "").match(/^(\d{1,2}):(\d{2})$/);
++  if (!match) {
++    return 24 * 60;
++  }
++  return Number(match[1]) * 60 + Number(match[2]);
++}
++
++function stayForDay(day) {
++  const plan = lodgingStayPlan(shortlistByCategory("lodging")?.artifacts?.lodging_structure);
++  return plan.find((stay) => day >= Number(stay.startDay || 0) && day <= Number(stay.endDay || 0)) || plan[0] || null;
++}
++
++function stayDateForDay(day) {
++  if (!day) {
++    return "";
++  }
++  return formatIsoShortDate(addDaysToIso(tripStartDate(), day - 1));
++}
++
++function activityRouteFit(option, stay) {
++  if (!stay?.region) {
++    return {
++      title: "Stay base TBD",
++      detail: "Pick a stay location before treating this timing as solid.",
++    };
++  }
++  const regionMatch = regionOverlap(stay.region, option.island_location);
++  return regionMatch
++    ? {
++        title: `From ${stay.region}`,
++        detail: "Fits the chosen stay area and should avoid unnecessary backtracking.",
++      }
++    : {
++        title: `From ${stay.region}`,
++        detail: "Outside this stay base; verify the route before approving.",
++      };
++}
++
++function regionOverlap(left, right) {
++  const leftTokens = regionTokens(left);
++  const rightTokens = regionTokens(right);
++  return leftTokens.some((token) => rightTokens.includes(token));
++}
++
++function activityCompareLinks(option, stay) {
++  const links = [];
++  if (option.deep_link) {
++    links.push(externalLink(option.deep_link, "Provider", "secondary-link"));
++  }
++  for (const [label, url] of Object.entries(option.validation_links || {})) {
++    if (url && !String(label).toLowerCase().includes("airbnb") && !String(url).includes("airbnb.")) {
++      links.push(externalLink(url, label, "secondary-link"));
++    }
++  }
++  if (stay?.region && option.island_location) {
++    links.push(externalLink(mapsDirectionsUrl(stay.region, option.island_location), "Route", "secondary-link"));
++  }
++  return links.join("");
++}
++
+ function activitySchedulePanel(shortlist) {
+   const schedule = shortlist.artifacts?.activity_schedule;
+-  const entries = schedule?.entries || [];
++  const entries = sortedActivityScheduleEntries(schedule?.entries || []);
+   const approved = entries.filter((entry) => ["approved", "booked"].includes(entry.status));
+   return `<section class="structure-panel">
+     <div>
+@@ -2248,40 +2874,29 @@ function activitySchedulePanel(shortlist) {
+ function activityScheduleChip(entry) {
+   const day = entry.scheduled_day || entry.suggested_day || "TBD";
+   const time = entry.scheduled_start_time || entry.suggested_start_time || "";
++  const stay = stayForDay(Number(day || 0));
+   const status = entry.status || "researched";
+   return `<article class="schedule-chip ${status === "approved" ? "is-approved" : ""}">
+     <strong>Day ${escapeHtml(day)}</strong>
+-    <span>${escapeHtml(time || "time TBD")}</span>
++    <span>${escapeHtml([entry.scheduled_date || entry.suggested_date || "", time || "time TBD"].filter(Boolean).join(" · "))}</span>
+     <small>${escapeHtml(entry.activity_name || "")}</small>
++    ${stay?.region ? `<small>${escapeHtml(stay.region)}</small>` : ""}
+   </article>`;
+ }
+ 
+ function activityComparison(shortlist) {
+-  const rows = shortlist.activity_options || [];
++  const rows = sortedActivityOptions(shortlist.activity_options || []);
+   return `<section class="comparison-panel">
+-    <div class="comparison-head">
++    <div class="comparison-head compact-head compare-header-tight">
+       <div>
+         <p class="eyebrow">Activities</p>
+-        <h3>Approve, schedule, and track</h3>
+-        <p>${escapeHtml(shortlist.recommendation_summary || "")}</p>
++        <h3>Approve and place each activity</h3>
++        <p>Each option should make sense for the chosen stay location, day, cost, and route.</p>
+       </div>
+-      <span class="metric live">Recommended ${escapeHtml(shortlist.recommended_option_id || "TBD")}</span>
++      <span class="metric live">${escapeHtml(shortlist.recommended_option_id ? `Top pick ${shortlist.recommended_option_id}` : "Compare")}</span>
+     </div>
+-    <div class="comparison-table-wrap">
+-      <table class="comparison-table activity-table">
+-        <thead>
+-          <tr>
+-            <th>Activity / source</th>
+-            <th>Suggested slot</th>
+-            <th>Fit</th>
+-            <th>Safety / crowd</th>
+-            <th>Score</th>
+-            <th>Schedule</th>
+-            <th></th>
+-          </tr>
+-        </thead>
+-        <tbody>${rows.map(activityRow).join("")}</tbody>
+-      </table>
++    <div class="activity-card-stack">
++      ${rows.map(activityRow).join("")}
+     </div>
+   </section>`;
+ }
+@@ -2293,37 +2908,58 @@ function activityRow(option) {
+   const scheduledDate = option.scheduled_date || option.suggested_date || "";
+   const start = option.scheduled_start_time || option.suggested_start_time || "";
+   const end = option.scheduled_end_time || option.suggested_end_time || "";
+-  return `<tr class="${isApproved ? "recommended-row" : ""}">
+-    <td>
+-      <strong>${escapeHtml(option.activity_name)}</strong>
+-      <small>${escapeHtml(option.source)} · ${escapeHtml(option.island_location)} · ${escapeHtml(validationSummary(option))}</small>
+-    </td>
+-    <td>
+-      <strong>${scheduledDay ? `Day ${escapeHtml(scheduledDay)}` : "Day TBD"}</strong>
+-      <small>${escapeHtml([scheduledDate, timeRange(start, end)].filter(Boolean).join(" · "))}</small>
+-    </td>
+-    <td>
+-      <strong>${escapeHtml(option.duration)}</strong>
+-      <small>${escapeHtml(option.age_family_fit || option.scheduling_rationale || "")}</small>
+-    </td>
+-    <td>
+-      <strong>${escapeHtml(option.group_size_signal)}</strong>
+-      <small>${escapeHtml(option.review_safety_signal)}</small>
+-    </td>
+-    <td>
+-      <span class="score-pill">${escapeHtml(option.family_pace_fit_score)} pace</span>
+-      <small>${escapeHtml((option.friction_flags || [])[0] || option.scheduling_rationale || "")}</small>
+-    </td>
+-    <td>${activityScheduleForm(option)}</td>
+-    <td>
+-      <button class="mini-button" type="button" data-select-activity="${escapeHtml(option.option_id)}">${isApproved ? "Approved" : "Approve"}</button>
+-      ${externalLink(option.deep_link, "Open")}
+-    </td>
+-  </tr>`;
++  const stay = stayForDay(Number(scheduledDay || 0));
++  const routeFit = activityRouteFit(option, stay);
++  const compareLinks = activityCompareLinks(option, stay);
++  const reviewText = option.validation?.extracted_fields?.rating_summary || option.review_safety_signal || "Ratings pending deeper validation";
++  const cost = option.validation?.extracted_fields?.price_signal || option.price_band;
++  const availability = option.validation?.extracted_fields?.availability_signal || "source availability required";
++  const duration = option.validation?.extracted_fields?.duration_signal || option.duration || "source duration required";
++  return `<article class="activity-card ${isApproved ? "recommended-row" : ""}">
++    <div class="activity-card-image">${imageBlock(`${option.activity_name} ${option.island_location} activity`, option.activity_name)}</div>
++    <div class="activity-card-main">
++      <div class="activity-card-head">
++        <div>
++          <p class="eyebrow">${escapeHtml(option.source)}</p>
++          <h4>${escapeHtml(option.activity_name)}</h4>
++          <p>${escapeHtml(option.island_location)}</p>
++        </div>
++        <div class="metric-row">
++          <span class="score-pill">${escapeHtml(option.family_pace_fit_score)} pace</span>
++          <span class="metric ${isApproved ? "live" : ""}">${escapeHtml(isApproved ? "Approved" : truthLabel(option))}</span>
++        </div>
++      </div>
++      <div class="activity-data-grid">
++        <div>
++          <strong>${scheduledDay ? `Day ${escapeHtml(scheduledDay)}` : "Day TBD"}</strong>
++          <small>${escapeHtml([scheduledDate || stayDateForDay(Number(scheduledDay || 0)), timeRange(start, end)].filter(Boolean).join(" · "))}</small>
++        </div>
++        <div>
++          <strong>${escapeHtml(cost)}</strong>
++          <small>${escapeHtml([availability, duration].filter(Boolean).join(" · "))}</small>
++        </div>
++        <div>
++          <strong>${escapeHtml(routeFit.title)}</strong>
++          <small>${escapeHtml(routeFit.detail)}</small>
++        </div>
++        <div>
++          <strong>${escapeHtml(reviewText)}</strong>
++          <small>${escapeHtml(option.group_size_signal || "")}</small>
++        </div>
++      </div>
++      <div class="activity-link-row">
++        ${compareLinks}
++      </div>
++      <div class="activity-card-actions">
++        <button class="mini-button" type="button" data-select-activity="${escapeHtml(option.option_id)}">${isApproved ? "Approved" : "Approve"}</button>
++        ${activityScheduleForm(option)}
++      </div>
++    </div>
++  </article>`;
+ }
+ 
+ function activityScheduleForm(option) {
+-  return `<form class="inline-schedule-form" data-activity-schedule-form>
++  return `<form class="inline-schedule-form compact" data-activity-schedule-form>
+     <input type="hidden" name="option_id" value="${escapeHtml(option.option_id)}" />
+     <label>Day<input name="day" type="number" min="1" value="${escapeHtml(option.scheduled_day || option.suggested_day || "")}" /></label>
+     <label>Date<input name="date" type="date" value="${escapeHtml(option.scheduled_date || option.suggested_date || "")}" /></label>
+@@ -2331,7 +2967,7 @@ function activityScheduleForm(option) {
+     <label>End<input name="end_time" type="time" value="${escapeHtml(option.scheduled_end_time || option.suggested_end_time || "")}" /></label>
+     <label class="checkbox-line"><input name="fixed" type="checkbox" ${option.scheduled_flexibility === "fixed" ? "checked" : ""} /> fixed</label>
+     <input name="notes" type="text" placeholder="notes" value="${escapeHtml(option.scheduling_notes || "")}" />
+-    <button class="mini-button secondary" type="submit">Save slot</button>
++    <button class="mini-button secondary" type="submit">Save</button>
+   </form>`;
+ }
+ 
+@@ -2378,7 +3014,7 @@ function carRow(option) {
+   return `<tr class="${isRecommended || isApproved ? "recommended-row" : ""}">
+     <td>
+       <strong>${escapeHtml(option.vehicle_class)}</strong>
+-      <small>${escapeHtml(option.booking_source)} · ${escapeHtml(option.row_status || "researched")} · ${escapeHtml(validationSummary(option))}</small>
++      <small>${escapeHtml(option.booking_source)} · ${escapeHtml(validationSummary(option))}</small>
+     </td>
+     <td>
+       <strong>${escapeHtml(option.pickup_location)}</strong>
+@@ -2404,6 +3040,7 @@ function carRow(option) {
+     </td>
+     <td>
+       <button class="mini-button" type="button" data-select-car="${escapeHtml(option.option_id)}">${isApproved ? "Selected" : "Choose"}</button>
++      ${bookingForm("car", option)}
+     </td>
+   </tr>`;
+ }
+@@ -2428,7 +3065,7 @@ function compactOptionCard(item) {
+     <h4>${escapeHtml(item.title || "Untitled")}</h4>
+     <p>${escapeHtml(item.subtitle || "")}</p>
+     <div class="metric-row">
+-      ${item.status ? `<span class="metric ${item.status === "verified_live" ? "live" : ""}">${escapeHtml(item.status)}</span>` : ""}
++      ${item.status ? `<span class="metric ${["Confirmed", "Booked", "Selected"].includes(item.status) ? "live" : ""}">${escapeHtml(item.status)}</span>` : ""}
+       ${item.verification ? `<span class="metric">${escapeHtml(item.verification)}</span>` : ""}
+     </div>
+     ${item.notes ? `<small>${escapeHtml(String(item.notes))}</small>` : ""}
+@@ -2486,11 +3123,48 @@ function mapsEmbedUrl(query) {
+   return `https://www.google.com/maps?q=${encodeURIComponent(query || "travel planning")}&output=embed`;
+ }
+ 
++function mapsDirectionsUrl(origin, destination) {
++  return `https://www.google.com/maps/dir/?api=1&origin=${encodeURIComponent(origin || "")}&destination=${encodeURIComponent(destination || "")}&travelmode=driving`;
++}
++
+ function mapFileUrl(kind) {
+   if (!state.activeTripId) return "";
+   return `/api/map-file?trip_id=${encodeURIComponent(state.activeTripId)}&kind=${encodeURIComponent(kind)}`;
+ }
+ 
++function googleSheetPanel(workspace, title, subtitle = "") {
++  const embedUrl = googleSheetEmbedUrl(workspace?.google_sheet_url);
++  return `<section class="stage-card sheet-frame-panel">
++    <div class="section-head compact-head">
++      <div>
++        <p class="eyebrow">Google Sheet</p>
++        <h3>${escapeHtml(title)}</h3>
++        ${subtitle ? `<p>${escapeHtml(subtitle)}</p>` : ""}
++      </div>
++      ${workspace?.google_sheet_url ? externalLink(workspace.google_sheet_url, "Open in Google Sheets", "primary-link") : ""}
++    </div>
++    ${
++      embedUrl
++        ? `<div class="sheet-frame-wrap"><iframe title="${escapeHtml(title)}" loading="lazy" src="${escapeHtml(embedUrl)}"></iframe></div>`
++        : `<div class="empty-state">Google Sheet link unavailable.</div>`
++    }
++  </section>`;
++}
++
++function googleSheetEmbedUrl(url) {
++  const text = String(url || "");
++  if (!text.includes("docs.google.com/spreadsheets")) {
++    return "";
++  }
++  const idMatch = text.match(/\/spreadsheets\/d\/([^/]+)/);
++  if (!idMatch) {
++    return text;
++  }
++  const gidMatch = text.match(/[?&#]gid=([0-9]+)/);
++  const gid = gidMatch?.[1] || "0";
++  return `https://docs.google.com/spreadsheets/d/${idMatch[1]}/edit?gid=${gid}&rm=minimal&widget=true&headers=false`;
++}
++
+ function workspaceSummary(workspace) {
+   const tabs = workspace.tabs || [];
+   const timeline = tabs.find((tab) => tab.name === "Master Timeline");
+@@ -2589,8 +3263,10 @@ function optionForPick(option, category) {
+   const title = option.airline || option.name || option.vehicle_class || option.activity_name || option.option_id;
+   const subtitle = option.location_area || option.island_location || option.departure_airport || option.pickup_location || category;
+   const link = option.deep_link;
+-  const status = option.row_status || "researched";
+-  const verification = option.validation?.verification_status || "";
++  const status = truthLabel(option);
++  const verification = option.validation?.confidence
++    ? `${Math.round(Number(option.validation.confidence) * 100)}% confidence`
++    : "";
+   const notes = option.recommendation_grade || option.traveler_fit || option.traveler_roster_supported || "";
+   return {
+     title,
+@@ -2609,7 +3285,7 @@ function pickCard(item) {
+       <h3>${escapeHtml(item.title || "Untitled")}</h3>
+       <p>${escapeHtml(item.subtitle || "")}</p>
+       <div class="metric-row">
+-        ${item.status ? `<span class="metric ${item.status === "verified_live" ? "live" : ""}">${escapeHtml(item.status)}</span>` : ""}
++        ${item.status ? `<span class="metric ${["Confirmed", "Booked", "Selected"].includes(item.status) ? "live" : ""}">${escapeHtml(item.status)}</span>` : ""}
+         ${item.verification ? `<span class="metric">${escapeHtml(item.verification)}</span>` : ""}
+       </div>
+       ${item.notes ? `<p>${escapeHtml(String(item.notes))}</p>` : ""}
+@@ -2655,6 +3331,10 @@ function shortlistReadyCount() {
+   return `${count}/4`;
+ }
+ 
++function tripPacketReadiness() {
++  return Number(state.trip?.trip_packet?.readiness_percent || 0);
++}
++
+ function latestWorkflowId() {
+   const workflows = state.trip?.recent_workflows || state.app?.recent_workflows || [];
+   return workflows.length ? workflows[workflows.length - 1].id : "";
+@@ -2704,6 +3384,59 @@ function formatTime(value) {
+   });
+ }
+ 
++function tripStartDate() {
++  return state.trip?.intake?.travel_window?.start_date || state.suggestedIntake?.travel_window?.start_date || "";
++}
++
++function addDaysToIso(isoDate, days) {
++  if (!isoDate) {
++    return "";
++  }
++  const base = new Date(`${isoDate}T12:00:00`);
++  if (Number.isNaN(base.getTime())) {
++    return "";
++  }
++  base.setDate(base.getDate() + Number(days || 0));
++  return base.toISOString().slice(0, 10);
++}
++
++function formatIsoShortDate(isoDate) {
++  if (!isoDate) {
++    return "";
++  }
++  const date = new Date(`${isoDate}T12:00:00`);
++  if (Number.isNaN(date.getTime())) {
++    return isoDate;
++  }
++  return date.toLocaleDateString([], {
++    month: "short",
++    day: "numeric",
++  });
++}
++
++function stayDateLabel(startDay, endDay) {
++  const tripStart = tripStartDate();
++  if (!tripStart) {
++    return `Day ${startDay}${endDay > startDay ? `-${endDay}` : ""}`;
++  }
++  const start = addDaysToIso(tripStart, startDay - 1);
++  const end = addDaysToIso(tripStart, endDay - 1);
++  return `${formatIsoShortDate(start)}${end && end !== start ? ` - ${formatIsoShortDate(end)}` : ""}`;
++}
++
++function tripDateRangeLabel() {
++  const intake = state.trip?.intake || state.suggestedIntake;
++  if (!intake) {
++    return "Dates TBD";
++  }
++  if (intake.travel_window?.start_date) {
++    const duration = Number(intake.duration_days || intake.duration_min_days || 0);
++    const end = duration ? addDaysToIso(intake.travel_window.start_date, duration - 1) : intake.travel_window?.end_date;
++    return `${formatIsoShortDate(intake.travel_window.start_date)}${end ? ` - ${formatIsoShortDate(end)}` : ""}`;
++  }
++  return intake.duration_label || "Dates TBD";
++}
++
+ function formPayload(form) {
+   const data = new FormData(form);
+   const payload = {};
+diff --git a/trippy/ui/templates/index.html b/trippy/ui/templates/index.html
+index b795ace..d88f88e 100644
+--- a/trippy/ui/templates/index.html
++++ b/trippy/ui/templates/index.html
+@@ -23,6 +23,16 @@
+           <a id="dashboardJsonLink" href="/api/state" title="Open backend state">Data</a>
+           <a id="logsJsonLink" href="/api/logs" title="Open workflow logs">Logs</a>
+         </nav>
++        <aside class="trip-rail" aria-label="Trips">
++          <div class="rail-head">
++            <div class="rail-actions">
++              <button id="generateTripButton" type="button" class="secondary">Generate</button>
++              <button id="newTripButton" type="button">New</button>
++            </div>
++          </div>
++          <div id="tripList" class="trip-list"></div>
++        </aside>
++        <div id="railResizeHandle" class="rail-resize-handle" aria-hidden="true"></div>
+       </header>
+ 
+       <main>
+@@ -38,16 +48,6 @@
+         </section>
+ 
+         <section class="layout">
+-          <aside class="trip-rail" aria-label="Trips">
+-            <div class="rail-head">
+-              <div class="rail-actions">
+-                <button id="generateTripButton" type="button" class="secondary">Generate</button>
+-                <button id="newTripButton" type="button">New</button>
+-              </div>
+-            </div>
+-            <div id="tripList" class="trip-list"></div>
+-          </aside>
+-
+           <section class="wizard-panel" aria-label="Planning wizard">
+             <div id="stageBody"></div>
+           </section>

--- a/trippy/agent.py
+++ b/trippy/agent.py
@@ -53,6 +53,24 @@ Prioritize practical, step-by-step guidance for:
 Be concise, actionable, and risk-aware. Flag any high-friction timing or transfer issue.
 """
 
+_PLANNING_STRATEGIST_PROMPT = """
+## Planning Strategy Requirements
+
+For trip ideas, ways to experience a destination or island, stay/split-stay structure,
+activity sequencing, and next-step recommendations:
+- Make an explicit strategy call. Do not merely list possibilities.
+- Ground the call in loaded memory, family travel preferences, country priors, the
+  trip intake, the selected plan shape, and current shortlist evidence.
+- Use `run_planning_service` before making stateful planning claims. For high-level
+  strategy questions, call `run_planning_service` with action `planning_advice` so
+  Trippy builds the preference-rich planning prompt and records the advice context.
+- Never invent source facts such as prices, availability, flight numbers, drive times,
+  bed layouts, or confirmation details. Label seeded/inferred/approximate items plainly.
+- When evidence is missing, state the exact source facts needed before booking.
+- Preserve review-gated learning. If a lesson seems reusable, propose it through the
+  reviewable learning path rather than silently changing memory or skills.
+"""
+
 
 class UserIntent(StrEnum):
     PLAN_TRIP = "plan_trip"
@@ -100,6 +118,8 @@ def _build_system_prompt(
 
     # Skills summary
     parts.append(get_all_skill_summaries())
+
+    parts.append(_PLANNING_STRATEGIST_PROMPT.strip())
 
     if operations_mode:
         parts.append(_OPERATIONS_MODE_PROMPT.strip())
@@ -234,6 +254,7 @@ def _skill_tools() -> list[dict[str, Any]]:
                             "activities",
                             "select_activity",
                             "schedule_activity",
+                            "planning_advice",
                             "propose_learning",
                         ],
                     },
@@ -249,6 +270,16 @@ def _skill_tools() -> list[dict[str, Any]]:
                     "avoidances": {"type": "array", "items": {"type": "string"}},
                     "option_id": {"type": "string"},
                     "notes": {"type": "string"},
+                    "planning_question": {
+                        "type": "string",
+                        "enum": [
+                            "trip_ideas",
+                            "trip_shape",
+                            "island_experience",
+                            "lodging_structure",
+                            "next_steps",
+                        ],
+                    },
                     "day": {"type": "integer"},
                     "date": {"type": "string"},
                     "start_time": {"type": "string"},
@@ -360,6 +391,51 @@ def _run_planning_service(inputs: dict[str, Any]) -> str:
     deep_research = bool(inputs.get("deep_research", False))
     adapter = str(inputs.get("adapter") or "auto")
     try:
+        if action == "planning_advice":
+            from trippy.models.planning_advice import PlanningAdviceKind
+            from trippy.models.shortlists import ShortlistCategory
+            from trippy.services.planning_advisor import PlanningAdvisorService
+            from trippy.services.shortlist_store import ShortlistStore
+            from trippy.services.trip_intake import TripIntakeService
+            from trippy.services.trip_planner import TripPlannerService
+
+            question = str(inputs.get("planning_question") or "next_steps")
+            kind = PlanningAdviceKind(question)
+            intake = TripIntakeService().load(trip_id) if trip_id else None
+            draft = TripPlannerService().load_draft(trip_id) if trip_id else None
+            if kind == PlanningAdviceKind.LODGING_STRUCTURE and intake is not None and draft:
+                option = draft.get_option()
+                lodging_state = ShortlistStore().load(trip_id, ShortlistCategory.LODGING)
+                if option is not None:
+                    return (
+                        PlanningAdvisorService()
+                        .advise_lodging_structure(intake, option, lodging_state)
+                        .model_dump_json(indent=2)
+                    )
+            if (
+                kind
+                in {
+                    PlanningAdviceKind.TRIP_SHAPE,
+                    PlanningAdviceKind.ISLAND_EXPERIENCE,
+                }
+                and intake is not None
+                and draft is not None
+            ):
+                advisor = PlanningAdvisorService()
+                if kind == PlanningAdviceKind.ISLAND_EXPERIENCE:
+                    return advisor.advise_island_experience(intake, draft).model_dump_json(indent=2)
+                return advisor.advise_trip_shape(intake, draft).model_dump_json(indent=2)
+            shortlists = ShortlistStore().load_all(trip_id) if trip_id else []
+            return (
+                PlanningAdvisorService()
+                .advise_next_steps(
+                    intake,
+                    draft,
+                    shortlists,
+                    user_question=str(inputs.get("notes") or ""),
+                )
+                .model_dump_json(indent=2)
+            )
         if action == "create_intake":
             from trippy.models.trip_planning import (
                 TravelWindow,

--- a/trippy/agent.py
+++ b/trippy/agent.py
@@ -227,8 +227,13 @@ def _skill_tools() -> list[dict[str, Any]]:
                             "map",
                             "flights",
                             "lodging",
+                            "select_lodging",
+                            "lodging_structure",
                             "cars",
+                            "select_car",
                             "activities",
+                            "select_activity",
+                            "schedule_activity",
                             "propose_learning",
                         ],
                     },
@@ -243,9 +248,31 @@ def _skill_tools() -> list[dict[str, Any]]:
                     "goals": {"type": "array", "items": {"type": "string"}},
                     "avoidances": {"type": "array", "items": {"type": "string"}},
                     "option_id": {"type": "string"},
+                    "notes": {"type": "string"},
+                    "day": {"type": "integer"},
+                    "date": {"type": "string"},
+                    "start_time": {"type": "string"},
+                    "end_time": {"type": "string"},
+                    "fixed": {"type": "boolean", "default": False},
                     "no_google": {"type": "boolean", "default": False},
                     "validate_live": {"type": "boolean", "default": False},
                     "deep_research": {"type": "boolean", "default": False},
+                    "strategy": {
+                        "type": "string",
+                        "enum": ["single_stay", "split_stay"],
+                    },
+                    "night_plan": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "region": {"type": "string"},
+                                "nights": {"type": "integer"},
+                                "lodging_option_id": {"type": "string"},
+                                "notes": {"type": "string"},
+                            },
+                        },
+                    },
                     "adapter": {
                         "type": "string",
                         "enum": ["auto", "link", "playwright", "openclaw"],
@@ -436,6 +463,29 @@ def _run_planning_service(inputs: dict[str, Any]) -> str:
                 )
                 .model_dump_json(indent=2)
             )
+        if action == "select_lodging":
+            from trippy.services.lodging_shortlist import LodgingShortlistService
+
+            if not option_id:
+                return json.dumps({"error": "option_id is required for select_lodging"})
+            return (
+                LodgingShortlistService()
+                .select_lodging(trip_id, option_id)
+                .model_dump_json(indent=2)
+            )
+        if action == "lodging_structure":
+            from trippy.services.lodging_shortlist import LodgingShortlistService
+
+            return (
+                LodgingShortlistService()
+                .update_stay_structure(
+                    trip_id,
+                    strategy=str(inputs.get("strategy") or "split_stay"),
+                    night_plan=list(inputs.get("night_plan") or []),
+                    notes=str(inputs.get("notes") or ""),
+                )
+                .model_dump_json(indent=2)
+            )
         if action == "cars":
             from trippy.services.car_shortlist import CarShortlistService
 
@@ -449,6 +499,13 @@ def _run_planning_service(inputs: dict[str, Any]) -> str:
                 )
                 .model_dump_json(indent=2)
             )
+        if action == "select_car":
+            from trippy.services.car_shortlist import CarShortlistService
+
+            option_id = str(inputs.get("option_id") or "")
+            if not option_id:
+                return json.dumps({"error": "option_id is required for select_car"})
+            return CarShortlistService().select_car(trip_id, option_id).model_dump_json(indent=2)
         if action == "activities":
             from trippy.services.activity_shortlist import ActivityShortlistService
 
@@ -459,6 +516,37 @@ def _run_planning_service(inputs: dict[str, Any]) -> str:
                     validate_live=validate_live,
                     deep_research=deep_research,
                     adapter_mode=adapter,
+                )
+                .model_dump_json(indent=2)
+            )
+        if action == "select_activity":
+            from trippy.services.activity_shortlist import ActivityShortlistService
+
+            option_id = str(inputs.get("option_id") or "")
+            if not option_id:
+                return json.dumps({"error": "option_id is required for select_activity"})
+            return (
+                ActivityShortlistService()
+                .select_activity(trip_id, option_id)
+                .model_dump_json(indent=2)
+            )
+        if action == "schedule_activity":
+            from trippy.services.activity_shortlist import ActivityShortlistService
+
+            option_id = str(inputs.get("option_id") or "")
+            if not option_id:
+                return json.dumps({"error": "option_id is required for schedule_activity"})
+            return (
+                ActivityShortlistService()
+                .schedule_activity(
+                    trip_id,
+                    option_id,
+                    day=_optional_positive_int(inputs.get("day")),
+                    date_value=str(inputs.get("date") or ""),
+                    start_time=str(inputs.get("start_time") or ""),
+                    end_time=str(inputs.get("end_time") or ""),
+                    fixed=bool(inputs.get("fixed", False)),
+                    notes=str(inputs.get("notes") or ""),
                 )
                 .model_dump_json(indent=2)
             )
@@ -481,6 +569,16 @@ def _as_string_list(value: Any) -> list[str]:
     if isinstance(value, list):
         return [str(item).strip() for item in value if str(item).strip()]
     return [str(value).strip()]
+
+
+def _optional_positive_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = int(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _run_skill(skill_name: str, inputs: dict[str, Any]) -> str:

--- a/trippy/config.py
+++ b/trippy/config.py
@@ -42,6 +42,8 @@ GOOGLE_TOKEN_PATH: Path = _expand("GOOGLE_TOKEN_PATH", "~/.trippy/google_token.j
 
 # API keys
 ANTHROPIC_API_KEY: str = os.environ.get("ANTHROPIC_API_KEY", "")
+PLANNING_LLM_MODEL: str = os.environ.get("TRIPPY_PLANNING_LLM_MODEL", "claude-sonnet-4-6")
+PLANNING_LLM_ENABLED: bool = _bool("TRIPPY_PLANNING_LLM_ENABLED", bool(ANTHROPIC_API_KEY))
 GOOGLE_SHEETS_API_KEY: str = os.environ.get("GOOGLE_SHEETS_API_KEY", "")
 SHERPA_API_KEY: str = os.environ.get("SHERPA_API_KEY", "")
 DUFFEL_ACCESS_TOKEN: str = os.environ.get("DUFFEL_ACCESS_TOKEN", "")

--- a/trippy/models/ideas.py
+++ b/trippy/models/ideas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -10,6 +12,9 @@ class TripIdeaRequest(BaseModel):
     duration_days: int | None = None
     budget_cad: float | None = None
     travelers: int = 5
+    party_type: str | None = None
+    adults: int | None = None
+    children: int | None = None
     max_flight_hours: float | None = None
     direct_flight_preferred: bool = True
     goals: list[str] = Field(default_factory=list)
@@ -46,3 +51,4 @@ class TripComparison(BaseModel):
     concepts: list[TripConcept]
     recommended_concept_id: str | None = None
     scoring_notes: list[str] = Field(default_factory=list)
+    advisor: dict[str, Any] = Field(default_factory=dict)

--- a/trippy/models/maps.py
+++ b/trippy/models/maps.py
@@ -52,6 +52,8 @@ class TripMapArtifact(BaseModel):
     trip_id: str
     title: str
     generated_at: datetime = Field(default_factory=datetime.utcnow)
+    primary_google_maps_url: str | None = None
+    google_my_maps_url: str = "https://www.google.com/maps/d/u/0/"
     pins: list[MapPin] = Field(default_factory=list)
     routes: list[MapRoute] = Field(default_factory=list)
     day_groups: dict[str, list[str]] = Field(default_factory=dict)

--- a/trippy/models/planning_advice.py
+++ b/trippy/models/planning_advice.py
@@ -1,0 +1,45 @@
+"""Models for preference-rich LLM planning advice."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class PlanningAdviceKind(StrEnum):
+    TRIP_IDEAS = "trip_ideas"
+    TRIP_SHAPE = "trip_shape"
+    ISLAND_EXPERIENCE = "island_experience"
+    LODGING_STRUCTURE = "lodging_structure"
+    NEXT_STEPS = "next_steps"
+
+
+class PlanningAdviceResult(BaseModel):
+    """Structured result from Trippy's planning-advisor LLM call."""
+
+    kind: PlanningAdviceKind
+    status: str
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    model: str = ""
+    prompt_version: str = "planning-advisor-v1"
+    prompt: str = ""
+    summary: str = ""
+    recommendation: str = ""
+    rationale: list[str] = Field(default_factory=list)
+    next_actions: list[str] = Field(default_factory=list)
+    questions_for_user: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    evidence_needed: list[str] = Field(default_factory=list)
+    stay_strategy: str = ""
+    night_plan: list[dict[str, Any]] = Field(default_factory=list)
+    confidence: float = 0.0
+    raw_response: str = ""
+    error: str = ""
+
+    @field_validator("confidence")
+    @classmethod
+    def _confidence_range(cls, value: float) -> float:
+        return max(0.0, min(1.0, value))

--- a/trippy/models/shortlists.py
+++ b/trippy/models/shortlists.py
@@ -40,6 +40,7 @@ class ShortlistRowStatus(StrEnum):
     REJECTED = "rejected"
     APPROVED = "approved"
     BOOKED = "booked"
+    CONFIRMED = "confirmed"
 
 
 class VerificationStatus(StrEnum):
@@ -114,6 +115,8 @@ class FlightOption(BaseModel):
     rank: int
     airline: str
     flight_numbers: list[str] = Field(default_factory=list)
+    departure_date: str = ""
+    arrival_date: str = ""
     departure_airport: str
     arrival_airport: str
     departure_time: str = ""

--- a/trippy/models/shortlists.py
+++ b/trippy/models/shortlists.py
@@ -210,6 +210,8 @@ class CarOption(BaseModel):
     pickup_location: str
     dropoff_location: str
     vehicle_class: str
+    price_band: str = "live quote required"
+    current_price_signal: str = ""
     seating_capacity: int | None = None
     passenger_fit: str
     luggage_fit: str
@@ -253,6 +255,17 @@ class ActivityOption(BaseModel):
     age_family_fit: str = ""
     price_band: str
     duration: str
+    suggested_day: int | None = None
+    suggested_date: str = ""
+    suggested_start_time: str = ""
+    suggested_end_time: str = ""
+    scheduling_rationale: str = ""
+    scheduled_day: int | None = None
+    scheduled_date: str = ""
+    scheduled_start_time: str = ""
+    scheduled_end_time: str = ""
+    scheduled_flexibility: str = "flexible"
+    scheduling_notes: str = ""
     deep_link: str
     validation_links: dict[str, str] = Field(default_factory=dict)
     family_pace_fit_score: int

--- a/trippy/models/trip_execution.py
+++ b/trippy/models/trip_execution.py
@@ -1,0 +1,92 @@
+"""Trip execution and confirmation packet models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ExecutionCategory(StrEnum):
+    FLIGHT = "flight"
+    LODGING = "lodging"
+    CAR = "car"
+    ACTIVITY = "activity"
+    OTHER = "other"
+
+
+class ExecutionStatus(StrEnum):
+    SELECTED = "selected"
+    BOOKED = "booked"
+    CONFIRMED = "confirmed"
+
+
+class TripPacketItem(BaseModel):
+    """A human-facing travel execution item.
+
+    Shortlists decide what to choose. Packet items track what the family has
+    selected, booked, confirmed, and needs on trip day.
+    """
+
+    item_id: str
+    category: ExecutionCategory
+    option_id: str = ""
+    title: str
+    provider: str = ""
+    status: ExecutionStatus = ExecutionStatus.SELECTED
+    source_url: str = ""
+    booking_link: str = ""
+    confirmation_code: str = ""
+    date: str = ""
+    start_time: str = ""
+    end_time: str = ""
+    address: str = ""
+    cost_cad: float | None = None
+    notes: str = ""
+    evidence: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    @field_validator("title")
+    @classmethod
+    def _title_required(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("packet item title is required")
+        return cleaned
+
+    @property
+    def is_booked(self) -> bool:
+        return self.status in {ExecutionStatus.BOOKED, ExecutionStatus.CONFIRMED}
+
+    @property
+    def is_confirmed(self) -> bool:
+        return self.status == ExecutionStatus.CONFIRMED and bool(self.confirmation_code.strip())
+
+
+class TripPacketState(BaseModel):
+    trip_id: str
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    readiness_percent: int = 0
+    status_label: str = "not ready"
+    items: list[TripPacketItem] = Field(default_factory=list)
+    missing_items: list[str] = Field(default_factory=list)
+    next_actions: list[str] = Field(default_factory=list)
+    summary: str = ""
+
+    def get_item(
+        self,
+        category: ExecutionCategory,
+        option_id: str,
+    ) -> TripPacketItem | None:
+        return next(
+            (
+                item
+                for item in self.items
+                if item.category == category and item.option_id == option_id
+            ),
+            None,
+        )

--- a/trippy/models/trip_planning.py
+++ b/trippy/models/trip_planning.py
@@ -392,6 +392,7 @@ class TripPlanDraft(BaseModel):
     selected_option_id: str | None = None
     assumptions: list[str] = Field(default_factory=list)
     source_notes: list[str] = Field(default_factory=list)
+    advisor: dict[str, Any] = Field(default_factory=dict)
 
     def get_option(self, option_id: str | None = None) -> TripPlanOption | None:
         selected = option_id or self.selected_option_id or self.recommended_option_id

--- a/trippy/services/activity_shortlist.py
+++ b/trippy/services/activity_shortlist.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import unicodedata
+from datetime import date, timedelta
+from typing import Any
+
 from trippy.models.shortlists import (
     ActivityOption,
     LiveDataStatus,
     RecommendationGrade,
     ResearchShortlistState,
     ShortlistCategory,
+    ShortlistRowStatus,
 )
 from trippy.models.sources import TravelSourceCategory
 from trippy.models.trip_planning import TripIntake
@@ -54,6 +59,7 @@ class ActivityShortlistService:
         )
         profile = profile_for_intake(ctx.intake)
         plan = source_plan(TravelSourceCategory.TOURS)
+        existing = self._store.load(trip_id, ShortlistCategory.ACTIVITIES)
         options = _options_from_profile(profile, ctx.intake, ctx.option.regions)
         state = ResearchShortlistState(
             trip_id=trip_id,
@@ -76,9 +82,76 @@ class ActivityShortlistService:
                 "Place each activity into the map/day plan before booking to avoid overpacking.",
             ],
         )
+        _apply_activity_schedule_suggestions(
+            state,
+            ctx.intake,
+            ctx.option,
+            self._store.load(trip_id, ShortlistCategory.LODGING),
+        )
+        _merge_existing_activity_state(state, existing)
         LiveValidationService().validate_state(state, attempt_network=validate_live)
         if deep_research:
             SourceResearchService().research_state(state, adapter_mode=adapter_mode)
+        _write_activity_schedule_artifact(state)
+        return self._store.save(state)
+
+    def select_activity(self, trip_id: str, option_id: str) -> ResearchShortlistState:
+        """Approve an activity and give it a concrete timeline slot."""
+        state = self._store.load(trip_id, ShortlistCategory.ACTIVITIES) or self.build(trip_id)
+        option = _activity_by_id(state, option_id)
+        if option is None:
+            raise ValueError(f"No activity option {option_id!r} for trip {trip_id!r}")
+        _schedule_activity_option(option, {})
+        state.recommended_option_id = option.option_id
+        state.recommendation_summary = (
+            f"Approved {option.activity_name}; keep this slot visible in the Master Timeline "
+            "and adjust manually if lodging or flight timing changes."
+        )
+        if (
+            "Approved activities now hydrate into the Master Timeline with date/time tracking."
+            not in (state.next_actions)
+        ):
+            state.next_actions.insert(
+                0,
+                "Approved activities now hydrate into the Master Timeline with date/time tracking.",
+            )
+        _write_activity_schedule_artifact(state)
+        return self._store.save(state)
+
+    def schedule_activity(
+        self,
+        trip_id: str,
+        option_id: str,
+        *,
+        day: int | None = None,
+        date_value: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        fixed: bool = False,
+        notes: str = "",
+    ) -> ResearchShortlistState:
+        """Approve or move an activity into a user-controlled day/time slot."""
+        state = self._store.load(trip_id, ShortlistCategory.ACTIVITIES) or self.build(trip_id)
+        option = _activity_by_id(state, option_id)
+        if option is None:
+            raise ValueError(f"No activity option {option_id!r} for trip {trip_id!r}")
+        _schedule_activity_option(
+            option,
+            {
+                "day": day,
+                "date": date_value,
+                "start_time": start_time,
+                "end_time": end_time,
+                "fixed": fixed,
+                "notes": notes,
+            },
+        )
+        state.recommended_option_id = option.option_id
+        state.recommendation_summary = (
+            "Activity schedule updated. Rebuild or refresh the workspace to see the exact "
+            "slot in the Master Timeline."
+        )
+        _write_activity_schedule_artifact(state)
         return self._store.save(state)
 
 
@@ -153,3 +226,222 @@ def _options_from_profile(
             )
         )
     return options
+
+
+def _activity_by_id(
+    state: ResearchShortlistState,
+    option_id: str,
+) -> ActivityOption | None:
+    return next(
+        (option for option in state.activity_options if option.option_id == option_id), None
+    )
+
+
+def _apply_activity_schedule_suggestions(
+    state: ResearchShortlistState,
+    intake: TripIntake,
+    option: object,
+    lodging_state: ResearchShortlistState | None,
+) -> None:
+    anchors = _stay_day_anchors(option, lodging_state)
+    used_days: set[int] = set()
+    for idx, activity in enumerate(state.activity_options, start=1):
+        anchor = _best_anchor_for_activity(activity, anchors) or anchors[0]
+        day = _suggested_activity_day(
+            anchor, used_days, int(getattr(option, "duration_days", 0) or 0)
+        )
+        used_days.add(day)
+        start_time = "09:30" if idx % 2 else "14:00"
+        end_time = _default_end_time(start_time, activity.duration)
+        date_value = _date_for_day(intake.travel_window.start_date, day)
+        activity.suggested_day = day
+        activity.suggested_date = date_value.isoformat() if date_value else ""
+        activity.suggested_start_time = start_time
+        activity.suggested_end_time = end_time
+        activity.scheduling_rationale = (
+            f"Suggested while based in {anchor['region']} so the activity matches lodging "
+            "geography and avoids unnecessary backtracking."
+        )
+    _write_activity_schedule_artifact(state)
+
+
+def _merge_existing_activity_state(
+    state: ResearchShortlistState,
+    existing: ResearchShortlistState | None,
+) -> None:
+    if existing is None:
+        return
+    existing_by_id = {option.option_id: option for option in existing.activity_options}
+    for option in state.activity_options:
+        previous = existing_by_id.get(option.option_id)
+        if previous is None:
+            continue
+        option.row_status = previous.row_status
+        option.scheduled_day = previous.scheduled_day
+        option.scheduled_date = previous.scheduled_date
+        option.scheduled_start_time = previous.scheduled_start_time
+        option.scheduled_end_time = previous.scheduled_end_time
+        option.scheduled_flexibility = previous.scheduled_flexibility
+        option.scheduling_notes = previous.scheduling_notes
+        if previous.suggested_day:
+            option.suggested_day = previous.suggested_day
+            option.suggested_date = previous.suggested_date
+            option.suggested_start_time = previous.suggested_start_time
+            option.suggested_end_time = previous.suggested_end_time
+            option.scheduling_rationale = previous.scheduling_rationale
+    if existing.recommended_option_id:
+        state.recommended_option_id = existing.recommended_option_id
+    state.artifacts.update(existing.artifacts)
+    _write_activity_schedule_artifact(state)
+
+
+def _schedule_activity_option(option: ActivityOption, values: dict[str, Any]) -> None:
+    day = _positive_int(values.get("day")) or option.scheduled_day or option.suggested_day
+    date_value = str(values.get("date") or option.scheduled_date or option.suggested_date or "")
+    start_time = str(
+        values.get("start_time")
+        or option.scheduled_start_time
+        or option.suggested_start_time
+        or "09:30"
+    )
+    end_time = str(
+        values.get("end_time")
+        or option.scheduled_end_time
+        or option.suggested_end_time
+        or _default_end_time(start_time, option.duration)
+    )
+    option.row_status = ShortlistRowStatus.APPROVED
+    option.scheduled_day = day
+    option.scheduled_date = date_value
+    option.scheduled_start_time = start_time
+    option.scheduled_end_time = end_time
+    option.scheduled_flexibility = "fixed" if bool(values.get("fixed", False)) else "flexible"
+    notes = str(values.get("notes") or "").strip()
+    if notes:
+        option.scheduling_notes = notes
+    elif not option.scheduling_notes:
+        option.scheduling_notes = "Approved from activity shortlist; confirm exact operator time."
+
+
+def _write_activity_schedule_artifact(state: ResearchShortlistState) -> None:
+    entries = []
+    for option in state.activity_options:
+        entries.append(
+            {
+                "activity_option_id": option.option_id,
+                "activity_name": option.activity_name,
+                "location": option.island_location,
+                "status": option.row_status.value,
+                "suggested_day": option.suggested_day,
+                "suggested_date": option.suggested_date,
+                "suggested_start_time": option.suggested_start_time,
+                "suggested_end_time": option.suggested_end_time,
+                "scheduled_day": option.scheduled_day,
+                "scheduled_date": option.scheduled_date,
+                "scheduled_start_time": option.scheduled_start_time,
+                "scheduled_end_time": option.scheduled_end_time,
+                "fixed_vs_flexible": option.scheduled_flexibility,
+                "rationale": option.scheduling_rationale,
+                "notes": option.scheduling_notes,
+            }
+        )
+    state.artifacts["activity_schedule"] = {
+        "data_status": "suggested_and_manual",
+        "summary": (
+            "Activities are suggested against lodging geography. Approved activities get "
+            "explicit day/time slots for tracking in the Master Timeline."
+        ),
+        "entries": entries,
+    }
+
+
+def _stay_day_anchors(
+    option: object,
+    lodging_state: ResearchShortlistState | None,
+) -> list[dict[str, int | str]]:
+    structure = (getattr(lodging_state, "artifacts", {}) or {}).get("lodging_structure", {})
+    raw_plan = structure.get("night_plan") if isinstance(structure, dict) else None
+    if not raw_plan:
+        raw_plan = [
+            {"region": region, "nights": nights}
+            for region, nights in getattr(option, "nights_by_region", {}).items()
+        ]
+    if not raw_plan:
+        raw_plan = [{"region": region, "nights": 2} for region in getattr(option, "regions", [])]
+    anchors: list[dict[str, int | str]] = []
+    cursor = 1
+    for raw in raw_plan or [{"region": "destination", "nights": 2}]:
+        region = str(raw.get("region") or "destination")
+        nights = max(1, _positive_int(raw.get("nights")) or 1)
+        anchors.append(
+            {
+                "region": region,
+                "start_day": cursor,
+                "end_day": cursor + nights,
+                "nights": nights,
+            }
+        )
+        cursor += nights
+    return anchors or [{"region": "destination", "start_day": 2, "end_day": 3, "nights": 1}]
+
+
+def _best_anchor_for_activity(
+    activity: ActivityOption,
+    anchors: list[dict[str, int | str]],
+) -> dict[str, int | str] | None:
+    location = _normalize_location(activity.island_location)
+    for anchor in anchors:
+        region = _normalize_location(str(anchor["region"]))
+        if region and (region in location or location in region):
+            return anchor
+        for piece in region.replace(" or ", " / ").split(" / "):
+            piece = piece.strip()
+            if piece and piece in location:
+                return anchor
+    return None
+
+
+def _suggested_activity_day(
+    anchor: dict[str, int | str],
+    used_days: set[int],
+    duration_days: int,
+) -> int:
+    start_day = int(anchor["start_day"])
+    end_day = int(anchor["end_day"])
+    first_usable = start_day + (1 if start_day == 1 else 0)
+    last_usable = max(first_usable, end_day - 1)
+    if duration_days:
+        last_usable = min(last_usable, max(1, duration_days - 1))
+    candidates = list(range(first_usable, last_usable + 1)) or [max(2, start_day)]
+    middle = candidates[len(candidates) // 2]
+    ordered = [middle, *candidates]
+    for day in ordered:
+        if day not in used_days:
+            return day
+    return ordered[0]
+
+
+def _date_for_day(start: date | None, day: int | None) -> date | None:
+    if start is None or not day:
+        return None
+    return start + timedelta(days=max(0, day - 1))
+
+
+def _default_end_time(start_time: str, duration: str) -> str:
+    if start_time == "14:00":
+        return "17:30" if "full" not in duration.lower() else "18:00"
+    return "13:00" if "full" not in duration.lower() else "16:30"
+
+
+def _positive_int(value: object) -> int | None:
+    try:
+        parsed = int(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _normalize_location(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+    return " ".join(ascii_value.lower().replace("-", " ").split())

--- a/trippy/services/activity_shortlist.py
+++ b/trippy/services/activity_shortlist.py
@@ -160,15 +160,20 @@ def _options_from_profile(
     intake: TripIntake,
     selected_regions: list[str],
 ) -> list[ActivityOption]:
-    targets = [
-        target
-        for target in getattr(profile, "activity_search_targets", [])
-        if target_matches_selected_regions(
-            target,
-            selected_regions,
-            getattr(profile, "island_or_region_terms", []),
-        )
-    ]
+    raw_targets = list(getattr(profile, "activity_search_targets", []))
+    targets = (
+        raw_targets
+        if getattr(profile, "key", "") == "generic"
+        else [
+            target
+            for target in raw_targets
+            if target_matches_selected_regions(
+                target,
+                selected_regions,
+                getattr(profile, "island_or_region_terms", []),
+            )
+        ]
+    )
     party = intake.party
     traveler_count = party.total_travelers
     has_children = party.has_children
@@ -198,12 +203,11 @@ def _options_from_profile(
                     if has_children
                     else f"Must fit {traveler_count} adult traveler(s)."
                 ),
-                price_band="live verify per person/family total",
-                duration="half-day target unless explicitly planned as a full-day anchor",
+                price_band="source price required",
+                duration="source schedule required",
                 deep_link=source_search_url("GetYourGuide", query),
                 validation_links={
                     "Tripadvisor": source_search_url("Tripadvisor", query),
-                    "Airbnb Experiences": source_search_url("Airbnb Experiences", query),
                 },
                 family_pace_fit_score=88 if idx <= 3 else 74,
                 safety_confidence_score=78,
@@ -220,7 +224,7 @@ def _options_from_profile(
                 ],
                 friction_flags=flags,
                 confidence_notes=[
-                    "Source link is the start of live validation, not a confirmed booking option."
+                    "Source research must extract current cost, bookable time, duration, and availability before booking."
                 ],
                 live_data_status=LiveDataStatus.HANDOFF_REQUIRED,
             )
@@ -245,14 +249,16 @@ def _apply_activity_schedule_suggestions(
 ) -> None:
     anchors = _stay_day_anchors(option, lodging_state)
     used_days: set[int] = set()
-    for idx, activity in enumerate(state.activity_options, start=1):
+    for activity in state.activity_options:
         anchor = _best_anchor_for_activity(activity, anchors) or anchors[0]
         day = _suggested_activity_day(
             anchor, used_days, int(getattr(option, "duration_days", 0) or 0)
         )
         used_days.add(day)
-        start_time = "09:30" if idx % 2 else "14:00"
-        end_time = _default_end_time(start_time, activity.duration)
+        start_time = _source_field(activity, "start_time")
+        end_time = _source_field(activity, "end_time") or (
+            _default_end_time(start_time, activity.duration) if start_time else ""
+        )
         date_value = _date_for_day(intake.travel_window.start_date, day)
         activity.suggested_day = day
         activity.suggested_date = date_value.isoformat() if date_value else ""
@@ -263,6 +269,13 @@ def _apply_activity_schedule_suggestions(
             "geography and avoids unnecessary backtracking."
         )
     _write_activity_schedule_artifact(state)
+
+
+def _source_field(activity: ActivityOption, field: str) -> str:
+    value = ""
+    if activity.validation and isinstance(activity.validation.extracted_fields, dict):
+        value = str(activity.validation.extracted_fields.get(field) or "").strip()
+    return value
 
 
 def _merge_existing_activity_state(
@@ -345,6 +358,13 @@ def _write_activity_schedule_artifact(state: ResearchShortlistState) -> None:
                 "notes": option.scheduling_notes,
             }
         )
+    entries.sort(
+        key=lambda entry: (
+            int(entry.get("scheduled_day") or entry.get("suggested_day") or 999),
+            str(entry.get("scheduled_start_time") or entry.get("suggested_start_time") or "99:99"),
+            str(entry.get("activity_name") or ""),
+        )
+    )
     state.artifacts["activity_schedule"] = {
         "data_status": "suggested_and_manual",
         "summary": (

--- a/trippy/services/car_shortlist.py
+++ b/trippy/services/car_shortlist.py
@@ -8,6 +8,7 @@ from trippy.models.shortlists import (
     RecommendationGrade,
     ResearchShortlistState,
     ShortlistCategory,
+    ShortlistRowStatus,
 )
 from trippy.models.sources import TravelSourceCategory
 from trippy.models.trip_planning import TripIntake
@@ -81,6 +82,33 @@ class CarShortlistService:
             SourceResearchService().research_state(state, adapter_mode=adapter_mode)
         return self._store.save(state)
 
+    def select_car(self, trip_id: str, option_id: str) -> ResearchShortlistState:
+        """Approve a car option so it can drive pickup/dropoff planning."""
+        state = self._store.load(trip_id, ShortlistCategory.CARS) or self.build(trip_id)
+        option = _car_by_id(state, option_id)
+        if option is None:
+            raise ValueError(f"No car option {option_id!r} for trip {trip_id!r}")
+        for candidate in state.car_options:
+            if candidate.option_id == option_id:
+                candidate.row_status = ShortlistRowStatus.APPROVED
+            elif candidate.row_status == ShortlistRowStatus.APPROVED:
+                candidate.row_status = ShortlistRowStatus.RESEARCHED
+        state.recommended_option_id = option_id
+        state.recommendation_summary = (
+            f"Selected {option.vehicle_class} from {option.booking_source}. Confirm live price, "
+            "provider terms, luggage fit, automatic transmission, deposit, and pickup details before booking."
+        )
+        state.artifacts["selected_car_option_id"] = option_id
+        if (
+            "Selected car now drives pickup/dropoff, luggage-fit, parking, and timeline checks."
+            not in (state.next_actions)
+        ):
+            state.next_actions.insert(
+                0,
+                "Selected car now drives pickup/dropoff, luggage-fit, parking, and timeline checks.",
+            )
+        return self._store.save(state)
+
 
 def _options_from_profile(
     profile: object,
@@ -121,6 +149,8 @@ def _options_from_profile(
                 pickup_location=str(target["pickup"]),
                 dropoff_location=str(target["dropoff"]),
                 vehicle_class=vehicle_class,
+                price_band="live quote required; compare total with taxes and fees",
+                current_price_signal="not live-quoted yet",
                 seating_capacity=seating_capacity,
                 passenger_fit=(
                     f"{traveler_count} traveler(s) fit on seats; comfort depends on exact model"
@@ -169,3 +199,7 @@ def _options_from_profile(
             )
         )
     return options
+
+
+def _car_by_id(state: ResearchShortlistState, option_id: str) -> CarOption | None:
+    return next((option for option in state.car_options if option.option_id == option_id), None)

--- a/trippy/services/dashboard.py
+++ b/trippy/services/dashboard.py
@@ -169,16 +169,36 @@ def _budget_band(trip: Trip) -> str:
 
 
 def _planning_completeness(trip: Trip) -> int:
+    """Estimate true booking readiness, not scaffold creation.
+
+    A trip should only reach 100% when real booking state exists: confirmed
+    flights/lodging plus an operational sheet. Placeholder research rows count
+    as progress, but they are intentionally capped below full completion.
+    """
+    planning_status = _planning_status(trip.trip_id)
+    shortlist_status = _shortlist_status(trip.trip_id)
+    approved_categories = sum(
+        1 for value in shortlist_status.values() if " approved" in value or "booked" in value
+    )
+    booked_flights = bool(trip.segments) and not trip.unconfirmed_segments
+    booked_lodging = bool(trip.stays) and not trip.unconfirmed_stays
+    sheet_ready = bool(trip.sync.google_sheet_url or trip.sync.google_sheet_id)
     checks = [
-        bool(trip.segments),
-        bool(trip.stays),
+        "intake" in planning_status,
+        planning_status.get("draft") == "selected",
+        len(shortlist_status) >= 4,
+        approved_categories >= 1,
+        approved_categories >= 2,
+        sheet_ready,
+        booked_flights,
+        booked_lodging,
+        booked_flights and booked_lodging and sheet_ready,
         bool(trip.travelers),
-        bool(trip.sync.google_sheet_url or trip.sync.google_sheet_id),
-        not trip.unconfirmed_segments,
-        not trip.unconfirmed_stays,
-        any(item.category in {"visa", "document", "logistics"} for item in trip.checklist),
     ]
-    return int(sum(1 for item in checks if item) / len(checks) * 100)
+    score = int(sum(1 for item in checks if item) / len(checks) * 100)
+    if not (booked_flights and booked_lodging and sheet_ready):
+        score = min(score, 85)
+    return score
 
 
 def _planning_status(trip_id: str) -> dict[str, str]:

--- a/trippy/services/destination_profiles.py
+++ b/trippy/services/destination_profiles.py
@@ -51,14 +51,54 @@ def profile_for_intake(intake: TripIntake) -> DestinationProfile:
                 "query": f"{destination} car rental SUV minivan family luggage",
             }
         ],
-        activity_search_targets=[
-            {
-                "name": f"{destination} small-group family activities",
-                "location": destination,
-                "query": f"{destination} small group family activities",
-            }
-        ],
+        activity_search_targets=_generic_activity_search_targets(intake, destination),
     )
+
+
+def _generic_activity_search_targets(
+    intake: TripIntake,
+    destination: str,
+) -> list[dict[str, str]]:
+    seeds = [seed.strip() for seed in intake.destination_seeds if seed.strip()] or [destination]
+    targets: list[dict[str, str]] = []
+    for seed in seeds[:5]:
+        lower = seed.lower()
+        if "stingray" in lower:
+            name = f"{seed} family stingray and sandbar tour"
+            query = f"{seed} small group family stingray sandbar tour"
+        elif "rum point" in lower:
+            name = f"{seed} family boat and beach day"
+            query = f"{seed} small group family boat beach tour"
+        elif any(term in lower for term in ["beach", "bay", "island", "coast"]):
+            name = f"{seed} family snorkeling or beach activity"
+            query = f"{seed} family snorkeling beach activity small group"
+        else:
+            name = f"{seed} family-friendly guided activity"
+            query = f"{seed} family friendly guided activity small group"
+        targets.append({"name": name, "location": seed, "query": query})
+    if len(targets) < 5:
+        targets.extend(
+            [
+                {
+                    "name": f"{destination} private family highlights tour",
+                    "location": destination,
+                    "query": f"{destination} private family highlights tour",
+                },
+                {
+                    "name": f"{destination} family food or culture experience",
+                    "location": destination,
+                    "query": f"{destination} family food culture experience",
+                },
+            ]
+        )
+    deduped: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for target in targets:
+        key = target["query"].lower()
+        if key not in seen:
+            seen.add(key)
+            deduped.append(target)
+    return deduped[:8]
 
 
 _AZORES = DestinationProfile(

--- a/trippy/services/flight_shortlist.py
+++ b/trippy/services/flight_shortlist.py
@@ -3,17 +3,27 @@
 from __future__ import annotations
 
 import base64
+import json
 import re
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
 
+from trippy import config
 from trippy.models.shortlists import (
+    AvailabilityStatus,
     FlightOption,
+    FreshnessStatus,
     LiveDataStatus,
+    PriceStatus,
     RecommendationGrade,
     ResearchShortlistState,
     ShortlistCategory,
     ShortlistRowStatus,
+    SourceType,
+    SourceValidation,
+    VerificationStatus,
 )
 from trippy.models.sources import TravelSourceCategory
 from trippy.services.destination_profiles import profile_for_intake
@@ -23,8 +33,6 @@ from trippy.services.shortlist_store import (
     ShortlistStore,
     source_plan,
     source_plan_payload,
-    source_search_url,
-    trip_query,
 )
 from trippy.services.source_research import SourceResearchService
 from trippy.services.trip_intake import TripIntakeService
@@ -59,9 +67,9 @@ class FlightShortlistService:
         )
         plan = source_plan(TravelSourceCategory.FLIGHTS)
         profile = profile_for_intake(ctx.intake)
-        options = _azores_options(
-            ctx, profile.gateway_airports[0] if profile.gateway_airports else "destination"
-        )
+        gateway = profile.gateway_airports[0] if profile.gateway_airports else "destination"
+        live_options, live_notes = _duffel_live_options(ctx, gateway)
+        options = live_options or _azores_options(ctx, gateway)
         state = ResearchShortlistState(
             trip_id=trip_id,
             category=ShortlistCategory.FLIGHTS,
@@ -74,12 +82,21 @@ class FlightShortlistService:
                 "availability, fare rules, baggage, seats, and Aeroplan eligibility before handoff."
             ),
             warnings=[
-                "Flight numbers and fares are not asserted unless the source link confirms them live.",
+                (
+                    "Live Duffel offers populated exact flight rows."
+                    if live_options
+                    else "Flight numbers and fares are not asserted unless a live provider or source link confirms them."
+                ),
+                *live_notes,
                 *profile.flight_notes,
             ],
             next_actions=[
-                "Open the Google Flights link for the top option and verify exact dates.",
-                "Cross-check the same routing on Kayak.ca, Expedia, and Flighthub.",
+                (
+                    "Review the live provider offer details, then cross-check the top option in Google Flights."
+                    if live_options
+                    else "Configure DUFFEL_ACCESS_TOKEN or add a flight candidate with exact itinerary text to replace placeholders."
+                ),
+                "Cross-check the same routing on Kayak.ca before booking.",
                 "Reject multi-ticket routings unless airport, baggage, and delay protection are clearly acceptable.",
             ],
         )
@@ -172,16 +189,7 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
     traveler_count = ctx.intake.party.total_travelers
     party_note = ctx.intake.party.summary()
     date_hint = _flight_date_hint(ctx)
-    query_base = trip_query(
-        ctx.intake,
-        f"flights {origin} to {gateway} {traveler_count} travelers",
-    )
-    comparison = {
-        "Google Flights": _flight_source_url("Google Flights", origin, gateway, ctx),
-        "Kayak.ca": _flight_source_url("Kayak.ca", origin, gateway, ctx),
-        "Expedia": _flight_source_url("Expedia", origin, gateway, ctx),
-        "Flighthub": source_search_url("Flighthub", query_base),
-    }
+    comparison = _flight_comparison_links(origin, gateway, ctx)
     return [
         FlightOption(
             option_id="flight-direct-yyz-pdl",
@@ -286,10 +294,7 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
             deep_link=_flight_source_url("Kayak.ca", origin, gateway, ctx),
             traveler_count=traveler_count,
             traveler_fit=f"Weak fit for {party_note} unless protected, because luggage/recheck risk scales with party size.",
-            comparison_links={
-                "Google Flights": _flight_source_url("Google Flights", origin, gateway, ctx),
-                "Expedia": _flight_source_url("Expedia", origin, gateway, ctx),
-            },
+            comparison_links=_flight_comparison_links(origin, gateway, ctx),
             aeroplan_relevance="Possible on the Toronto-Boston leg only; weak overall unless same-ticket.",
             friction_score=48,
             family_comfort_score=62,
@@ -311,6 +316,228 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
     ]
 
 
+def _duffel_live_options(
+    ctx: ShortlistContext,
+    gateway: str,
+) -> tuple[list[FlightOption], list[str]]:
+    token = config.DUFFEL_ACCESS_TOKEN.strip()
+    if not token:
+        return [], ["DUFFEL_ACCESS_TOKEN is not configured, so flight rows are search handoffs."]
+    origin = _iata_or_text(
+        ctx.intake.departure_airports[0] if ctx.intake.departure_airports else "YYZ"
+    )
+    destination = _iata_or_text(gateway)
+    if not _looks_like_iata(origin) or not _looks_like_iata(destination):
+        return [], [
+            f"Duffel live search skipped because route codes are not IATA: {origin} to {destination}."
+        ]
+    departure_date, return_date = _flight_dates(ctx)
+    try:
+        payload = _duffel_offer_request_payload(
+            ctx, origin, destination, departure_date, return_date
+        )
+        response = _post_duffel_offer_request(token, payload)
+    except (HTTPError, URLError, TimeoutError, OSError, ValueError) as exc:
+        return [], [f"Duffel live flight search failed: {exc}"]
+    offers = list((response.get("data") or {}).get("offers") or [])
+    if not offers:
+        return [], ["Duffel returned no live offers for this route/date search."]
+    comparison = _flight_comparison_links(origin, destination, ctx)
+    options = [
+        option
+        for option in (
+            _duffel_offer_to_option(offer, index, ctx, origin, destination, comparison)
+            for index, offer in enumerate(offers[:8], start=1)
+        )
+        if option is not None
+    ]
+    return options, [
+        f"Duffel returned {len(options)} exact offer row(s) for {origin}-{destination}.",
+        "Duffel prices are live offer signals but can expire; verify before booking.",
+    ]
+
+
+def _duffel_offer_request_payload(
+    ctx: ShortlistContext,
+    origin: str,
+    destination: str,
+    departure_date: date,
+    return_date: date,
+) -> dict[str, object]:
+    return {
+        "data": {
+            "slices": [
+                {
+                    "origin": origin,
+                    "destination": destination,
+                    "departure_date": departure_date.isoformat(),
+                },
+                {
+                    "origin": destination,
+                    "destination": origin,
+                    "departure_date": return_date.isoformat(),
+                },
+            ],
+            "passengers": _duffel_passengers(ctx),
+            "cabin_class": "economy",
+            "max_connections": 1,
+        }
+    }
+
+
+def _duffel_passengers(ctx: ShortlistContext) -> list[dict[str, object]]:
+    party = ctx.intake.party
+    passengers: list[dict[str, object]] = []
+    passengers.extend({"type": "adult"} for _ in range(max(1, party.adults or 1)))
+    child_ages = list(party.child_ages or [])
+    for index in range(max(0, party.children)):
+        if index < len(child_ages):
+            passengers.append({"age": int(child_ages[index])})
+        else:
+            passengers.append({"type": "child"})
+    total = ctx.intake.party.total_travelers or ctx.intake.travelers or len(passengers)
+    while len(passengers) < total:
+        passengers.append({"type": "adult"})
+    return passengers
+
+
+def _post_duffel_offer_request(token: str, payload: dict[str, object]) -> dict[str, object]:
+    body = json.dumps(payload).encode("utf-8")
+    request = Request(
+        "https://api.duffel.com/air/offer_requests?return_offers=true&supplier_timeout=10000",
+        data=body,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Duffel-Version": "v2",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "Trippy/0.2 flight-offer-search",
+        },
+        method="POST",
+    )
+    with urlopen(request, timeout=max(15, config.SOURCE_RESEARCH_TIMEOUT_SECONDS)) as response:  # noqa: S310 - configured authenticated API endpoint
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _duffel_offer_to_option(
+    offer: dict[str, object],
+    rank: int,
+    ctx: ShortlistContext,
+    origin: str,
+    destination: str,
+    comparison: dict[str, str],
+) -> FlightOption | None:
+    slices = [item for item in offer.get("slices", []) if isinstance(item, dict)]
+    if not slices:
+        return None
+    outbound = slices[0]
+    segments = [item for item in outbound.get("segments", []) if isinstance(item, dict)]
+    if not segments:
+        return None
+    first = segments[0]
+    last = segments[-1]
+    flight_numbers = [_segment_flight_number(segment) for segment in segments]
+    flight_numbers = [number for number in flight_numbers if number]
+    carriers = _segment_carriers(segments)
+    owner = offer.get("owner")
+    owner_name = str(owner.get("name") or "") if isinstance(owner, dict) else ""
+    airline = " / ".join(carriers) if carriers else owner_name or "Live flight offer"
+    departing_at = str(first.get("departing_at") or "")
+    arriving_at = str(last.get("arriving_at") or "")
+    departure_date, departure_time = _split_duffel_timestamp(departing_at)
+    arrival_date, arrival_time = _split_duffel_timestamp(arriving_at)
+    stops = max(0, len(segments) - 1)
+    layover_airports = [
+        str(destination.get("iata_code") or "")
+        for segment in segments[:-1]
+        if isinstance(destination := segment.get("destination"), dict)
+    ]
+    layover_airports = [airport for airport in layover_airports if airport]
+    layover_duration = _duffel_layover_duration(segments)
+    duration = _duffel_duration(outbound, first, last)
+    price = _duffel_price(offer)
+    google_link = _flight_source_url("Google Flights", origin, destination, ctx)
+    offer_id = str(offer.get("id") or f"duffel-offer-{rank}")
+    validation = SourceValidation(
+        source_name="Duffel",
+        source_type=SourceType.LIVE_SEARCH,
+        verified_at=datetime.utcnow(),
+        freshness_status=FreshnessStatus.CURRENT,
+        verification_status=VerificationStatus.LIVE_VERIFIED,
+        availability_status=AvailabilityStatus.AVAILABILITY_SIGNAL,
+        price_status=PriceStatus.LIVE_SIGNAL if price else PriceStatus.UNKNOWN,
+        confidence=0.86,
+        evidence_url=f"duffel:{offer_id}",
+        adapter_used="duffel",
+        extracted_fields={
+            "airline": airline,
+            "flight_numbers": flight_numbers,
+            "departure_date": departure_date,
+            "arrival_date": arrival_date,
+            "departure_time": departure_time,
+            "arrival_time": arrival_time,
+            "total_duration": duration,
+            "stops": stops,
+            "layover_airports": layover_airports,
+            "layover_duration": layover_duration or "",
+            "price_signal": price,
+            "availability_signal": "live offer returned",
+            "offer_id": offer_id,
+        },
+        notes=[
+            "Offer came from Duffel live flight search; fare and inventory can expire.",
+            "Cross-check public search links before booking if not purchasing through Duffel.",
+        ],
+        missing_fields=[],
+    )
+    friction = min(
+        90,
+        8 + stops * 16 + (8 if layover_duration and "overnight" in layover_duration.lower() else 0),
+    )
+    comfort = max(35, 94 - stops * 12)
+    return FlightOption(
+        option_id=f"duffel-flight-{rank}",
+        rank=rank,
+        airline=airline,
+        flight_numbers=flight_numbers,
+        departure_date=departure_date,
+        arrival_date=arrival_date,
+        departure_airport=_segment_airport(first, "origin") or origin,
+        arrival_airport=_segment_airport(last, "destination") or destination,
+        departure_time=departure_time,
+        arrival_time=arrival_time,
+        stops=stops,
+        layover_airports=layover_airports,
+        layover_duration=layover_duration,
+        total_travel_duration=duration,
+        timing_fit=_timing_fit(arrival_time, departure_time),
+        fare_estimate_cad=price,
+        price_band=price,
+        baggage_cabin_notes=_duffel_baggage_notes(offer),
+        booking_source="Duffel",
+        deep_link=google_link,
+        traveler_count=ctx.intake.party.total_travelers,
+        traveler_fit=f"Live offer for {ctx.intake.party.summary()}; verify fare expiry, baggage, seats, and booking channel.",
+        comparison_links={**comparison, "Duffel offer id": offer_id},
+        aeroplan_relevance="Verify earning by carrier and fare class before assuming Aeroplan value.",
+        friction_score=friction,
+        family_comfort_score=comfort,
+        recommendation_grade=RecommendationGrade.STRONG if stops == 0 else RecommendationGrade.GOOD,
+        tradeoffs=[
+            "Specific live offer with flight numbers, times, duration, and fare signal.",
+            "Offer may expire or reprice before booking.",
+        ],
+        friction_flags=_planning_timing_flags_for_values(stops, layover_duration),
+        confidence_notes=[
+            "Exact itinerary fields came from Duffel offer segments.",
+            f"Duffel offer id: {offer_id}",
+        ],
+        live_data_status=LiveDataStatus.LIVE_VERIFIED,
+        row_status=ShortlistRowStatus.VERIFIED_LIVE,
+        validation=validation,
+    )
+
+
 def _user_candidate_option(
     state: ResearchShortlistState,
     ctx: ShortlistContext,
@@ -329,6 +556,8 @@ def _user_candidate_option(
     duration = _duration_from_notes(notes) or "duration not supplied"
     departure = _time_from_notes(notes, ["depart", "departure", "leaves", "outbound"])
     arrival = _time_from_notes(notes, ["arrive", "arrival", "lands"])
+    departure_date = _date_from_notes(notes, ["depart", "departure", "outbound", "leave", "leaves"])
+    arrival_date = _date_from_notes(notes, ["arrive", "arrival", "lands"])
     price = _price_signal(notes) or "not supplied"
     flags = []
     if stops is None:
@@ -360,6 +589,8 @@ def _user_candidate_option(
         rank=rank,
         airline=display_name,
         flight_numbers=_flight_numbers(notes),
+        departure_date=departure_date,
+        arrival_date=arrival_date,
         departure_airport=origin,
         arrival_airport=destination,
         departure_time=departure or "not supplied",
@@ -446,22 +677,161 @@ def _flight_source_url(
             f"{origin_code}-{destination_code}/{departure_date.isoformat()}/{return_date.isoformat()}"
             f"/{total_travelers}adults?sort=bestflight_a"
         )
-    if source == "Expedia":
-        return "https://www.expedia.ca/Flights-Search?" + urlencode(
-            {
-                "trip": "roundtrip",
-                "leg1": f"from:{origin_code},to:{destination_code},departure:{departure_date.isoformat()}TANYT",
-                "leg2": f"from:{destination_code},to:{origin_code},departure:{return_date.isoformat()}TANYT",
-                "passengers": f"adults:{adults}",
-                "mode": "search",
-            }
-        )
-    query = trip_query(
-        ctx.intake,
-        f"flights {origin_code} to {destination_code} {total_travelers} travelers "
-        f"{departure_date.isoformat()} return {return_date.isoformat()}",
+    return _flight_source_url("Google Flights", origin_code, destination_code, ctx)
+
+
+def _flight_comparison_links(
+    origin: str,
+    destination: str,
+    ctx: ShortlistContext,
+) -> dict[str, str]:
+    """Only expose providers with route URLs that reliably preserve search fields."""
+    return {
+        "Google Flights": _flight_source_url("Google Flights", origin, destination, ctx),
+        "Kayak.ca": _flight_source_url("Kayak.ca", origin, destination, ctx),
+    }
+
+
+def _looks_like_iata(value: str) -> bool:
+    return bool(re.fullmatch(r"[A-Z]{3}", value.strip().upper()))
+
+
+def _segment_flight_number(segment: dict[str, object]) -> str:
+    carrier = segment.get("marketing_carrier")
+    carrier_code = ""
+    if isinstance(carrier, dict):
+        carrier_code = str(carrier.get("iata_code") or "")
+    number = str(
+        segment.get("marketing_carrier_flight_number") or segment.get("flight_number") or ""
     )
-    return source_search_url(source, query)
+    return f"{carrier_code}{number}".strip().upper() if number else ""
+
+
+def _segment_carriers(segments: list[dict[str, object]]) -> list[str]:
+    carriers: list[str] = []
+    for segment in segments:
+        carrier = segment.get("operating_carrier") or segment.get("marketing_carrier")
+        name = ""
+        if isinstance(carrier, dict):
+            name = str(carrier.get("name") or carrier.get("iata_code") or "")
+        if name and name not in carriers:
+            carriers.append(name)
+    return carriers
+
+
+def _segment_airport(segment: dict[str, object], key: str) -> str:
+    airport = segment.get(key)
+    if isinstance(airport, dict):
+        return str(airport.get("iata_code") or "")
+    return ""
+
+
+def _split_duffel_timestamp(value: str) -> tuple[str, str]:
+    if not value:
+        return "", ""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return value[:10], value[11:16] if len(value) >= 16 else ""
+    return parsed.date().isoformat(), parsed.strftime("%-I:%M %p")
+
+
+def _duffel_duration(
+    outbound_slice: dict[str, object],
+    first_segment: dict[str, object],
+    last_segment: dict[str, object],
+) -> str:
+    duration = str(outbound_slice.get("duration") or "")
+    if duration:
+        return _format_iso_duration(duration)
+    start = _parse_duffel_datetime(str(first_segment.get("departing_at") or ""))
+    end = _parse_duffel_datetime(str(last_segment.get("arriving_at") or ""))
+    if not start or not end:
+        return "duration unavailable"
+    return _format_minutes(int((end - start).total_seconds() // 60))
+
+
+def _duffel_layover_duration(segments: list[dict[str, object]]) -> str | None:
+    if len(segments) <= 1:
+        return None
+    pieces: list[str] = []
+    for previous, next_segment in zip(segments, segments[1:], strict=False):
+        arrival = _parse_duffel_datetime(str(previous.get("arriving_at") or ""))
+        departure = _parse_duffel_datetime(str(next_segment.get("departing_at") or ""))
+        airport = ""
+        destination = previous.get("destination")
+        if isinstance(destination, dict):
+            airport = str(destination.get("iata_code") or "")
+        if arrival and departure:
+            pieces.append(
+                f"{airport} {_format_minutes(int((departure - arrival).total_seconds() // 60))}".strip()
+            )
+    return ", ".join(pieces) or None
+
+
+def _parse_duffel_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _format_iso_duration(value: str) -> str:
+    match = re.fullmatch(r"P(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?", value)
+    if not match:
+        return value
+    hours = int(match.group(1) or 0)
+    minutes = int(match.group(2) or 0)
+    return _format_minutes(hours * 60 + minutes)
+
+
+def _format_minutes(total_minutes: int) -> str:
+    if total_minutes <= 0:
+        return "duration unavailable"
+    hours, minutes = divmod(total_minutes, 60)
+    if hours and minutes:
+        return f"{hours}h {minutes}m"
+    if hours:
+        return f"{hours}h"
+    return f"{minutes}m"
+
+
+def _duffel_price(offer: dict[str, object]) -> str:
+    amount = str(offer.get("total_amount") or "")
+    currency = str(offer.get("total_currency") or "")
+    if not amount:
+        return "live fare returned; amount unavailable"
+    if currency.upper() == "CAD":
+        return f"CAD {amount} total"
+    return f"{currency} {amount} total".strip()
+
+
+def _duffel_baggage_notes(offer: dict[str, object]) -> str:
+    conditions = offer.get("conditions")
+    notes: list[str] = []
+    if isinstance(conditions, dict):
+        for key in ("refund_before_departure", "change_before_departure"):
+            value = conditions.get(key)
+            if isinstance(value, dict) and value.get("allowed") is not None:
+                notes.append(
+                    f"{key.replace('_', ' ')}: {'allowed' if value.get('allowed') else 'not allowed'}"
+                )
+    return (
+        "; ".join(notes) or "Validate bags, seats, fare rules, and family seating before booking."
+    )
+
+
+def _planning_timing_flags_for_values(stops: int, layover_duration: str | None) -> list[str]:
+    flags: list[str] = []
+    if stops > 1:
+        flags.append("multiple connections increase travel-day friction")
+    elif stops == 1:
+        flags.append("connection timing must be checked against family luggage and delay risk")
+    if layover_duration and "overnight" in layover_duration.lower():
+        flags.append("overnight layover requires lodging plan")
+    return flags
 
 
 def _flight_date_hint(ctx: ShortlistContext) -> str:
@@ -967,6 +1337,19 @@ def _time_from_notes(notes: str, labels: list[str]) -> str:
         flags=re.IGNORECASE,
     )
     return match.group(1).strip() if match else ""
+
+
+def _date_from_notes(notes: str, labels: list[str]) -> str:
+    label_pattern = "|".join(re.escape(label) for label in labels)
+    match = re.search(
+        rf"(?:{label_pattern})(?:ure|s|ing)?\s*(?:date)?\s*(?:on|:|-)?\s*"
+        r"((?:20\d{2}-\d{2}-\d{2})|(?:\d{4}-\d{2}-\d{2})|"
+        r"(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+20\d{2})|"
+        r"(?:\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+20\d{2}))",
+        notes,
+        flags=re.IGNORECASE,
+    )
+    return " ".join(match.group(1).replace(",", "").split()) if match else ""
 
 
 def _layover_duration_from_notes(notes: str) -> str | None:

--- a/trippy/services/flight_shortlist.py
+++ b/trippy/services/flight_shortlist.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import base64
 import re
-from urllib.parse import urlparse
+from datetime import date, timedelta
+from urllib.parse import urlencode, urlparse
 
 from trippy.models.shortlists import (
     FlightOption,
@@ -169,13 +171,15 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
     origin = ctx.intake.departure_airports[0] if ctx.intake.departure_airports else "YYZ"
     traveler_count = ctx.intake.party.total_travelers
     party_note = ctx.intake.party.summary()
+    date_hint = _flight_date_hint(ctx)
     query_base = trip_query(
         ctx.intake,
         f"flights {origin} to {gateway} {traveler_count} travelers",
     )
     comparison = {
-        "Kayak.ca": source_search_url("Kayak.ca", query_base),
-        "Expedia": source_search_url("Expedia", query_base),
+        "Google Flights": _flight_source_url("Google Flights", origin, gateway, ctx),
+        "Kayak.ca": _flight_source_url("Kayak.ca", origin, gateway, ctx),
+        "Expedia": _flight_source_url("Expedia", origin, gateway, ctx),
         "Flighthub": source_search_url("Flighthub", query_base),
     }
     return [
@@ -200,7 +204,7 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
             price_band="CAD 900-1,600 pp live-verify band",
             baggage_cabin_notes="Validate included bags, seat selection, and family seating before booking.",
             booking_source="Google Flights",
-            deep_link=source_search_url("Google Flights", query_base + " nonstop Azores Airlines"),
+            deep_link=_flight_source_url("Google Flights", origin, gateway, ctx),
             traveler_count=traveler_count,
             traveler_fit=f"Best fit for {party_note}: one plane, no layover, simplest baggage/seat path.",
             comparison_links=comparison,
@@ -216,7 +220,10 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
                 "seasonal availability must be verified",
                 "baggage and seat terms unknown",
             ],
-            confidence_notes=["This is a source-linked candidate, not a confirmed fare."],
+            confidence_notes=[
+                "This is a source-linked candidate, not a confirmed fare.",
+                date_hint,
+            ],
             live_data_status=LiveDataStatus.HANDOFF_REQUIRED,
         ),
         FlightOption(
@@ -237,7 +244,7 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
             price_band="CAD 850-1,500 pp live-verify band",
             baggage_cabin_notes="Prefer same-ticket baggage through-check and long-haul seat selection clarity.",
             booking_source="Google Flights",
-            deep_link=source_search_url("Google Flights", query_base + " Air Canada TAP Lisbon"),
+            deep_link=_flight_source_url("Google Flights", origin, gateway, ctx),
             traveler_count=traveler_count,
             traveler_fit=f"Acceptable for {party_note} only with same-ticket baggage and sane Lisbon buffer.",
             comparison_links=comparison,
@@ -254,7 +261,8 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
                 "avoid overnight or very tight Lisbon transfer",
             ],
             confidence_notes=[
-                "Use as the best backup if nonstop is unavailable or irrationally expensive."
+                "Use as the best backup if nonstop is unavailable or irrationally expensive.",
+                date_hint,
             ],
         ),
         FlightOption(
@@ -275,12 +283,12 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
             price_band="CAD 700-1,400 pp live-verify band",
             baggage_cabin_notes="Do not accept unprotected baggage recheck with a tight family connection.",
             booking_source="Kayak.ca",
-            deep_link=source_search_url("Kayak.ca", query_base + " via Boston"),
+            deep_link=_flight_source_url("Kayak.ca", origin, gateway, ctx),
             traveler_count=traveler_count,
             traveler_fit=f"Weak fit for {party_note} unless protected, because luggage/recheck risk scales with party size.",
             comparison_links={
-                "Google Flights": source_search_url("Google Flights", query_base + " via Boston"),
-                "Expedia": source_search_url("Expedia", query_base + " via Boston"),
+                "Google Flights": _flight_source_url("Google Flights", origin, gateway, ctx),
+                "Expedia": _flight_source_url("Expedia", origin, gateway, ctx),
             },
             aeroplan_relevance="Possible on the Toronto-Boston leg only; weak overall unless same-ticket.",
             friction_score=48,
@@ -295,7 +303,10 @@ def _azores_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
                 "delay protection risk",
                 "family luggage burden",
             ],
-            confidence_notes=["Use mainly as a price sanity check, not default recommendation."],
+            confidence_notes=[
+                "Use mainly as a price sanity check, not default recommendation.",
+                date_hint,
+            ],
         ),
     ]
 
@@ -368,14 +379,8 @@ def _user_candidate_option(
             f"User-supplied flight for {intake.party.summary()}; verify timing, fare, baggage, and source evidence."
         ),
         comparison_links={
-            "Google Flights": source_search_url(
-                "Google Flights",
-                trip_query(intake, f"flights {origin} to {destination} {traveler_count} travelers"),
-            ),
-            "Kayak.ca": source_search_url(
-                "Kayak.ca",
-                trip_query(intake, f"flights {origin} to {destination} {traveler_count} travelers"),
-            ),
+            "Google Flights": _flight_source_url("Google Flights", origin, destination, ctx),
+            "Kayak.ca": _flight_source_url("Kayak.ca", origin, destination, ctx),
         },
         aeroplan_relevance="User-supplied candidate; verify carrier, fare class, and Aeroplan earning.",
         friction_score=friction,
@@ -394,6 +399,213 @@ def _user_candidate_option(
         ],
         live_data_status=LiveDataStatus.HANDOFF_REQUIRED,
     )
+
+
+def _flight_source_url(
+    source: str,
+    origin: str,
+    destination: str,
+    ctx: ShortlistContext,
+) -> str:
+    """Build route-specific flight handoff URLs instead of generic query pages.
+
+    Google Flights ignores the old natural-language ``?q=`` URLs. Its share/search
+    links need structured route data, so fuzzy trips receive deterministic placeholder
+    dates from the intake window and carry confidence notes explaining that the dates
+    must be adjusted before booking.
+    """
+    origin_code = _iata_or_text(origin)
+    destination_code = _iata_or_text(destination)
+    departure_date, return_date = _flight_dates(ctx)
+    adults = max(1, ctx.intake.party.adults or ctx.intake.party.total_travelers or 1)
+    total_travelers = max(1, ctx.intake.party.total_travelers or ctx.intake.travelers or adults)
+    if source == "Google Flights":
+        tfs = _google_flights_tfs(
+            origin_code,
+            destination_code,
+            departure_date.isoformat(),
+            return_date.isoformat(),
+            adults=adults,
+        )
+        return "https://www.google.com/travel/flights/search?" + urlencode(
+            {
+                "tfs": tfs,
+                "tfu": "EgIIACIA",
+                "hl": "en-CA",
+                "gl": "ca",
+                "curr": "CAD",
+                "origin": origin_code,
+                "destination": destination_code,
+                "departure": departure_date.isoformat(),
+                "return": return_date.isoformat(),
+            }
+        )
+    if source == "Kayak.ca":
+        return (
+            "https://www.ca.kayak.com/flights/"
+            f"{origin_code}-{destination_code}/{departure_date.isoformat()}/{return_date.isoformat()}"
+            f"/{total_travelers}adults?sort=bestflight_a"
+        )
+    if source == "Expedia":
+        return "https://www.expedia.ca/Flights-Search?" + urlencode(
+            {
+                "trip": "roundtrip",
+                "leg1": f"from:{origin_code},to:{destination_code},departure:{departure_date.isoformat()}TANYT",
+                "leg2": f"from:{destination_code},to:{origin_code},departure:{return_date.isoformat()}TANYT",
+                "passengers": f"adults:{adults}",
+                "mode": "search",
+            }
+        )
+    query = trip_query(
+        ctx.intake,
+        f"flights {origin_code} to {destination_code} {total_travelers} travelers "
+        f"{departure_date.isoformat()} return {return_date.isoformat()}",
+    )
+    return source_search_url(source, query)
+
+
+def _flight_date_hint(ctx: ShortlistContext) -> str:
+    window = ctx.intake.travel_window
+    if window.start_date and window.end_date:
+        return "Source links use the exact intake date range."
+    departure_date, return_date = _flight_dates(ctx)
+    return (
+        "Source links use placeholder search dates "
+        f"{departure_date.isoformat()} to {return_date.isoformat()} from the fuzzy intake window; "
+        "adjust dates in the source before treating fares as real."
+    )
+
+
+def _google_flights_tfs(
+    origin: str,
+    destination: str,
+    departure_date: str,
+    return_date: str,
+    *,
+    adults: int,
+) -> str:
+    """Build the Google Flights ``tfs`` search payload for a basic round trip.
+
+    Google ignores readable natural-language query params on the flights page.
+    The accepted handoff is a URL-safe protobuf blob; this encoder intentionally
+    stays narrow and only represents facts Trippy knows: route, dates, economy,
+    and adult passenger count.
+    """
+    info = (
+        _protobuf_varint_field(1, 28)
+        + _protobuf_varint_field(2, 2)
+        + _protobuf_len_field(3, _google_flight_leg(departure_date, origin, destination))
+        + _protobuf_len_field(3, _google_flight_leg(return_date, destination, origin))
+    )
+    for _ in range(max(1, adults)):
+        info += _protobuf_varint_field(8, 1)
+    info += _protobuf_varint_field(9, 1)  # economy
+    info += _protobuf_varint_field(14, 1)
+    info += _protobuf_len_field(16, b"\x08" + b"\xff" * 9 + b"\x01")
+    info += _protobuf_varint_field(19, 1)  # round trip
+    return base64.urlsafe_b64encode(info).rstrip(b"=").decode("ascii")
+
+
+def _google_flight_leg(leg_date: str, origin: str, destination: str) -> bytes:
+    return (
+        _protobuf_len_field(2, leg_date.encode())
+        + _protobuf_len_field(13, _google_airport(origin))
+        + _protobuf_len_field(14, _google_airport(destination))
+    )
+
+
+def _google_airport(code: str) -> bytes:
+    return _protobuf_varint_field(1, 1) + _protobuf_len_field(2, code.upper().encode())
+
+
+def _protobuf_varint_field(field_no: int, value: int) -> bytes:
+    return _protobuf_varint((field_no << 3) | 0) + _protobuf_varint(value)
+
+
+def _protobuf_len_field(field_no: int, value: bytes) -> bytes:
+    return _protobuf_varint((field_no << 3) | 2) + _protobuf_varint(len(value)) + value
+
+
+def _protobuf_varint(value: int) -> bytes:
+    chunks: list[int] = []
+    while value > 0x7F:
+        chunks.append((value & 0x7F) | 0x80)
+        value >>= 7
+    chunks.append(value & 0x7F)
+    return bytes(chunks)
+
+
+def _flight_dates(ctx: ShortlistContext) -> tuple[date, date]:
+    window = ctx.intake.travel_window
+    departure_date = window.start_date or _representative_departure_date(window.display())
+    duration_days = (
+        ctx.intake.duration_days or ctx.intake.duration_min_days or ctx.option.duration_days or 7
+    )
+    if window.end_date and window.start_date:
+        return_date = window.end_date
+    else:
+        return_date = departure_date + timedelta(days=max(1, duration_days))
+    if return_date <= departure_date:
+        return_date = departure_date + timedelta(days=max(1, duration_days))
+    return departure_date, return_date
+
+
+def _representative_departure_date(label: str) -> date:
+    cleaned = label.lower()
+    year_match = re.search(r"\b(20\d{2})\b", cleaned)
+    year = int(year_match.group(1)) if year_match else date.today().year
+    month_lookup = {
+        "jan": 1,
+        "january": 1,
+        "feb": 2,
+        "february": 2,
+        "mar": 3,
+        "march": 3,
+        "apr": 4,
+        "april": 4,
+        "may": 5,
+        "jun": 6,
+        "june": 6,
+        "jul": 7,
+        "july": 7,
+        "aug": 8,
+        "august": 8,
+        "sep": 9,
+        "sept": 9,
+        "september": 9,
+        "oct": 10,
+        "october": 10,
+        "nov": 11,
+        "november": 11,
+        "dec": 12,
+        "december": 12,
+    }
+    month_positions = [
+        (match.start(), month)
+        for name, month in month_lookup.items()
+        if (match := re.search(rf"\b{name}\b", cleaned))
+    ]
+    if not month_positions:
+        return date(year, 6, 15)
+    index, month = min(month_positions, key=lambda item: item[0])
+    nearby = cleaned[max(0, index - 18) : index + 24]
+    if "late" in nearby:
+        day = 24
+    elif "early" in nearby:
+        day = 5
+    elif "mid" in nearby:
+        day = 15
+    else:
+        day = 15
+    return date(year, month, day)
+
+
+def _iata_or_text(value: str) -> str:
+    match = re.search(r"\b[A-Z]{3}\b", value.upper())
+    if match:
+        return match.group(0)
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "-", value.strip()).strip("-").upper()
+    return cleaned or "DEST"
 
 
 def _refresh_flight_recommendations(

--- a/trippy/services/live_validation.py
+++ b/trippy/services/live_validation.py
@@ -67,18 +67,22 @@ class LiveValidationService:
         validation = getattr(option, "validation", SourceValidation())
         validation.source_name = source_name
         validation.source_type = _source_type(option)
-        validation.evidence_url = url
+        validation.evidence_url = validation.evidence_url or url
         validation.missing_fields = _missing_fields(option, state, validation)
         validation.notes = _dedupe_notes([*_base_notes(option, state), *validation.notes])
         if not attempt_network:
-            if validation.verification_status != VerificationStatus.LIVE_VERIFIED:
+            if validation.verification_status == VerificationStatus.LIVE_VERIFIED:
+                validation.freshness_status = FreshnessStatus.CURRENT
+                option.row_status = ShortlistRowStatus.VERIFIED_LIVE
+                option.live_data_status = LiveDataStatus.LIVE_VERIFIED
+            else:
                 validation.verification_status = VerificationStatus.MANUAL_REQUIRED
-            validation.freshness_status = FreshnessStatus.UNKNOWN
-            validation.availability_status = AvailabilityStatus.UNKNOWN
-            validation.price_status = _price_status(option)
-            validation.confidence = min(validation.confidence, 0.55)
-            option.row_status = ShortlistRowStatus.RESEARCHED
-            option.live_data_status = LiveDataStatus.HANDOFF_REQUIRED
+                validation.freshness_status = FreshnessStatus.UNKNOWN
+                validation.availability_status = AvailabilityStatus.UNKNOWN
+                validation.price_status = _price_status(option)
+                validation.confidence = min(validation.confidence, 0.55)
+                option.row_status = ShortlistRowStatus.RESEARCHED
+                option.live_data_status = LiveDataStatus.HANDOFF_REQUIRED
             option.validation = validation
             return
 

--- a/trippy/services/lodging_shortlist.py
+++ b/trippy/services/lodging_shortlist.py
@@ -11,9 +11,10 @@ from trippy.models.shortlists import (
     RecommendationGrade,
     ResearchShortlistState,
     ShortlistCategory,
+    ShortlistRowStatus,
 )
 from trippy.models.sources import TravelSourceCategory
-from trippy.models.trip_planning import TripIntake
+from trippy.models.trip_planning import TripIntake, TripPlanOption
 from trippy.services.destination_profiles import profile_for_intake
 from trippy.services.live_validation import LiveValidationService
 from trippy.services.shortlist_store import (
@@ -63,6 +64,9 @@ class LodgingShortlistService:
         )
         plan = source_plan(category)
         options = _options_from_profile(profile, ctx.intake, ctx.option.regions)
+        requires_three_beds = (
+            ctx.intake.party.total_travelers >= 5 or ctx.intake.party.children >= 2
+        )
         recommended = next(
             (
                 option.option_id
@@ -79,22 +83,139 @@ class LodgingShortlistService:
             lodging_options=options,
             recommended_option_id=recommended,
             recommendation_summary=(
-                "Prioritize lodging that proves 3+ beds, parking/access clarity, and safe practical "
+                "Prioritize lodging that proves king-bed comfort, parking/access clarity, and safe practical "
+                "location before optimizing price."
+                if not requires_three_beds
+                else "Prioritize lodging that proves 3+ beds, parking/access clarity, and safe practical "
                 "location before optimizing price. Queen-bed compromises remain conditional."
             ),
             warnings=[
-                "Exact room/rental availability and bed layout must be verified live before recommendation handoff.",
-                "Two-room hotel solutions can work, but only if total comfort beats a private rental.",
+                (
+                    "Exact room availability, king-bed signal, cancellation, and location/access must be verified live."
+                    if not requires_three_beds
+                    else "Exact room/rental availability and bed layout must be verified live before recommendation handoff."
+                ),
+                (
+                    "For a couple trip, avoid overpaying for unnecessary space unless the location or experience is exceptional."
+                    if not requires_three_beds
+                    else "Two-room hotel solutions can work, but only if total comfort beats a private rental."
+                ),
             ],
             next_actions=[
-                "Open the recommended option source link and validate 5-person occupancy.",
-                "Reject any option that cannot explicitly prove 3+ beds.",
+                (
+                    f"Open the recommended option source link and validate occupancy for {ctx.intake.party.total_travelers} traveler(s)."
+                    if not requires_three_beds
+                    else "Open the recommended option source link and validate 5-person occupancy."
+                ),
+                (
+                    "Confirm king-bed or clearly worthwhile queen-bed tradeoff."
+                    if not requires_three_beds
+                    else "Reject any option that cannot explicitly prove 3+ beds."
+                ),
                 "Cross-check location and review/safety signals on Tripadvisor or Booking.com.",
             ],
+            artifacts={
+                "lodging_structure": _lodging_structure_guidance(ctx.option, ctx.intake),
+            },
         )
         LiveValidationService().validate_state(state, attempt_network=validate_live)
         if deep_research:
             SourceResearchService().research_state(state, adapter_mode=adapter_mode)
+        return self._store.save(state)
+
+    def select_lodging(self, trip_id: str, option_id: str) -> ResearchShortlistState:
+        """Promote a lodging option as the current human-preferred planning choice."""
+        ctx = ShortlistContext(
+            trip_id,
+            intake_service=self._intakes,
+            planner_service=self._planner,
+        )
+        state = self._store.load(trip_id, ShortlistCategory.LODGING)
+        if state is None:
+            state = self.build(trip_id, validate_live=False)
+        option_ids = {option.option_id for option in state.lodging_options}
+        if option_id not in option_ids:
+            raise ValueError(f"Lodging option {option_id!r} was not found for trip {trip_id!r}")
+        state.recommended_option_id = option_id
+        for option in state.lodging_options:
+            if option.option_id == option_id:
+                option.row_status = ShortlistRowStatus.APPROVED
+            elif option.row_status == ShortlistRowStatus.APPROVED:
+                option.row_status = ShortlistRowStatus.RESEARCHED
+        structure = state.artifacts.setdefault(
+            "lodging_structure",
+            _lodging_structure_guidance(ctx.option, ctx.intake),
+        )
+        if isinstance(structure, dict):
+            structure["selected_lodging_option_id"] = option_id
+            structure["data_status"] = (
+                "manual_lodging_selection"
+                if structure.get("data_status") != "manual_override"
+                else "manual_override"
+            )
+        state.next_actions.insert(
+            0,
+            "Selected lodging now drives stay-structure review, workspace timeline, and map planning.",
+        )
+        return self._store.save(state)
+
+    def update_stay_structure(
+        self,
+        trip_id: str,
+        *,
+        strategy: str,
+        night_plan: list[dict[str, object]],
+        notes: str = "",
+    ) -> ResearchShortlistState:
+        """Persist a manual one-base or split-stay lodging structure override."""
+        ctx = ShortlistContext(
+            trip_id,
+            intake_service=self._intakes,
+            planner_service=self._planner,
+        )
+        state = self._store.load(trip_id, ShortlistCategory.LODGING)
+        if state is None:
+            state = self.build(trip_id, validate_live=False)
+        normalized = _normalize_night_plan(night_plan)
+        if not normalized:
+            raise ValueError("Stay structure requires at least one region/night row.")
+        strategy_value = strategy if strategy in {"single_stay", "split_stay"} else "split_stay"
+        expected_nights = (
+            ctx.intake.duration_days or ctx.intake.duration_min_days or ctx.option.duration_days
+        )
+        total_nights = sum(int(str(item["nights"])) for item in normalized)
+        reasoning = [
+            "Manual stay structure saved from the UI.",
+            "Use this to test one-base vs split-stay tradeoffs before booking lodging.",
+        ]
+        if total_nights != expected_nights:
+            reasoning.append(
+                f"Manual stay nights total {total_nights}; current trip duration signal is {expected_nights}."
+            )
+        if notes:
+            reasoning.append(notes)
+        selected_lodging = state.recommended_option_id
+        state.artifacts["lodging_structure"] = {
+            "strategy": strategy_value,
+            "confidence": "manual",
+            "data_status": "manual_override",
+            "summary": _manual_structure_summary(strategy_value, normalized, total_nights),
+            "reasoning": reasoning,
+            "night_plan": normalized,
+            "selected_plan_option_id": ctx.option.option_id,
+            "selected_plan_title": ctx.option.title,
+            "lodging_strategy": ctx.option.lodging_strategy,
+            "selected_lodging_option_id": selected_lodging,
+            "manual_notes": notes,
+            "tradeoffs": [
+                ctx.option.island_region_movement_friction,
+                "Manual split plans still need exact check-in/out, luggage, parking, and transfer validation.",
+            ],
+        }
+        state.next_actions.insert(
+            0,
+            "Review the manual stay structure against flights, check-in/out times, driving burden, and activities.",
+        )
         return self._store.save(state)
 
     def add_candidate(
@@ -128,6 +249,10 @@ class LodgingShortlistService:
         )
         state.lodging_options.append(option)
         state.lodging_options.sort(key=lambda item: item.rank)
+        state.artifacts.setdefault(
+            "lodging_structure",
+            _lodging_structure_guidance(ctx.option, ctx.intake),
+        )
         state.recommendation_summary = (
             state.recommendation_summary
             + " User-supplied candidates are scored in the same lodging model and should be validated against sourced options."
@@ -169,9 +294,10 @@ def _options_from_profile(
     options: list[LodgingOption] = []
     for idx, target in enumerate(targets[:5], start=1):
         source = "Booking.com" if target.get("lodging_type") != "private rental" else "Airbnb"
+        query = _query_for_party(str(target["query"]), requires_three_beds)
         validation = {
-            "Tripadvisor": source_search_url("Tripadvisor", str(target["query"])),
-            "Booking.com": source_search_url("Booking.com", str(target["query"])),
+            "Tripadvisor": source_search_url("Tripadvisor", query),
+            "Booking.com": source_search_url("Booking.com", query),
         }
         is_private = target.get("lodging_type") == "private rental"
         bed_fit_known = True if is_private else None
@@ -211,7 +337,11 @@ def _options_from_profile(
                 room_layout="whole-home/unit target"
                 if is_private
                 else "hotel room or two-room setup; live-verify",
-                bed_layout="target 3+ beds; exact layout must be live-verified",
+                bed_layout=(
+                    "target 3+ beds; exact layout must be live-verified"
+                    if requires_three_beds
+                    else "king bed strongly preferred; queen compromise needs a clear upside"
+                ),
                 adult_child_fit=(
                     f"Validate {party.adults} adult(s), {party.children} child(ren), "
                     f"{traveler_count} traveler(s) total."
@@ -236,7 +366,7 @@ def _options_from_profile(
                 walkability="validate restaurants/groceries and whether driving is required every meal",
                 cancellation_notes="live-verify free cancellation/refund deadline before handoff",
                 price_band="live verify; compare total stay cost including taxes/fees",
-                deep_link=source_search_url(source, str(target["query"])),
+                deep_link=source_search_url(source, query),
                 validation_links=validation,
                 friction_score=score,
                 family_comfort_score=comfort,
@@ -257,6 +387,119 @@ def _options_from_profile(
             )
         )
     return options
+
+
+def _query_for_party(query: str, requires_three_beds: bool) -> str:
+    if requires_three_beds:
+        return query
+    replacements = {
+        "family room 3 beds": "king room",
+        "family room": "king room",
+        "3 bedroom vacation rental family": "comfortable stay king bed",
+        "family parking": "parking",
+        "family": "couple",
+        "3 beds": "king bed",
+    }
+    adjusted = query
+    for old, new in replacements.items():
+        adjusted = adjusted.replace(old, new)
+    return adjusted
+
+
+def _lodging_structure_guidance(
+    option: TripPlanOption,
+    intake: TripIntake,
+) -> dict[str, object]:
+    night_plan = [
+        {"region": region, "nights": nights}
+        for region, nights in option.nights_by_region.items()
+        if nights
+    ]
+    stay_count = len(night_plan) or len(option.regions) or 1
+    duration = intake.duration_display()
+    traveler_summary = intake.party.summary()
+    if stay_count <= 1:
+        strategy = "single_stay"
+        summary = (
+            f"One stay is the cleaner default for {duration}: it protects downtime, unpacking ease, "
+            "and first/last-day simplicity unless exact flight or lodging evidence proves a split is worth it."
+        )
+        reasoning = [
+            "The selected plan has one primary region/base.",
+            "One lodging search reduces bed-layout, parking, cancellation, and check-in risk.",
+            f"Still validate that the property comfortably fits {traveler_summary}.",
+        ]
+    else:
+        strategy = "split_stay"
+        summary = (
+            f"Split stays are expected for this selected shape: {stay_count} base(s) reduce backtracking "
+            "but add check-in, luggage, transfer, and bed-validation risk."
+        )
+        reasoning = [
+            "The selected plan covers multiple regions where one base may create wasted driving.",
+            "Only keep the split if each stay has clear comfort upside and enough nights to justify repacking.",
+            "Avoid same-day tight transfers around inter-island flights, ferries, tours, or early returns.",
+        ]
+    return {
+        "strategy": strategy,
+        "confidence": "plan-based",
+        "data_status": "inferred_from_selected_plan",
+        "summary": summary,
+        "reasoning": reasoning,
+        "night_plan": night_plan
+        or [{"region": region, "nights": "TBD"} for region in option.regions],
+        "selected_plan_option_id": option.option_id,
+        "selected_plan_title": option.title,
+        "lodging_strategy": option.lodging_strategy,
+        "tradeoffs": [
+            option.island_region_movement_friction,
+            "Exact property availability, bed layout, cancellation, and access remain manual/live-verification items.",
+        ],
+    }
+
+
+def _normalize_night_plan(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    normalized: list[dict[str, object]] = []
+    for index, row in enumerate(rows, start=1):
+        region = str(row.get("region") or row.get("location") or "").strip()
+        if not region:
+            raise ValueError(f"Stay row {index} is missing a region/location.")
+        nights_raw = row.get("nights")
+        try:
+            nights = int(str(nights_raw))
+        except (TypeError, ValueError):
+            raise ValueError(f"Stay row {index} has invalid nights {nights_raw!r}.") from None
+        if nights < 1:
+            raise ValueError(f"Stay row {index} must have at least one night.")
+        lodging_option_id = str(row.get("lodging_option_id") or "").strip()
+        notes = str(row.get("notes") or "").strip()
+        normalized.append(
+            {
+                "region": region,
+                "nights": nights,
+                "lodging_option_id": lodging_option_id,
+                "notes": notes,
+            }
+        )
+    return normalized
+
+
+def _manual_structure_summary(
+    strategy: str,
+    night_plan: list[dict[str, object]],
+    total_nights: int,
+) -> str:
+    if strategy == "single_stay" or len(night_plan) == 1:
+        region = str(night_plan[0]["region"])
+        return (
+            f"Manual one-stay plan: {total_nights} night(s) based in {region}. "
+            "This favors unpacking ease and fewer check-in transitions."
+        )
+    labels = ", ".join(f"{item['region']} ({item['nights']}n)" for item in night_plan)
+    return (
+        f"Manual split-stay plan across {len(night_plan)} base(s): {labels}. "
+        "This can reduce backtracking, but adds luggage, parking, and check-in friction."
+    )
 
 
 def _user_candidate_option(

--- a/trippy/services/lodging_shortlist.py
+++ b/trippy/services/lodging_shortlist.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from urllib.parse import urlparse
+import re
+from datetime import timedelta
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from trippy.models.shortlists import (
     LiveDataStatus,
@@ -17,6 +19,7 @@ from trippy.models.sources import TravelSourceCategory
 from trippy.models.trip_planning import TripIntake, TripPlanOption
 from trippy.services.destination_profiles import profile_for_intake
 from trippy.services.live_validation import LiveValidationService
+from trippy.services.planning_advisor import PlanningAdvisorService
 from trippy.services.shortlist_store import (
     ShortlistContext,
     ShortlistStore,
@@ -118,6 +121,24 @@ class LodgingShortlistService:
                 "lodging_structure": _lodging_structure_guidance(ctx.option, ctx.intake),
             },
         )
+        advisor = PlanningAdvisorService(enabled=False).advise_lodging_structure(
+            ctx.intake,
+            ctx.option,
+            state,
+        )
+        state.artifacts["planning_advisor"] = advisor.model_dump(mode="json")
+        structure = state.artifacts.get("lodging_structure")
+        if isinstance(structure, dict):
+            structure["options"] = _stay_structure_options(ctx.option, ctx.intake)
+            structure["recommended_structure_id"] = (
+                structure["options"][0]["structure_id"] if structure["options"] else ""
+            )
+            structure["advisor_status"] = advisor.status
+            structure["advisor_summary"] = advisor.summary
+            if advisor.stay_strategy in {"single_stay", "split_stay", "unclear"}:
+                structure["advisor_stay_strategy"] = advisor.stay_strategy
+            if advisor.night_plan:
+                structure["advisor_night_plan"] = advisor.night_plan
         LiveValidationService().validate_state(state, attempt_network=validate_live)
         if deep_research:
             SourceResearchService().research_state(state, adapter_mode=adapter_mode)
@@ -195,6 +216,10 @@ class LodgingShortlistService:
         if notes:
             reasoning.append(notes)
         selected_lodging = state.recommended_option_id
+        previous_structure = state.artifacts.get("lodging_structure", {})
+        existing_options = (
+            previous_structure.get("options", []) if isinstance(previous_structure, dict) else []
+        )
         state.artifacts["lodging_structure"] = {
             "strategy": strategy_value,
             "confidence": "manual",
@@ -207,14 +232,62 @@ class LodgingShortlistService:
             "lodging_strategy": ctx.option.lodging_strategy,
             "selected_lodging_option_id": selected_lodging,
             "manual_notes": notes,
+            "options": existing_options,
             "tradeoffs": [
                 ctx.option.island_region_movement_friction,
                 "Manual split plans still need exact check-in/out, luggage, parking, and transfer validation.",
             ],
         }
+        _ensure_options_for_stay_regions(state, ctx.intake, normalized)
         state.next_actions.insert(
             0,
             "Review the manual stay structure against flights, check-in/out times, driving burden, and activities.",
+        )
+        return self._store.save(state)
+
+    def suggest_stay_structures(
+        self,
+        trip_id: str,
+        *,
+        use_llm: bool = True,
+    ) -> ResearchShortlistState:
+        """Generate editable one-base and split-stay options for the selected plan."""
+        ctx = ShortlistContext(
+            trip_id,
+            intake_service=self._intakes,
+            planner_service=self._planner,
+        )
+        state = self._store.load(trip_id, ShortlistCategory.LODGING)
+        if state is None:
+            state = self.build(trip_id, validate_live=False)
+
+        structure = state.artifacts.setdefault(
+            "lodging_structure",
+            _lodging_structure_guidance(ctx.option, ctx.intake),
+        )
+        if not isinstance(structure, dict):
+            structure = _lodging_structure_guidance(ctx.option, ctx.intake)
+            state.artifacts["lodging_structure"] = structure
+
+        options = _stay_structure_options(ctx.option, ctx.intake)
+        advisor = PlanningAdvisorService(enabled=use_llm).advise_lodging_structure(
+            ctx.intake,
+            ctx.option,
+            state,
+        )
+        advisor_option = _advisor_stay_structure_option(advisor, ctx.option, ctx.intake)
+        if advisor_option:
+            options = _dedupe_structure_options([advisor_option, *options])
+
+        structure["options"] = options[:3]
+        structure["recommended_structure_id"] = options[0]["structure_id"] if options else ""
+        structure["advisor_status"] = advisor.status
+        structure["advisor_summary"] = advisor.summary
+        structure["advisor_recommendation"] = advisor.recommendation
+        structure["advisor_confidence"] = advisor.confidence
+        state.next_actions.insert(
+            0,
+            "Pick a stay-structure option or edit the night allocation before choosing exact lodging.",
         )
         return self._store.save(state)
 
@@ -297,8 +370,9 @@ def _options_from_profile(
         query = _query_for_party(str(target["query"]), requires_three_beds)
         validation = {
             "Tripadvisor": source_search_url("Tripadvisor", query),
-            "Booking.com": source_search_url("Booking.com", query),
+            "Booking.com": _lodging_source_url("Booking.com", query, intake),
         }
+        deep_link = _lodging_source_url(source, query, intake)
         is_private = target.get("lodging_type") == "private rental"
         bed_fit_known = True if is_private else None
         king_known = None
@@ -359,14 +433,14 @@ def _options_from_profile(
                 comfort_fit=_comfort_fit(fit_category, party.summary()),
                 fit_category=fit_category,
                 bed_layout_confidence=0.62 if is_private else 0.28,
-                current_availability_signal="not live-checked yet",
-                current_price_signal="estimated/search handoff only",
+                current_availability_signal="live availability required",
+                current_price_signal="live price required",
                 parking_practicality=parking,
                 driving_practicality="good only if roads, driveway, and loading access are clear",
                 walkability="validate restaurants/groceries and whether driving is required every meal",
                 cancellation_notes="live-verify free cancellation/refund deadline before handoff",
                 price_band="live verify; compare total stay cost including taxes/fees",
-                deep_link=source_search_url(source, query),
+                deep_link=deep_link,
                 validation_links=validation,
                 friction_score=score,
                 family_comfort_score=comfort,
@@ -404,6 +478,73 @@ def _query_for_party(query: str, requires_three_beds: bool) -> str:
     for old, new in replacements.items():
         adjusted = adjusted.replace(old, new)
     return adjusted
+
+
+def _lodging_source_url(source: str, query: str, intake: TripIntake) -> str:
+    if source == "Booking.com":
+        return _booking_url(query, intake)
+    return source_search_url(source, query)
+
+
+def _normalize_lodging_link(link: str, intake: TripIntake) -> str:
+    parsed = urlparse(link)
+    if "booking.com" not in parsed.netloc.lower():
+        return link
+    return _booking_url("", intake, base_url=link)
+
+
+def _booking_url(query: str, intake: TripIntake, *, base_url: str = "") -> str:
+    parsed = urlparse(base_url or "https://www.booking.com/searchresults.html")
+    existing = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    params: dict[str, object] = {
+        **existing,
+        "group_adults": max(1, intake.party.adults or intake.party.total_travelers or 1),
+        "group_children": max(0, intake.party.children or 0),
+        "no_rooms": 1,
+        "selected_currency": "CAD",
+    }
+    if query and not base_url:
+        params.update({"ss": query, "sb": 1, "src": "searchresults"})
+    checkin, checkout = _booking_dates(intake)
+    if checkin and checkout:
+        params["checkin"] = checkin
+        params["checkout"] = checkout
+    ages = _booking_child_ages(intake)
+    if ages:
+        params["age"] = ages
+    return urlunparse(
+        (
+            parsed.scheme or "https",
+            parsed.netloc or "www.booking.com",
+            parsed.path or "/searchresults.html",
+            parsed.params,
+            urlencode(params, doseq=True),
+            parsed.fragment,
+        )
+    )
+
+
+def _booking_dates(intake: TripIntake) -> tuple[str, str]:
+    start = intake.travel_window.start_date
+    if not start:
+        return "", ""
+    end = intake.travel_window.end_date
+    if end is None:
+        nights = max(1, (intake.duration_days or intake.duration_min_days or 2) - 1)
+        end = start + timedelta(days=nights)
+    if end <= start:
+        end = start + timedelta(days=1)
+    return start.isoformat(), end.isoformat()
+
+
+def _booking_child_ages(intake: TripIntake) -> list[int]:
+    child_count = max(0, intake.party.children or 0)
+    if child_count == 0:
+        return []
+    ages = list(intake.party.child_ages or [])[:child_count]
+    while len(ages) < child_count:
+        ages.append(10)
+    return [max(0, min(17, int(age))) for age in ages]
 
 
 def _lodging_structure_guidance(
@@ -458,6 +599,323 @@ def _lodging_structure_guidance(
     }
 
 
+def _stay_structure_options(
+    option: TripPlanOption,
+    intake: TripIntake,
+) -> list[dict[str, object]]:
+    total_nights = _structure_total_nights(option, intake)
+    selected_regions = [region for region in option.regions if region]
+    existing = [
+        {"region": region, "nights": nights}
+        for region, nights in option.nights_by_region.items()
+        if nights
+    ]
+    if len(existing) > 1:
+        return _multi_region_structure_options(option, total_nights, existing)
+    primary = (
+        existing[0]["region"]
+        if existing
+        else selected_regions[0]
+        if selected_regions
+        else "Main base"
+    )
+    return _single_region_structure_options(option, intake, str(primary), total_nights)
+
+
+def _single_region_structure_options(
+    option: TripPlanOption,
+    intake: TripIntake,
+    primary_region: str,
+    total_nights: int,
+) -> list[dict[str, object]]:
+    anchors = _same_region_stay_anchors(primary_region, intake)
+    split_a = _two_part_split(total_nights, short_second=True)
+    split_b = _two_part_split(total_nights, short_second=False)
+    return [
+        {
+            "structure_id": "stay-one-base",
+            "title": f"One base: {primary_region}",
+            "strategy": "single_stay",
+            "recommendation_label": "smoothest",
+            "confidence": "plan-based",
+            "summary": "Best default if one location keeps drives reasonable and protects unpacking ease.",
+            "night_plan": [
+                {
+                    "region": primary_region,
+                    "nights": total_nights,
+                    "lodging_option_id": "",
+                    "notes": "single base; lowest check-in/luggage friction",
+                }
+            ],
+            "reasoning": [
+                "One check-in and one bed-layout validation keeps the trip simpler.",
+                "Use this if daily drives from the base are acceptable and food access is strong.",
+            ],
+            "tradeoffs": [
+                option.island_region_movement_friction,
+                "May create backtracking if activities cluster far from the base.",
+            ],
+            "map_regions": [primary_region],
+            "thumbnail_variant": 1,
+        },
+        {
+            "structure_id": "stay-central-plus-scenic",
+            "title": f"{anchors[0]} + {anchors[1]}",
+            "strategy": "split_stay",
+            "recommendation_label": "balanced split",
+            "confidence": "planner-suggested",
+            "summary": "Tests whether a short second base cuts backtracking enough to justify repacking.",
+            "night_plan": [
+                {
+                    "region": anchors[0],
+                    "nights": split_a[0],
+                    "lodging_option_id": "",
+                    "notes": "arrival/food/airport-friendly base",
+                },
+                {
+                    "region": anchors[1],
+                    "nights": split_a[1],
+                    "lodging_option_id": "",
+                    "notes": "activity-side base; verify check-in and parking",
+                },
+            ],
+            "reasoning": [
+                "Keeps most nights in the practical base while giving the far side of the destination its own window.",
+                "Only worth it if the second location has a lodging win and activities nearby.",
+            ],
+            "tradeoffs": [
+                "Adds one checkout/check-in and luggage move.",
+                "Can reduce late-day driving after remote activities.",
+            ],
+            "map_regions": anchors[:2],
+            "thumbnail_variant": 2,
+        },
+        {
+            "structure_id": "stay-loop-split",
+            "title": f"{anchors[2]} + {anchors[0]}",
+            "strategy": "split_stay",
+            "recommendation_label": "route-first",
+            "confidence": "planner-suggested",
+            "summary": "Starts or ends near a different activity cluster so the route feels less repetitive.",
+            "night_plan": [
+                {
+                    "region": anchors[2],
+                    "nights": split_b[0],
+                    "lodging_option_id": "",
+                    "notes": "scenic/activity cluster first; validate road and parking comfort",
+                },
+                {
+                    "region": anchors[0],
+                    "nights": split_b[1],
+                    "lodging_option_id": "",
+                    "notes": "finish near food/airport logistics",
+                },
+            ],
+            "reasoning": [
+                "Useful if the best activities naturally form a loop instead of out-and-back drives.",
+                "Return to the practical base before departure if flight timing or airport access matters.",
+            ],
+            "tradeoffs": [
+                "More sequencing-dependent than the balanced split.",
+                "Reject if exact lodging options make the second base weaker or less comfortable.",
+            ],
+            "map_regions": [anchors[2], anchors[0]],
+            "thumbnail_variant": 3,
+        },
+    ]
+
+
+def _multi_region_structure_options(
+    option: TripPlanOption,
+    total_nights: int,
+    existing: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    primary = str(existing[0]["region"])
+    secondary = str(existing[1]["region"]) if len(existing) > 1 else primary
+    consolidated_nights = max(1, total_nights - 2)
+    return [
+        {
+            "structure_id": "stay-plan-default",
+            "title": "Use selected trip shape",
+            "strategy": "split_stay",
+            "recommendation_label": "shape-based",
+            "confidence": "plan-based",
+            "summary": "Matches the chosen plan and avoids excessive backtracking between regions.",
+            "night_plan": [
+                {
+                    "region": str(item["region"]),
+                    "nights": int(str(item["nights"])),
+                    "lodging_option_id": "",
+                    "notes": "from selected plan shape",
+                }
+                for item in existing
+            ],
+            "reasoning": [
+                "The selected option already spans multiple regions.",
+                "Keep the split only if each base has strong lodging fit and protected transfer timing.",
+            ],
+            "tradeoffs": [option.island_region_movement_friction],
+            "map_regions": [str(item["region"]) for item in existing],
+            "thumbnail_variant": min(len(existing), 3),
+        },
+        {
+            "structure_id": "stay-reduced-moves",
+            "title": f"Reduce moves: {primary} + {secondary}",
+            "strategy": "split_stay",
+            "recommendation_label": "lower friction",
+            "confidence": "planner-suggested",
+            "summary": "Consolidates the trip into fewer bases if comfort beats complete coverage.",
+            "night_plan": [
+                {
+                    "region": primary,
+                    "nights": consolidated_nights,
+                    "lodging_option_id": "",
+                    "notes": "primary comfort base",
+                },
+                {
+                    "region": secondary,
+                    "nights": total_nights - consolidated_nights,
+                    "lodging_option_id": "",
+                    "notes": "secondary base only if transfer timing is clean",
+                },
+            ],
+            "reasoning": [
+                "Fewer lodging searches means fewer bed, parking, and check-in risks.",
+                "Use if the broader route starts to feel overcompressed.",
+            ],
+            "tradeoffs": ["May sacrifice coverage or create longer day trips."],
+            "map_regions": [primary, secondary],
+            "thumbnail_variant": 2,
+        },
+        {
+            "structure_id": "stay-one-base-test",
+            "title": f"Stress-test one base: {primary}",
+            "strategy": "single_stay",
+            "recommendation_label": "comfort test",
+            "confidence": "planner-suggested",
+            "summary": "Useful as a comparison baseline: only choose if drives/transfers stay comfortable.",
+            "night_plan": [
+                {
+                    "region": primary,
+                    "nights": total_nights,
+                    "lodging_option_id": "",
+                    "notes": "one-base stress test against selected multi-region shape",
+                }
+            ],
+            "reasoning": [
+                "Shows what the trip would feel like with maximum unpacking simplicity.",
+                "Reject if it creates wasted travel days or too much backtracking.",
+            ],
+            "tradeoffs": ["Likely weaker for genuinely multi-region trips."],
+            "map_regions": [primary],
+            "thumbnail_variant": 1,
+        },
+    ]
+
+
+def _advisor_stay_structure_option(
+    advisor: object,
+    option: TripPlanOption,
+    intake: TripIntake,
+) -> dict[str, object] | None:
+    night_plan = getattr(advisor, "night_plan", None) or []
+    normalized = _normalize_advisor_night_plan(night_plan)
+    if not normalized:
+        return None
+    strategy = getattr(advisor, "stay_strategy", "") or (
+        "split_stay" if len(normalized) > 1 else "single_stay"
+    )
+    return {
+        "structure_id": "stay-advisor",
+        "title": "Advisor pick",
+        "strategy": strategy if strategy in {"single_stay", "split_stay"} else "split_stay",
+        "recommendation_label": "agent call",
+        "confidence": f"advisor {getattr(advisor, 'confidence', 0.35):.0%}",
+        "summary": getattr(advisor, "recommendation", "")
+        or getattr(advisor, "summary", "")
+        or "Advisor-generated stay structure.",
+        "night_plan": normalized,
+        "reasoning": getattr(advisor, "rationale", []) or [option.lodging_strategy],
+        "tradeoffs": getattr(advisor, "warnings", []) or [option.island_region_movement_friction],
+        "map_regions": [str(item["region"]) for item in normalized],
+        "thumbnail_variant": min(max(len(normalized), 1), 3),
+        "advisor_status": getattr(advisor, "status", ""),
+        "advisor_prompt_version": getattr(advisor, "prompt_version", ""),
+        "duration_context": intake.duration_display(),
+    }
+
+
+def _normalize_advisor_night_plan(rows: list[object]) -> list[dict[str, object]]:
+    normalized: list[dict[str, object]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        region = str(row.get("region") or row.get("location") or "").strip()
+        if not region:
+            continue
+        try:
+            nights = int(str(row.get("nights") or 0))
+        except ValueError:
+            continue
+        if nights < 1:
+            continue
+        normalized.append(
+            {
+                "region": region,
+                "nights": nights,
+                "lodging_option_id": str(row.get("lodging_option_id") or "").strip(),
+                "notes": str(row.get("reason") or row.get("notes") or "").strip(),
+            }
+        )
+    return normalized
+
+
+def _dedupe_structure_options(options: list[dict[str, object]]) -> list[dict[str, object]]:
+    seen: set[tuple[tuple[str, int], ...]] = set()
+    deduped: list[dict[str, object]] = []
+    for option in options:
+        raw_night_plan = option.get("night_plan", [])
+        night_plan = raw_night_plan if isinstance(raw_night_plan, list) else []
+        signature = tuple(
+            (str(item.get("region") or ""), int(item.get("nights") or 0))
+            for item in night_plan
+            if isinstance(item, dict)
+        )
+        if signature in seen:
+            continue
+        seen.add(signature)
+        deduped.append(option)
+    return deduped
+
+
+def _structure_total_nights(option: TripPlanOption, intake: TripIntake) -> int:
+    total = sum(int(nights) for nights in option.nights_by_region.values() if nights)
+    if total:
+        return total
+    return intake.duration_days or intake.duration_min_days or option.duration_days or 1
+
+
+def _same_region_stay_anchors(primary_region: str, intake: TripIntake) -> list[str]:
+    text = " ".join([primary_region, *intake.destination_seeds, intake.trip_name]).lower()
+    if "azores" in text or "sao miguel" in text or "são miguel" in text:
+        return ["Ponta Delgada / south coast", "Furnas / east side", "Ribeira Grande / north coast"]
+    destination = primary_region or ", ".join(intake.destination_seeds) or "destination"
+    return [
+        f"{destination} central base",
+        f"{destination} scenic/activity side",
+        f"{destination} arrival/departure-friendly base",
+    ]
+
+
+def _two_part_split(total_nights: int, *, short_second: bool) -> tuple[int, int]:
+    if total_nights <= 2:
+        return (1, max(1, total_nights - 1))
+    second = max(2, round(total_nights * 0.35)) if short_second else max(2, total_nights // 2)
+    second = min(second, total_nights - 1)
+    first = max(1, total_nights - second)
+    return (first, second)
+
+
 def _normalize_night_plan(rows: list[dict[str, object]]) -> list[dict[str, object]]:
     normalized: list[dict[str, object]] = []
     for index, row in enumerate(rows, start=1):
@@ -482,6 +940,152 @@ def _normalize_night_plan(rows: list[dict[str, object]]) -> list[dict[str, objec
             }
         )
     return normalized
+
+
+def _ensure_options_for_stay_regions(
+    state: ResearchShortlistState,
+    intake: TripIntake,
+    night_plan: list[dict[str, object]],
+) -> None:
+    next_rank = max((option.rank for option in state.lodging_options), default=0) + 1
+    for stay in night_plan:
+        region = str(stay.get("region") or "").strip()
+        if not region:
+            continue
+        if any(_lodging_option_matches_region(option, region) for option in state.lodging_options):
+            continue
+        state.lodging_options.append(
+            _stay_region_search_option(
+                state,
+                intake,
+                region=region,
+                rank=next_rank,
+            )
+        )
+        next_rank += 1
+    state.lodging_options.sort(key=lambda option: option.rank)
+
+
+def _lodging_option_matches_region(option: LodgingOption, region: str) -> bool:
+    tokens = _region_match_tokens(region)
+    if not tokens:
+        return False
+    haystack = " ".join(
+        [
+            option.name,
+            option.location_area,
+            option.island_or_region,
+            option.lodging_type,
+        ]
+    ).lower()
+    return any(token in haystack for token in tokens)
+
+
+def _stay_region_search_option(
+    state: ResearchShortlistState,
+    intake: TripIntake,
+    *,
+    region: str,
+    rank: int,
+) -> LodgingOption:
+    party = intake.party
+    traveler_count = party.total_travelers
+    requires_three_beds = traveler_count >= 5 or party.children >= 2
+    query = _query_for_party(f"{region} lodging parking walkable restaurants", requires_three_beds)
+    if requires_three_beds:
+        query = f"{query} 3 beds family"
+    option_id = f"stay-region-lodging-{_slug(region)}"
+    existing_ids = {option.option_id for option in state.lodging_options}
+    if option_id in existing_ids:
+        option_id = f"{option_id}-{rank}"
+    flags = [
+        "location-specific search seed; exact property still required",
+        "bed layout not proven",
+        "parking/access practicality not proven",
+    ]
+    return LodgingOption(
+        option_id=option_id,
+        rank=rank,
+        source="Booking.com",
+        name=f"{region} lodging search",
+        location_area=region,
+        island_or_region=", ".join(intake.destination_seeds) or region,
+        lodging_type="location-specific lodging search",
+        room_layout="search target for this stay base; choose exact property next",
+        bed_layout=(
+            "target 3+ beds; exact layout must be live-verified"
+            if requires_three_beds
+            else "king bed strongly preferred; exact layout must be verified"
+        ),
+        adult_child_fit=(
+            f"Validate {party.adults} adult(s), {party.children} child(ren), "
+            f"{traveler_count} traveler(s) total for this base."
+        ),
+        traveler_roster_supported=None,
+        min_three_beds_satisfied=None,
+        king_bed_preference_satisfied=None,
+        family_of_five_fit=None,
+        separate_room_privacy_fit=None,
+        occupancy_fit=f"Search seed only; exact occupancy for {traveler_count} traveler(s) is not proven.",
+        comfort_fit="Potential fit only after exact property, beds, cancellation, and access are verified.",
+        fit_category=LodgingFitCategory.TECHNICAL,
+        bed_layout_confidence=0.15,
+        current_availability_signal="live availability required",
+        current_price_signal="live price required",
+        parking_practicality="not proven",
+        driving_practicality="validate road access, driveway/loading, and daily route fit",
+        walkability="validate food/grocery/activity access from this base",
+        cancellation_notes="not supplied",
+        price_band="live verify; compare total stay cost including taxes/fees",
+        deep_link=_lodging_source_url("Booking.com", query, intake),
+        validation_links={
+            "Booking.com": _lodging_source_url("Booking.com", query, intake),
+            "Tripadvisor": source_search_url("Tripadvisor", f"{region} hotels lodging"),
+            "Airbnb": source_search_url("Airbnb", f"{region} vacation rental parking"),
+        },
+        friction_score=58,
+        family_comfort_score=52,
+        recommendation_grade=RecommendationGrade.CONDITIONAL,
+        tradeoffs=[
+            "Created because the chosen stay split needs lodging options for this specific base.",
+            "Promote only after exact property fit is verified.",
+        ],
+        friction_flags=flags,
+        confidence_notes=[
+            "This is a location-specific search seed, not a verified lodging recommendation."
+        ],
+        live_data_status=LiveDataStatus.SEARCH_LINK_ONLY,
+    )
+
+
+def _region_match_tokens(region: str) -> set[str]:
+    stopwords = {
+        "the",
+        "and",
+        "base",
+        "side",
+        "coast",
+        "area",
+        "near",
+        "central",
+        "north",
+        "south",
+        "east",
+        "west",
+        "sao",
+        "são",
+        "miguel",
+    }
+    return {
+        token
+        for token in re.split(r"[^a-z0-9]+", region.lower())
+        if len(token) >= 4 and token not in stopwords
+    }
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "base"
 
 
 def _manual_structure_summary(
@@ -572,7 +1176,7 @@ def _user_candidate_option(
         fit_category=fit_category,
         bed_layout_confidence=0.68 if three_beds else 0.22,
         current_availability_signal="user-supplied; live source still required",
-        current_price_signal=price or "not supplied",
+        current_price_signal=price or "live price required",
         parking_practicality="parking mentioned; verify exact access"
         if parking_known
         else "not proven",
@@ -581,14 +1185,14 @@ def _user_candidate_option(
         cancellation_notes="mentioned in notes; verify deadline"
         if "cancel" in lower
         else "not supplied",
-        price_band=price or "not supplied",
-        deep_link=link,
+        price_band=price or "live price required",
+        deep_link=_normalize_lodging_link(link, intake),
         validation_links={
             "Tripadvisor": source_search_url(
                 "Tripadvisor", f"{display_name} {intake.travel_window.display()}"
             ),
-            "Booking.com": source_search_url(
-                "Booking.com", f"{display_name} {intake.travel_window.display()}"
+            "Booking.com": _lodging_source_url(
+                "Booking.com", f"{display_name} {intake.travel_window.display()}", intake
             ),
         },
         friction_score=friction,

--- a/trippy/services/planning_advisor.py
+++ b/trippy/services/planning_advisor.py
@@ -1,0 +1,454 @@
+"""Preference-rich LLM planning advisor for trip strategy decisions."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import anthropic
+
+from trippy import config
+from trippy.memory.store import MemoryStore
+from trippy.models.ideas import TripComparison, TripIdeaRequest
+from trippy.models.planning_advice import PlanningAdviceKind, PlanningAdviceResult
+from trippy.models.preferences import FamilyTravelPreferences
+from trippy.models.shortlists import ResearchShortlistState
+from trippy.models.trip_planning import TripIntake, TripPlanDraft, TripPlanOption
+from trippy.services.country_priors import CountryPriorService
+
+_PROMPT_VERSION = "planning-advisor-v1"
+_MAX_TOKENS = 1800
+
+
+class PlanningAdvisorService:
+    """Build strong planning prompts and optionally ask an LLM for strategy.
+
+    The service is deliberately advisory: it does not mutate trip state, memory, skills,
+    or shortlist rows. Callers decide how to persist or display its recommendation.
+    """
+
+    def __init__(
+        self,
+        *,
+        preferences: FamilyTravelPreferences | None = None,
+        memory: MemoryStore | None = None,
+        anthropic_client: Any | None = None,
+        enabled: bool | None = None,
+        model: str | None = None,
+    ) -> None:
+        self._prefs = preferences or FamilyTravelPreferences()
+        self._memory = memory or MemoryStore(config.MEMORY_PATH)
+        self._client = anthropic_client
+        self._enabled = config.PLANNING_LLM_ENABLED if enabled is None else enabled
+        self._model = model or config.PLANNING_LLM_MODEL
+        self._country_priors = CountryPriorService()
+
+    def advise_trip_ideas(
+        self,
+        request: TripIdeaRequest,
+        comparison: TripComparison,
+    ) -> PlanningAdviceResult:
+        prompt = self._prompt(
+            PlanningAdviceKind.TRIP_IDEAS,
+            user_goal=(
+                "Evaluate these generated trip concepts. Obey the requested duration, season, "
+                "party, goals, avoidances, flight burden, and family preferences before ranking."
+            ),
+            request_payload=request.model_dump(mode="json"),
+            comparison_payload=_compact_dump(comparison.model_dump(mode="json"), ["advisor"]),
+        )
+        return self._call_or_fallback(
+            PlanningAdviceKind.TRIP_IDEAS,
+            prompt,
+            fallback="Use the highest scoring duration-fit concept, then ask the user to confirm or reject it before detailed intake.",
+        )
+
+    def advise_trip_shape(
+        self,
+        intake: TripIntake,
+        draft: TripPlanDraft,
+    ) -> PlanningAdviceResult:
+        prompt = self._prompt(
+            PlanningAdviceKind.TRIP_SHAPE,
+            user_goal=(
+                "Choose the best trip shape and explain how the family should experience the destination. "
+                "For islands, decide whether to prioritize one base, two bases, or a broader sampler."
+            ),
+            intake=intake,
+            draft_payload=_compact_dump(draft.model_dump(mode="json"), ["advisor"]),
+        )
+        return self._call_or_fallback(
+            PlanningAdviceKind.TRIP_SHAPE,
+            prompt,
+            fallback="Use the recommended plan option until exact flights, lodging, and local logistics prove a better structure.",
+        )
+
+    def advise_lodging_structure(
+        self,
+        intake: TripIntake,
+        option: TripPlanOption,
+        state: ResearchShortlistState | None = None,
+    ) -> PlanningAdviceResult:
+        prompt = self._prompt(
+            PlanningAdviceKind.LODGING_STRUCTURE,
+            user_goal=(
+                "Decide whether this trip should use one stay or split stays. Recommend night allocation, "
+                "where each base should be, why the split is or is not worth it, and what evidence is still needed."
+            ),
+            intake=intake,
+            plan_option_payload=option.model_dump(mode="json"),
+            shortlist_payload=_shortlist_summary(state) if state is not None else {},
+        )
+        return self._call_or_fallback(
+            PlanningAdviceKind.LODGING_STRUCTURE,
+            prompt,
+            fallback="Keep the selected plan's stay structure, but only split stays when reduced backtracking clearly beats check-in, luggage, and bed-validation friction.",
+        )
+
+    def advise_island_experience(
+        self,
+        intake: TripIntake,
+        draft: TripPlanDraft,
+    ) -> PlanningAdviceResult:
+        prompt = self._prompt(
+            PlanningAdviceKind.ISLAND_EXPERIENCE,
+            user_goal=(
+                "Recommend how to experience this island or region set day-to-day: base areas, "
+                "activity clusters, chill days, food access, driving loops, weather backups, and what not to overpack."
+            ),
+            intake=intake,
+            draft_payload=_compact_dump(draft.model_dump(mode="json"), ["advisor"]),
+        )
+        return self._call_or_fallback(
+            PlanningAdviceKind.ISLAND_EXPERIENCE,
+            prompt,
+            fallback="Experience the island through a small number of strong geographic clusters with downtime and weather backups, not by chasing every sight.",
+        )
+
+    def advise_next_steps(
+        self,
+        intake: TripIntake | None = None,
+        draft: TripPlanDraft | None = None,
+        shortlists: list[ResearchShortlistState] | None = None,
+        user_question: str = "",
+    ) -> PlanningAdviceResult:
+        prompt = self._prompt(
+            PlanningAdviceKind.NEXT_STEPS,
+            user_goal=(
+                user_question
+                or "Determine the next best planning step. Prefer concrete actions that reduce uncertainty and move the trip toward booking readiness."
+            ),
+            intake=intake,
+            draft_payload=_compact_dump(draft.model_dump(mode="json"), ["advisor"])
+            if draft is not None
+            else {},
+            shortlist_payload=[_shortlist_summary(state) for state in shortlists or []],
+        )
+        return self._call_or_fallback(
+            PlanningAdviceKind.NEXT_STEPS,
+            prompt,
+            fallback="Resolve the earliest high-impact unknown: exact flights, lodging structure, lodging fit, car need, or dated activities.",
+        )
+
+    def _prompt(
+        self,
+        kind: PlanningAdviceKind,
+        *,
+        user_goal: str,
+        intake: TripIntake | None = None,
+        request_payload: dict[str, Any] | None = None,
+        comparison_payload: dict[str, Any] | None = None,
+        draft_payload: dict[str, Any] | None = None,
+        plan_option_payload: dict[str, Any] | None = None,
+        shortlist_payload: Any = None,
+    ) -> str:
+        destination_text = _destination_text(
+            intake, request_payload, comparison_payload, plan_option_payload
+        )
+        country_signals = [
+            signal.model_dump(mode="json")
+            for signal in self._country_priors.fit_for_text(destination_text)
+        ]
+        memory_context = self._memory.to_context_string()
+        parts = [
+            f"# Trippy Planning Advisor ({_PROMPT_VERSION})",
+            "You are Trippy's senior trip-strategy LLM for the Chapman family.",
+            "",
+            "## Non-Negotiables",
+            "- Optimize comfort, convenience, safety, family smoothness, and food quality above raw lowest price.",
+            "- Never invent prices, availability, flight numbers, bed layouts, drive times, or booking facts.",
+            "- If evidence is missing, say what must be verified and keep confidence appropriately limited.",
+            "- Treat memory and country priors as directional evidence, not rigid rules.",
+            "- Keep recommendations practical: one or two strong calls beat a menu of weak possibilities.",
+            "- Preserve review-gated learning: propose lessons only as recommendations for review, never mutate memory.",
+            "",
+            self._prefs.to_context_string(),
+        ]
+        if memory_context:
+            parts.extend(["", memory_context])
+        if country_signals:
+            parts.extend(["", "## Matched Country Priors", _json(country_signals)])
+        if intake is not None:
+            parts.extend(["", "## Current Trip Intake", _json(_intake_payload(intake))])
+        if request_payload:
+            parts.extend(["", "## Idea Request", _json(request_payload)])
+        if comparison_payload:
+            parts.extend(["", "## Current Generated Concepts", _json(comparison_payload)])
+        if draft_payload:
+            parts.extend(["", "## Current Plan Draft", _json(draft_payload)])
+        if plan_option_payload:
+            parts.extend(["", "## Selected Plan Shape", _json(plan_option_payload)])
+        if shortlist_payload:
+            parts.extend(["", "## Current Shortlist / Evidence State", _json(shortlist_payload)])
+
+        parts.extend(
+            [
+                "",
+                "## Task",
+                user_goal,
+                "",
+                "## Output Contract",
+                "Return JSON only with these keys:",
+                _json(
+                    {
+                        "summary": "one sentence",
+                        "recommendation": "plain-English best call",
+                        "rationale": ["2-5 concise bullets tied to intake/preferences/evidence"],
+                        "next_actions": ["ordered concrete actions"],
+                        "questions_for_user": ["only decision-blocking questions"],
+                        "warnings": ["hidden friction or trust-boundary issues"],
+                        "evidence_needed": ["source facts that must be verified before booking"],
+                        "stay_strategy": "single_stay|split_stay|unclear when relevant",
+                        "night_plan": [
+                            {"region": "base/area", "nights": 3, "reason": "why this allocation"}
+                        ],
+                        "confidence": 0.0,
+                    }
+                ),
+            ]
+        )
+        return "\n".join(parts)
+
+    def _call_or_fallback(
+        self,
+        kind: PlanningAdviceKind,
+        prompt: str,
+        *,
+        fallback: str,
+    ) -> PlanningAdviceResult:
+        if not self._enabled:
+            return PlanningAdviceResult(
+                kind=kind,
+                status="disabled",
+                model=self._model,
+                prompt_version=_PROMPT_VERSION,
+                prompt=prompt,
+                summary=fallback,
+                recommendation=fallback,
+                next_actions=[
+                    "Enable TRIPPY_PLANNING_LLM_ENABLED with ANTHROPIC_API_KEY for LLM strategy calls."
+                ],
+                confidence=0.35,
+            )
+        if not config.ANTHROPIC_API_KEY and self._client is None:
+            return PlanningAdviceResult(
+                kind=kind,
+                status="skipped_no_api_key",
+                model=self._model,
+                prompt_version=_PROMPT_VERSION,
+                prompt=prompt,
+                summary=fallback,
+                recommendation=fallback,
+                next_actions=[
+                    "Set ANTHROPIC_API_KEY to enable preference-rich LLM planning advice."
+                ],
+                confidence=0.35,
+            )
+
+        try:
+            client = self._client or anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
+            response = client.messages.create(
+                model=self._model,
+                max_tokens=_MAX_TOKENS,
+                system=(
+                    "You are a concise, evidence-bound travel planning strategist. "
+                    "Return valid JSON only."
+                ),
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = _response_text(response)
+            parsed = _parse_json_response(text)
+            return PlanningAdviceResult(
+                kind=kind,
+                status="llm_success",
+                model=self._model,
+                prompt_version=_PROMPT_VERSION,
+                prompt=prompt,
+                summary=str(parsed.get("summary") or ""),
+                recommendation=str(parsed.get("recommendation") or ""),
+                rationale=_string_list(parsed.get("rationale")),
+                next_actions=_string_list(parsed.get("next_actions")),
+                questions_for_user=_string_list(parsed.get("questions_for_user")),
+                warnings=_string_list(parsed.get("warnings")),
+                evidence_needed=_string_list(parsed.get("evidence_needed")),
+                stay_strategy=str(parsed.get("stay_strategy") or ""),
+                night_plan=_dict_list(parsed.get("night_plan")),
+                confidence=_float(parsed.get("confidence"), 0.55),
+                raw_response=text,
+            )
+        except Exception as exc:
+            return PlanningAdviceResult(
+                kind=kind,
+                status="llm_failed",
+                model=self._model,
+                prompt_version=_PROMPT_VERSION,
+                prompt=prompt,
+                summary=fallback,
+                recommendation=fallback,
+                next_actions=["Retry the planning-advisor call after checking the LLM setup."],
+                confidence=0.25,
+                error=str(exc),
+            )
+
+
+def _intake_payload(intake: TripIntake) -> dict[str, Any]:
+    return {
+        "trip_id": intake.trip_id,
+        "trip_name": intake.trip_name,
+        "mode": intake.mode.value,
+        "destinations": intake.destination_seeds,
+        "travel_window": intake.travel_window.display(),
+        "duration": intake.duration_display(),
+        "duration_days": intake.duration_days,
+        "duration_min_days": intake.duration_min_days,
+        "duration_max_days": intake.duration_max_days,
+        "party": intake.party.model_dump(mode="json"),
+        "departure_airports": intake.departure_airports,
+        "budget_cad": intake.budget_cad,
+        "max_travel_time_hours": intake.max_travel_time_hours,
+        "flight_preferences": intake.flight_preferences.model_dump(mode="json"),
+        "goals": intake.goals,
+        "avoidances": intake.avoidances,
+        "pace": intake.pace.value,
+        "crowd_tolerance": intake.crowd_tolerance.value,
+        "food_priority": intake.food_priority.value,
+        "lodging_preferences": intake.lodging_preferences.model_dump(mode="json"),
+        "car_rental_expectations": intake.car_rental_expectations.model_dump(mode="json"),
+        "notes": intake.freeform_notes,
+    }
+
+
+def _shortlist_summary(state: ResearchShortlistState | None) -> dict[str, Any]:
+    if state is None:
+        return {}
+    options = state.options_as_dicts()[:5]
+    compact_options = [
+        {
+            "option_id": option.get("option_id"),
+            "rank": option.get("rank"),
+            "label": option.get("name")
+            or option.get("airline")
+            or option.get("booking_source")
+            or option.get("activity_name"),
+            "region": option.get("island_or_region") or option.get("island_location"),
+            "status": option.get("row_status"),
+            "grade": option.get("recommendation_grade"),
+            "friction_flags": option.get("friction_flags", [])[:4],
+            "tradeoffs": option.get("tradeoffs", [])[:3],
+            "confidence_notes": option.get("confidence_notes", [])[:3],
+        }
+        for option in options
+    ]
+    return {
+        "category": state.category.value,
+        "recommended_option_id": state.recommended_option_id,
+        "recommendation_summary": state.recommendation_summary,
+        "warnings": state.warnings[:5],
+        "next_actions": state.next_actions[:5],
+        "artifacts": _compact_dump(state.artifacts, ["planning_advisor"]),
+        "options": compact_options,
+    }
+
+
+def _destination_text(
+    intake: TripIntake | None,
+    request_payload: dict[str, Any] | None,
+    comparison_payload: dict[str, Any] | None,
+    plan_option_payload: dict[str, Any] | None,
+) -> str:
+    pieces: list[str] = []
+    if intake is not None:
+        pieces.extend([intake.trip_name, *intake.destination_seeds, intake.freeform_notes or ""])
+    if request_payload:
+        pieces.extend(str(value) for value in request_payload.values())
+    if comparison_payload:
+        pieces.append(_json(comparison_payload))
+    if plan_option_payload:
+        pieces.append(_json(plan_option_payload))
+    return " ".join(pieces)
+
+
+def _compact_dump(payload: Any, excluded_keys: list[str]) -> Any:
+    if isinstance(payload, dict):
+        return {
+            key: _compact_dump(value, excluded_keys)
+            for key, value in payload.items()
+            if key not in excluded_keys
+        }
+    if isinstance(payload, list):
+        return [_compact_dump(value, excluded_keys) for value in payload]
+    return payload
+
+
+def _response_text(response: Any) -> str:
+    parts: list[str] = []
+    for block in getattr(response, "content", []):
+        if getattr(block, "type", "") == "text":
+            parts.append(str(getattr(block, "text", "")))
+    return "\n".join(part for part in parts if part).strip()
+
+
+def _parse_json_response(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = stripped.strip("`")
+        if stripped.startswith("json"):
+            stripped = stripped.removeprefix("json").strip()
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        start = stripped.find("{")
+        end = stripped.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            raise
+        data = json.loads(stripped[start : end + 1])
+    if not isinstance(data, dict):
+        raise ValueError("Planning advisor response must be a JSON object")
+    return data
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, default=str)

--- a/trippy/services/source_registry.py
+++ b/trippy/services/source_registry.py
@@ -74,7 +74,7 @@ _ROUTING: dict[TravelSourceCategory, dict[str, list[str]]] = {
     },
     TravelSourceCategory.TOURS: {
         "primary": ["GetYourGuide"],
-        "secondary": ["Airbnb Experiences"],
+        "secondary": [],
         "validation": ["Tripadvisor"],
     },
     TravelSourceCategory.CAR_RENTALS: {

--- a/trippy/services/source_research.py
+++ b/trippy/services/source_research.py
@@ -79,6 +79,7 @@ class SourceResearchService:
             LinkResearchAdapter(),
             PlaywrightFlightAdapter(),
             PlaywrightLodgingAdapter(),
+            PlaywrightActivityAdapter(),
             OpenClawResearchAdapter(),
         ]
 
@@ -97,28 +98,34 @@ class SourceResearchService:
             "started_at": datetime.utcnow().isoformat(),
             "category": state.category.value,
         }
-        if state.category not in {ShortlistCategory.LODGING, ShortlistCategory.FLIGHTS}:
+        if state.category not in {
+            ShortlistCategory.LODGING,
+            ShortlistCategory.FLIGHTS,
+            ShortlistCategory.ACTIVITIES,
+        }:
             state.artifacts["deep_research"]["status"] = "skipped"
             state.artifacts["deep_research"]["notes"] = [
-                "Deep adapters are implemented for lodging and flights; other categories remain source-link validated."
+                "Deep adapters are implemented for lodging, flights, and activities; other categories remain source-link validated."
             ]
             return state
 
         run_results: list[SourceResearchResult] = []
         selected_option_ids = set(option_ids or [])
-        options = (
-            state.lodging_options
-            if state.category == ShortlistCategory.LODGING
-            else state.flight_options
-        )
+        if state.category == ShortlistCategory.LODGING:
+            options = state.lodging_options
+        elif state.category == ShortlistCategory.FLIGHTS:
+            options = state.flight_options
+        else:
+            options = state.activity_options
         for option in options:
             if selected_option_ids and option.option_id not in selected_option_ids:
                 continue
-            request = (
-                _request_for_lodging_option(state, option, mode)
-                if state.category == ShortlistCategory.LODGING
-                else _request_for_flight_option(state, option, mode)
-            )
+            if state.category == ShortlistCategory.LODGING:
+                request = _request_for_lodging_option(state, option, mode)
+            elif state.category == ShortlistCategory.FLIGHTS:
+                request = _request_for_flight_option(state, option, mode)
+            else:
+                request = _request_for_activity_option(state, option, mode)
             option_dir = (
                 self._research_dir
                 / state.trip_id
@@ -129,8 +136,10 @@ class SourceResearchService:
             result = self._research_request(request, mode=mode, artifact_dir=option_dir)
             if state.category == ShortlistCategory.LODGING:
                 _apply_lodging_observations(option, result, run_id=run_id)
-            else:
+            elif state.category == ShortlistCategory.FLIGHTS:
                 _apply_flight_observations(option, result, run_id=run_id)
+            else:
+                _apply_activity_observations(option, result, run_id=run_id)
             run_results.append(result)
 
         state.artifacts["deep_research"].update(
@@ -151,7 +160,12 @@ class SourceResearchService:
                 "or inventory as ready-to-click."
             )
             if state.category == ShortlistCategory.FLIGHTS
-            else "Review deep-research evidence for lodging rows before treating any option as ready-to-click.",
+            else (
+                "Review deep-research evidence for activity rows before treating cost, time, duration, "
+                "or availability as ready-to-click."
+                if state.category == ShortlistCategory.ACTIVITIES
+                else "Review deep-research evidence for lodging rows before treating any option as ready-to-click."
+            ),
         )
         self._record_run_event(state, run_id, run_results)
         return state
@@ -475,6 +489,102 @@ class PlaywrightLodgingAdapter:
         )
 
 
+class PlaywrightActivityAdapter:
+    """Browser-capable activity adapter for price, schedule, and inventory signals."""
+
+    capability = SourceAdapterCapability.PLAYWRIGHT
+
+    def __init__(
+        self,
+        *,
+        fetcher: HtmlFetcher | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self._fetcher = fetcher or _fetch_html
+        self._custom_fetcher = fetcher is not None
+        self._timeout = timeout_seconds or config.SOURCE_RESEARCH_TIMEOUT_SECONDS
+
+    def can_handle(self, request: SourceResearchRequest) -> bool:
+        return request.category == ShortlistCategory.ACTIVITIES.value and bool(request.source_url)
+
+    def research(
+        self,
+        request: SourceResearchRequest,
+        *,
+        artifact_dir: Path,
+    ) -> SourceResearchResult:
+        notes = [
+            "Read-only activity source extraction; no booking, login, payment, or cart action attempted."
+        ]
+        try:
+            if (
+                config.SOURCE_RESEARCH_PLAYWRIGHT_ENABLED
+                and not self._custom_fetcher
+                and shutil.which("npx") is not None
+            ):
+                html, final_url, fetch_notes = _fetch_html_with_playwright(
+                    request.source_url,
+                    self._timeout,
+                )
+            else:
+                html, final_url, fetch_notes = self._fetcher(request.source_url, self._timeout)
+        except (URLError, OSError, TimeoutError, ValueError) as exc:
+            return _result(
+                request,
+                adapter=self.capability,
+                status=SourceResearchStatus.BLOCKED,
+                confidence=0.2,
+                notes=[*notes, f"Activity source fetch was blocked: {exc}"],
+                missing_fields=_activity_missing_fields(),
+            )
+
+        notes.extend(fetch_notes)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        html_path = artifact_dir / "source.html"
+        html_path.write_text(html[:500_000], encoding="utf-8")
+        text = _page_text(html)
+        text_path = artifact_dir / "source-text.txt"
+        text_path.write_text(text[:80_000], encoding="utf-8")
+        observations = _extract_activity_observations(
+            text,
+            request=request,
+            evidence_refs=[str(html_path), str(text_path), final_url],
+        )
+        missing = _remaining_activity_fields(observations)
+        confidence = _observation_confidence(observations)
+        status = (
+            SourceResearchStatus.SUCCESS
+            if confidence >= 0.62 and len(missing) <= 2
+            else SourceResearchStatus.PARTIAL
+            if observations
+            else SourceResearchStatus.BLOCKED
+        )
+        artifacts = [
+            EvidenceArtifact(
+                artifact_type="html",
+                label="Fetched activity source HTML snapshot",
+                path=str(html_path),
+                url=final_url,
+            ),
+            EvidenceArtifact(
+                artifact_type="text",
+                label="Extracted activity source visible text",
+                path=str(text_path),
+                url=final_url,
+            ),
+        ]
+        return _result(
+            request,
+            adapter=self.capability,
+            status=status,
+            confidence=confidence,
+            observations=observations,
+            evidence_artifacts=artifacts,
+            notes=notes,
+            missing_fields=missing,
+        )
+
+
 class OpenClawResearchAdapter:
     capability = SourceAdapterCapability.OPENCLAW
 
@@ -493,7 +603,12 @@ class OpenClawResearchAdapter:
 
     def can_handle(self, request: SourceResearchRequest) -> bool:
         return (
-            request.category in {ShortlistCategory.LODGING.value, ShortlistCategory.FLIGHTS.value}
+            request.category
+            in {
+                ShortlistCategory.LODGING.value,
+                ShortlistCategory.FLIGHTS.value,
+                ShortlistCategory.ACTIVITIES.value,
+            }
             and self._enabled
             and bool(request.source_url)
             and shutil.which(self._command) is not None
@@ -666,6 +781,36 @@ def _request_for_flight_option(
     )
 
 
+def _request_for_activity_option(
+    state: ResearchShortlistState,
+    option: Any,
+    mode: SourceResearchMode,
+) -> SourceResearchRequest:
+    return SourceResearchRequest(
+        trip_id=state.trip_id,
+        category=state.category.value,
+        option_id=str(option.option_id),
+        source_name=str(option.source),
+        source_url=str(option.deep_link),
+        source_type=str(
+            option.validation.source_type.value if option.validation else "live_search"
+        ),
+        query=" ".join(
+            item
+            for item in [
+                str(option.activity_name),
+                str(option.island_location),
+                str(option.duration),
+                str(option.age_family_fit),
+            ]
+            if item
+        ),
+        candidate_name=str(option.activity_name),
+        adapter_mode=mode,
+        context=option.model_dump(mode="json"),
+    )
+
+
 def _apply_lodging_observations(option: Any, result: SourceResearchResult, *, run_id: str) -> None:
     validation: SourceValidation = option.validation or SourceValidation()
     validation.adapter_used = result.adapter_used.value
@@ -804,6 +949,10 @@ def _apply_flight_observations(option: Any, result: SourceResearchResult, *, run
         option.airline = str(observations["airline"])
     if isinstance(observations.get("flight_numbers"), list):
         option.flight_numbers = [str(value) for value in observations["flight_numbers"]]
+    if isinstance(observations.get("departure_date"), str):
+        option.departure_date = str(observations["departure_date"])
+    if isinstance(observations.get("arrival_date"), str):
+        option.arrival_date = str(observations["arrival_date"])
     if isinstance(observations.get("departure_time"), str):
         option.departure_time = str(observations["departure_time"])
     if isinstance(observations.get("arrival_time"), str):
@@ -833,6 +982,80 @@ def _apply_flight_observations(option: Any, result: SourceResearchResult, *, run
                 *option.tradeoffs,
                 "Observed timing should be checked against lodging check-in, car pickup, and first-day pacing.",
             ]
+        )
+    option.validation = validation
+
+
+def _apply_activity_observations(option: Any, result: SourceResearchResult, *, run_id: str) -> None:
+    validation: SourceValidation = option.validation or SourceValidation()
+    validation.adapter_used = result.adapter_used.value
+    validation.research_run_id = run_id
+    validation.verified_at = result.ended_at
+    validation.evidence_url = result.request.source_url or validation.evidence_url
+    validation.evidence_artifacts = result.evidence_artifacts
+    validation.extracted_fields = {
+        observation.field: observation.value for observation in result.observations
+    }
+    validation.notes = _dedupe_notes(
+        [
+            *validation.notes,
+            *result.notes,
+            "Activity source research extracts evidence only; final times, inventory, pickup, and booking terms can change before purchase.",
+        ]
+    )
+    validation.missing_fields = sorted(set(result.missing_fields))
+    validation.confidence = max(validation.confidence, result.confidence)
+    validation.price_status = (
+        PriceStatus.LIVE_SIGNAL
+        if "price_signal" in validation.extracted_fields
+        else validation.price_status
+    )
+    validation.availability_status = (
+        AvailabilityStatus.AVAILABILITY_SIGNAL
+        if "availability_signal" in validation.extracted_fields
+        else validation.availability_status
+    )
+    if result.status == SourceResearchStatus.SUCCESS:
+        validation.verification_status = VerificationStatus.LIVE_VERIFIED
+        validation.freshness_status = FreshnessStatus.CURRENT
+        option.row_status = ShortlistRowStatus.VERIFIED_LIVE
+        option.live_data_status = LiveDataStatus.LIVE_VERIFIED
+    elif result.status == SourceResearchStatus.PARTIAL:
+        if result.adapter_used == SourceAdapterCapability.LINK:
+            validation.verification_status = VerificationStatus.MANUAL_REQUIRED
+            validation.freshness_status = FreshnessStatus.UNKNOWN
+            option.row_status = ShortlistRowStatus.RESEARCHED
+            option.live_data_status = LiveDataStatus.HANDOFF_REQUIRED
+        else:
+            validation.verification_status = VerificationStatus.PARTIAL
+            validation.freshness_status = FreshnessStatus.CURRENT
+            option.row_status = (
+                ShortlistRowStatus.VERIFIED_LIVE
+                if result.confidence >= 0.45
+                else ShortlistRowStatus.RESEARCHED
+            )
+            option.live_data_status = LiveDataStatus.PARTIAL
+    else:
+        validation.verification_status = VerificationStatus.FAILED
+        option.row_status = ShortlistRowStatus.RESEARCHED
+        option.live_data_status = LiveDataStatus.HANDOFF_REQUIRED
+
+    observations = validation.extracted_fields
+    if isinstance(observations.get("price_signal"), str):
+        option.price_band = str(observations["price_signal"])
+    if isinstance(observations.get("duration_signal"), str):
+        option.duration = str(observations["duration_signal"])
+    if isinstance(observations.get("start_time"), str):
+        option.suggested_start_time = str(observations["start_time"])
+    if isinstance(observations.get("end_time"), str):
+        option.suggested_end_time = str(observations["end_time"])
+    if isinstance(observations.get("rating_summary"), str):
+        option.review_safety_signal = str(observations["rating_summary"])
+    if isinstance(observations.get("group_size_signal"), str):
+        option.group_size_signal = str(observations["group_size_signal"])
+    if isinstance(observations.get("availability_signal"), str):
+        option.confidence_notes = _dedupe_notes(
+            [*option.confidence_notes, str(observations["availability_signal"])]
         )
     option.validation = validation
 
@@ -896,10 +1119,12 @@ const timeout = Number(process.argv[2] || 12000);
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage();
   await page.goto(url, { waitUntil: 'domcontentloaded', timeout });
-  await page.waitForTimeout(1200);
+  await page.waitForLoadState('networkidle', { timeout }).catch(() => {});
+  await page.waitForTimeout(2500);
+  const visibleText = await page.evaluate(() => document.body ? document.body.innerText : '');
   const html = await page.content();
   await browser.close();
-  process.stdout.write(html);
+  process.stdout.write(`${html}<pre id="trippy-visible-text">${visibleText}</pre>`);
 })().catch((error) => {
   console.error(error && error.stack ? error.stack : String(error));
   process.exit(1);
@@ -1079,10 +1304,22 @@ def _extract_flight_observations(
         )
     departure = _time_signal(cleaned, ["depart", "departure", "leaves", "outbound"])
     arrival = _time_signal(cleaned, ["arrive", "arrival", "lands"])
+    departure_date = _date_signal(cleaned, ["depart", "departure", "outbound", "leaves"])
+    arrival_date = _date_signal(cleaned, ["arrive", "arrival", "lands"])
     if not departure or not arrival:
         paired_departure, paired_arrival = _time_pair_signal(cleaned)
         departure = departure or paired_departure
         arrival = arrival or paired_arrival
+    if not departure_date or not arrival_date:
+        paired_departure_date, paired_arrival_date = _date_pair_signal(cleaned)
+        departure_date = departure_date or paired_departure_date
+        arrival_date = arrival_date or paired_arrival_date
+    if departure_date:
+        observations.append(
+            _observation("departure_date", departure_date, 0.6, request, evidence_refs)
+        )
+    if arrival_date:
+        observations.append(_observation("arrival_date", arrival_date, 0.6, request, evidence_refs))
     if departure:
         observations.append(_observation("departure_time", departure, 0.56, request, evidence_refs))
     if arrival:
@@ -1109,6 +1346,61 @@ def _extract_flight_observations(
     baggage = _baggage_signal(lower)
     if baggage:
         observations.append(_observation("baggage_signal", baggage, 0.45, request, evidence_refs))
+    return observations
+
+
+def _extract_activity_observations(
+    text: str,
+    *,
+    request: SourceResearchRequest,
+    evidence_refs: list[str],
+) -> list[SourceObservation]:
+    cleaned = " ".join(text.split())
+    lower = cleaned.lower()
+    observations: list[SourceObservation] = []
+    price = _extract_price(cleaned)
+    if price:
+        observations.append(
+            _observation("price_signal", price, 0.64, request, evidence_refs, "Visible activity price text")
+        )
+    availability = _activity_availability_signal(lower)
+    if availability:
+        observations.append(
+            _observation(
+                "availability_signal",
+                availability,
+                0.55,
+                request,
+                evidence_refs,
+                "Visible activity booking/availability language",
+            )
+        )
+    start_time = _time_signal(cleaned, ["start", "starts", "departure", "meet", "meeting"])
+    end_time = _time_signal(cleaned, ["end", "ends", "return", "finish", "finishes"])
+    if not start_time or not end_time:
+        paired_start, paired_end = _time_pair_signal(cleaned)
+        start_time = start_time or paired_start
+        end_time = end_time or paired_end
+    if start_time:
+        observations.append(_observation("start_time", start_time, 0.56, request, evidence_refs))
+    if end_time:
+        observations.append(_observation("end_time", end_time, 0.52, request, evidence_refs))
+    duration = _duration_signal(cleaned)
+    if duration:
+        observations.append(_observation("duration_signal", duration, 0.58, request, evidence_refs))
+    cancellation = _cancellation_signal(lower)
+    if cancellation:
+        observations.append(
+            _observation("cancellation_signal", cancellation, 0.48, request, evidence_refs)
+        )
+    group_size = _group_size_signal(cleaned)
+    if group_size:
+        observations.append(
+            _observation("group_size_signal", group_size, 0.5, request, evidence_refs)
+        )
+    rating = _rating_signal(cleaned)
+    if rating:
+        observations.append(_observation("rating_summary", rating, 0.52, request, evidence_refs))
     return observations
 
 
@@ -1160,6 +1452,19 @@ def _flight_context_observations(
                 "Fallback from canonical candidate context, not live source evidence",
             )
         )
+    for field in ("departure_date", "arrival_date"):
+        value = str(context.get(field, "")).strip()
+        if value:
+            observations.append(
+                _observation(
+                    field,
+                    value,
+                    0.32,
+                    request,
+                    evidence_refs,
+                    "Fallback from canonical candidate context, not live source evidence",
+                )
+            )
     price = _extract_price(query_text)
     if price and not any(observation.field == "price_signal" for observation in observations):
         observations.append(
@@ -1256,6 +1561,27 @@ def _flight_availability_signal(lower: str) -> str:
     return ""
 
 
+def _activity_availability_signal(lower: str) -> str:
+    if any(
+        term in lower
+        for term in ["sold out", "not available", "unavailable", "no availability", "no tours"]
+    ):
+        return "unavailable/sold-out signal visible; choose another time, date, or operator"
+    if any(
+        term in lower
+        for term in [
+            "check availability",
+            "select participants",
+            "reserve now",
+            "book now",
+            "available",
+            "free cancellation",
+        ]
+    ):
+        return "booking or availability signal visible; final inventory still needs source review"
+    return ""
+
+
 def _time_signal(text: str, labels: list[str]) -> str:
     label_pattern = "|".join(re.escape(label) for label in labels)
     match = re.search(
@@ -1279,6 +1605,42 @@ def _time_pair_signal(text: str) -> tuple[str, str]:
     return "", ""
 
 
+def _date_signal(text: str, labels: list[str]) -> str:
+    label_pattern = "|".join(re.escape(label) for label in labels)
+    date_pattern = (
+        r"(?:20\d{2}-\d{2}-\d{2})|"
+        r"(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+20\d{2})|"
+        r"(?:\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+20\d{2})"
+    )
+    match = re.search(
+        rf"(?:{label_pattern})(?:ure|s|ing)?\s*(?:date)?\s*(?:on|:|-)?\s*({date_pattern})",
+        text,
+        flags=re.IGNORECASE,
+    )
+    return " ".join(match.group(1).replace(",", "").split()) if match else ""
+
+
+def _date_pair_signal(text: str) -> tuple[str, str]:
+    date_pattern = (
+        r"(?:20\d{2}-\d{2}-\d{2})|"
+        r"(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+20\d{2})|"
+        r"(?:\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+20\d{2})"
+    )
+    match = re.search(rf"\b({date_pattern})\s*(?:-|–|—|to|→)\s*({date_pattern})\b", text)
+    if match:
+        return (
+            " ".join(match.group(1).replace(",", "").split()),
+            " ".join(match.group(2).replace(",", "").split()),
+        )
+    dates = re.findall(date_pattern, text, flags=re.IGNORECASE)
+    if len(dates) >= 2:
+        return (
+            " ".join(str(dates[0]).replace(",", "").split()),
+            " ".join(str(dates[1]).replace(",", "").split()),
+        )
+    return "", ""
+
+
 def _duration_signal(text: str) -> str:
     match = re.search(
         r"(?:total\s+duration|duration|travel\s+time)\s*(?:is|:|-)?\s*((?:\d+\s?(?:h|hr|hrs|hour|hours))\s*(?:\d+\s?(?:m|min|mins|minute|minutes))?)",
@@ -1292,6 +1654,33 @@ def _duration_signal(text: str) -> str:
             flags=re.IGNORECASE,
         )
     return " ".join(match.group(1).split()) if match and match.group(1).strip() else ""
+
+
+def _group_size_signal(text: str) -> str:
+    lower = text.lower()
+    if "private tour" in lower or "private group" in lower:
+        return "private tour/group signal visible"
+    match = re.search(
+        r"(?:small group|group size|limited to|max(?:imum)?(?: group)?)(?:\s*(?:of|to|:|-))?\s*(\d{1,2})",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        return f"group size signal visible: {match.group(0).strip()}"
+    if "small group" in lower:
+        return "small-group signal visible"
+    return ""
+
+
+def _rating_signal(text: str) -> str:
+    match = re.search(
+        r"\b(\d(?:\.\d)?)(?:\s*/\s*5|\s+out of\s+5)\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        return f"visible rating {match.group(1)}/5; read recent reviews before booking"
+    return ""
 
 
 def _stops_signal(lower: str) -> int | None:
@@ -1352,7 +1741,10 @@ def _baggage_signal(lower: str) -> str:
 
 
 def _availability_signal(lower: str) -> str:
-    if any(term in lower for term in ["sold out", "not available", "unavailable"]):
+    if any(
+        term in lower
+        for term in ["sold out", "not available", "unavailable", "no properties found"]
+    ):
         return "unavailable signal visible; do not advance without another date/property"
     if any(term in lower for term in ["reserve", "book now", "availability", "available"]):
         return (
@@ -1438,6 +1830,8 @@ def _remaining_flight_fields(observations: Iterable[SourceObservation]) -> list[
     found = {observation.field for observation in observations}
     required = set(_flight_missing_fields())
     mapping = {
+        "departure_date": "exact_departure_date",
+        "arrival_date": "exact_arrival_date",
         "price_signal": "exact_fare",
         "departure_time": "exact_departure_time",
         "arrival_time": "exact_arrival_time",
@@ -1445,6 +1839,24 @@ def _remaining_flight_fields(observations: Iterable[SourceObservation]) -> list[
         "flight_numbers": "flight_numbers",
         "baggage_signal": "baggage_terms",
         "cabin_signal": "fare_rules",
+    }
+    for observation_field, missing_field in mapping.items():
+        if observation_field in found:
+            required.discard(missing_field)
+    return sorted(required)
+
+
+def _remaining_activity_fields(observations: Iterable[SourceObservation]) -> list[str]:
+    found = {observation.field for observation in observations}
+    required = set(_activity_missing_fields())
+    mapping = {
+        "price_signal": "current_price",
+        "availability_signal": "exact_availability",
+        "start_time": "bookable_time",
+        "end_time": "bookable_time",
+        "duration_signal": "duration",
+        "cancellation_signal": "cancellation_policy",
+        "group_size_signal": "group_size",
     }
     for observation_field, missing_field in mapping.items():
         if observation_field in found:
@@ -1466,6 +1878,8 @@ def _lodging_missing_fields() -> list[str]:
 
 def _flight_missing_fields() -> list[str]:
     return [
+        "exact_departure_date",
+        "exact_arrival_date",
         "flight_numbers",
         "exact_departure_time",
         "exact_arrival_time",
@@ -1476,18 +1890,39 @@ def _flight_missing_fields() -> list[str]:
     ]
 
 
+def _activity_missing_fields() -> list[str]:
+    return [
+        "exact_availability",
+        "current_price",
+        "bookable_time",
+        "duration",
+        "cancellation_policy",
+        "group_size",
+    ]
+
+
 def _missing_fields_for_category(category: str) -> list[str]:
     if category == ShortlistCategory.FLIGHTS.value:
         return _flight_missing_fields()
+    if category == ShortlistCategory.ACTIVITIES.value:
+        return _activity_missing_fields()
     return _lodging_missing_fields()
 
 
 def _missing_high_value_fields(result: SourceResearchResult) -> bool:
     if result.request.category == ShortlistCategory.FLIGHTS.value:
         return bool(
-            {"exact_departure_time", "exact_arrival_time", "exact_fare"}
+            {
+                "exact_departure_date",
+                "exact_departure_time",
+                "exact_arrival_date",
+                "exact_arrival_time",
+                "exact_fare",
+            }
             & set(result.missing_fields)
         )
+    if result.request.category == ShortlistCategory.ACTIVITIES.value:
+        return bool({"current_price", "exact_availability", "bookable_time"} & set(result.missing_fields))
     return bool(
         {"final_total_price", "bed_layout", "min_three_beds_satisfied"} & set(result.missing_fields)
     )
@@ -1578,11 +2013,17 @@ def _dedupe_notes(notes: list[str]) -> list[str]:
 def _openclaw_prompt(request: SourceResearchRequest) -> str:
     if request.category == ShortlistCategory.FLIGHTS.value:
         useful_fields = (
-            "airline, flight_numbers, departure_time, arrival_time, total_duration, stops, "
-            "layover_airports, layover_duration, price_signal, availability_signal, "
+            "airline, flight_numbers, departure_date, departure_time, arrival_date, arrival_time, "
+            "total_duration, stops, layover_airports, layover_duration, price_signal, availability_signal, "
             "cabin_signal, baggage_signal"
         )
         category_note = "flight research"
+    elif request.category == ShortlistCategory.ACTIVITIES.value:
+        useful_fields = (
+            "price_signal, availability_signal, start_time, end_time, duration_signal, "
+            "cancellation_signal, group_size_signal, rating_summary"
+        )
+        category_note = "activity research"
     else:
         useful_fields = (
             "price_signal, availability_signal, bed_layout_signal, "

--- a/trippy/services/trip_execution.py
+++ b/trippy/services/trip_execution.py
@@ -1,0 +1,359 @@
+"""Trip packet and booking confirmation state."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from trippy import config
+from trippy.models.shortlists import ResearchShortlistState, ShortlistCategory, ShortlistRowStatus
+from trippy.models.trip_execution import (
+    ExecutionCategory,
+    ExecutionStatus,
+    TripPacketItem,
+    TripPacketState,
+)
+from trippy.services.shortlist_store import ShortlistStore
+
+
+class TripExecutionService:
+    """Build and persist the trip-ready execution packet.
+
+    This service intentionally does not book anything. It tracks the human's
+    selected, booked, and confirmed items so the rest of Trippy can produce a
+    truthful timeline, sheet, map, and concierge packet.
+    """
+
+    def __init__(
+        self,
+        *,
+        packet_dir: Path | None = None,
+        shortlist_store: ShortlistStore | None = None,
+    ) -> None:
+        self._dir = packet_dir or config.WORKSPACES_PATH / "trip_packets"
+        self._shortlists = shortlist_store or ShortlistStore()
+
+    def path_for(self, trip_id: str) -> Path:
+        return self._dir / f"{trip_id}.packet.json"
+
+    def load(self, trip_id: str) -> TripPacketState | None:
+        path = self.path_for(trip_id)
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return TripPacketState.model_validate(data)
+
+    def build(self, trip_id: str, *, save: bool = False) -> TripPacketState:
+        packet = self.load(trip_id) or TripPacketState(trip_id=trip_id)
+        packet = self._merge_selected_shortlist_items(packet)
+        packet = self._recalculate(packet)
+        if save:
+            self.save(packet)
+        return packet
+
+    def save(self, packet: TripPacketState) -> TripPacketState:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        packet.updated_at = datetime.utcnow()
+        self.path_for(packet.trip_id).write_text(
+            packet.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+        return packet
+
+    def update_item(
+        self,
+        trip_id: str,
+        *,
+        category: str,
+        option_id: str,
+        status: str,
+        provider: str = "",
+        booking_link: str = "",
+        confirmation_code: str = "",
+        date: str = "",
+        start_time: str = "",
+        end_time: str = "",
+        address: str = "",
+        cost_cad: float | None = None,
+        notes: str = "",
+    ) -> TripPacketState:
+        execution_category = ExecutionCategory(category)
+        execution_status = ExecutionStatus(status)
+        packet = self.build(trip_id, save=False)
+        item = packet.get_item(execution_category, option_id)
+        if item is None:
+            item = TripPacketItem(
+                item_id=f"{execution_category.value}:{option_id}",
+                category=execution_category,
+                option_id=option_id,
+                title=option_id or execution_category.value.title(),
+            )
+            packet.items.append(item)
+        item.status = execution_status
+        if provider.strip():
+            item.provider = provider.strip()
+        if booking_link.strip():
+            item.booking_link = booking_link.strip()
+            item.source_url = item.source_url or item.booking_link
+        if confirmation_code.strip():
+            item.confirmation_code = confirmation_code.strip()
+        if date.strip():
+            item.date = date.strip()
+        if start_time.strip():
+            item.start_time = start_time.strip()
+        if end_time.strip():
+            item.end_time = end_time.strip()
+        if address.strip():
+            item.address = address.strip()
+        if cost_cad is not None:
+            item.cost_cad = cost_cad
+        if notes.strip():
+            item.notes = notes.strip()
+        item.updated_at = datetime.utcnow()
+
+        self._sync_shortlist_row_status(
+            trip_id,
+            execution_category,
+            option_id,
+            execution_status,
+        )
+        packet = self._recalculate(packet)
+        return self.save(packet)
+
+    def _merge_selected_shortlist_items(self, packet: TripPacketState) -> TripPacketState:
+        existing_keys = {(item.category, item.option_id) for item in packet.items}
+        for shortlist in self._shortlists.load_all(packet.trip_id):
+            category = _execution_category_for_shortlist(shortlist.category)
+            for option in _selected_options(shortlist):
+                option_id = str(getattr(option, "option_id", ""))
+                if not option_id or (category, option_id) in existing_keys:
+                    continue
+                packet.items.append(_packet_item_from_option(category, option))
+                existing_keys.add((category, option_id))
+        return packet
+
+    def _sync_shortlist_row_status(
+        self,
+        trip_id: str,
+        category: ExecutionCategory,
+        option_id: str,
+        status: ExecutionStatus,
+    ) -> None:
+        shortlist_category = _shortlist_category_for_execution(category)
+        if shortlist_category is None:
+            return
+        state = self._shortlists.load(trip_id, shortlist_category)
+        if state is None:
+            return
+        new_status = (
+            ShortlistRowStatus.CONFIRMED
+            if status == ExecutionStatus.CONFIRMED
+            else ShortlistRowStatus.BOOKED
+        )
+        changed = False
+        for option in _state_options(state):
+            if getattr(option, "option_id", "") == option_id:
+                option.row_status = new_status
+                changed = True
+        if changed:
+            state.recommended_option_id = option_id or state.recommended_option_id
+            self._shortlists.save(state)
+
+    def _recalculate(self, packet: TripPacketState) -> TripPacketState:
+        packet.items.sort(key=_packet_sort_key)
+        required = _required_items(packet.items)
+        score = 0
+        max_score = max(len(required) * 100, 1)
+        missing: list[str] = []
+        for category in required:
+            item = next((entry for entry in packet.items if entry.category == category), None)
+            label = category.value
+            if item is None:
+                missing.append(f"Choose a {label} option.")
+                continue
+            if item.status == ExecutionStatus.SELECTED:
+                score += 35
+                missing.append(f"Book selected {label} or replace it.")
+                continue
+            if item.status == ExecutionStatus.BOOKED:
+                score += 70
+                if not item.confirmation_code:
+                    missing.append(f"Add {label} confirmation code/details.")
+                continue
+            if item.is_confirmed:
+                score += 100
+            else:
+                score += 80
+                missing.append(f"Add {label} confirmation code/details.")
+
+        packet.readiness_percent = int(round((score / max_score) * 100))
+        if packet.readiness_percent >= 100:
+            packet.status_label = "trip packet confirmed"
+        elif any(item.status == ExecutionStatus.BOOKED for item in packet.items):
+            packet.status_label = "bookings in progress"
+        elif packet.items:
+            packet.status_label = "recommendations selected"
+        else:
+            packet.status_label = "not ready"
+        packet.missing_items = missing
+        packet.next_actions = _next_actions(packet, required)
+        packet.summary = _packet_summary(packet, required)
+        packet.updated_at = datetime.utcnow()
+        return packet
+
+
+def _selected_options(state: ResearchShortlistState) -> list[Any]:
+    selected_statuses = {
+        ShortlistRowStatus.APPROVED,
+        ShortlistRowStatus.BOOKED,
+        ShortlistRowStatus.CONFIRMED,
+    }
+    options = [
+        option
+        for option in _state_options(state)
+        if getattr(option, "row_status", "") in selected_statuses
+    ]
+    if options:
+        return options
+    recommended_id = state.recommended_option_id
+    if recommended_id:
+        return [
+            option
+            for option in _state_options(state)
+            if getattr(option, "option_id", "") == recommended_id
+        ]
+    return []
+
+
+def _state_options(state: ResearchShortlistState) -> list[Any]:
+    if state.category == ShortlistCategory.FLIGHTS:
+        return list(state.flight_options)
+    if state.category == ShortlistCategory.LODGING:
+        return list(state.lodging_options)
+    if state.category == ShortlistCategory.CARS:
+        return list(state.car_options)
+    return list(state.activity_options)
+
+
+def _packet_item_from_option(
+    category: ExecutionCategory,
+    option: Any,
+) -> TripPacketItem:
+    title = (
+        getattr(option, "airline", "")
+        or getattr(option, "name", "")
+        or getattr(option, "vehicle_class", "")
+        or getattr(option, "activity_name", "")
+        or getattr(option, "option_id", "")
+    )
+    provider = (
+        getattr(option, "booking_source", "")
+        or getattr(option, "source", "")
+        or getattr(option, "provider", "")
+    )
+    return TripPacketItem(
+        item_id=f"{category.value}:{getattr(option, 'option_id', '')}",
+        category=category,
+        option_id=str(getattr(option, "option_id", "")),
+        title=str(title),
+        provider=str(provider),
+        status=_execution_status_from_row(getattr(option, "row_status", "")),
+        source_url=str(getattr(option, "deep_link", "") or ""),
+        booking_link=str(getattr(option, "deep_link", "") or ""),
+        date=str(
+            getattr(option, "scheduled_date", "") or getattr(option, "suggested_date", "") or ""
+        ),
+        start_time=str(
+            getattr(option, "scheduled_start_time", "")
+            or getattr(option, "suggested_start_time", "")
+            or getattr(option, "departure_time", "")
+            or ""
+        ),
+        end_time=str(
+            getattr(option, "scheduled_end_time", "")
+            or getattr(option, "suggested_end_time", "")
+            or getattr(option, "arrival_time", "")
+            or ""
+        ),
+        evidence={
+            "row_status": str(getattr(getattr(option, "row_status", ""), "value", "")),
+            "verification": str(
+                getattr(
+                    getattr(getattr(option, "validation", None), "verification_status", ""),
+                    "value",
+                    "",
+                )
+            ),
+            "confidence": getattr(getattr(option, "validation", None), "confidence", None),
+        },
+    )
+
+
+def _execution_status_from_row(row_status: Any) -> ExecutionStatus:
+    value = getattr(row_status, "value", row_status)
+    if value == ShortlistRowStatus.CONFIRMED.value:
+        return ExecutionStatus.CONFIRMED
+    if value == ShortlistRowStatus.BOOKED.value:
+        return ExecutionStatus.BOOKED
+    return ExecutionStatus.SELECTED
+
+
+def _execution_category_for_shortlist(category: ShortlistCategory) -> ExecutionCategory:
+    return {
+        ShortlistCategory.FLIGHTS: ExecutionCategory.FLIGHT,
+        ShortlistCategory.LODGING: ExecutionCategory.LODGING,
+        ShortlistCategory.CARS: ExecutionCategory.CAR,
+        ShortlistCategory.ACTIVITIES: ExecutionCategory.ACTIVITY,
+    }[category]
+
+
+def _shortlist_category_for_execution(category: ExecutionCategory) -> ShortlistCategory | None:
+    return {
+        ExecutionCategory.FLIGHT: ShortlistCategory.FLIGHTS,
+        ExecutionCategory.LODGING: ShortlistCategory.LODGING,
+        ExecutionCategory.CAR: ShortlistCategory.CARS,
+        ExecutionCategory.ACTIVITY: ShortlistCategory.ACTIVITIES,
+    }.get(category)
+
+
+def _required_items(items: list[TripPacketItem]) -> list[ExecutionCategory]:
+    required = [ExecutionCategory.FLIGHT, ExecutionCategory.LODGING]
+    if any(item.category == ExecutionCategory.CAR for item in items):
+        required.append(ExecutionCategory.CAR)
+    if any(item.category == ExecutionCategory.ACTIVITY for item in items):
+        required.append(ExecutionCategory.ACTIVITY)
+    return required
+
+
+def _next_actions(
+    packet: TripPacketState,
+    required: list[ExecutionCategory],
+) -> list[str]:
+    actions = []
+    for missing in packet.missing_items[:5]:
+        actions.append(missing)
+    if not actions and required:
+        actions.append("Review the trip packet, map, and timeline before departure.")
+    return actions
+
+
+def _packet_summary(packet: TripPacketState, required: list[ExecutionCategory]) -> str:
+    confirmed = sum(1 for item in packet.items if item.is_confirmed)
+    booked = sum(1 for item in packet.items if item.is_booked)
+    return (
+        f"{booked} booked item(s), {confirmed} confirmed item(s), "
+        f"{len(required)} required category/categories."
+    )
+
+
+def _packet_sort_key(item: TripPacketItem) -> tuple[int, str, str]:
+    order = {
+        ExecutionCategory.FLIGHT: 10,
+        ExecutionCategory.LODGING: 20,
+        ExecutionCategory.CAR: 30,
+        ExecutionCategory.ACTIVITY: 40,
+        ExecutionCategory.OTHER: 90,
+    }
+    return (order.get(item.category, 99), item.date or "", item.title)

--- a/trippy/services/trip_ideation.py
+++ b/trippy/services/trip_ideation.py
@@ -8,6 +8,7 @@ from trippy.memory.store import MemoryStore
 from trippy.models.ideas import TripComparison, TripConcept, TripIdeaRequest
 from trippy.models.preferences import FamilyTravelPreferences
 from trippy.services.country_priors import CountryPriorService
+from trippy.services.planning_advisor import PlanningAdvisorService
 
 
 @dataclass(frozen=True)
@@ -44,7 +45,16 @@ _TEMPLATES = [
         base_comfort=84,
         food_score=78,
         crowd_risk=36,
-        tags={"nature", "food", "island", "short-flight", "low-crowd", "chill"},
+        tags={
+            "nature",
+            "food",
+            "island",
+            "azores",
+            "portugal",
+            "short-flight",
+            "low-crowd",
+            "chill",
+        },
         risks=[
             "Weather can disrupt outdoor plans; keep flexible hot springs, food, and scenic backup days."
         ],
@@ -101,8 +111,150 @@ _TEMPLATES = [
         base_comfort=78,
         food_score=76,
         crowd_risk=42,
-        tags={"beach", "nature", "adventure", "short-flight", "water", "chill"},
+        tags={
+            "belize",
+            "caribbean",
+            "beach",
+            "nature",
+            "adventure",
+            "short-flight",
+            "water",
+            "reef",
+            "snorkel",
+            "snorkeling",
+            "chill",
+        },
         risks=["Extra hops to islands can eat time; keep the route simple for only six days."],
+    ),
+    _ConceptTemplate(
+        concept_id="cayman-reef-food-easy-week",
+        title="Cayman Reef + Food Easy Week",
+        countries=["Cayman Islands"],
+        destinations=["Seven Mile Beach", "West Bay", "Stingray City or Rum Point"],
+        recommended_duration_days=7,
+        best_season="winter or spring, including March break if prices are acceptable",
+        estimated_cost_band_cad="CAD 18k-32k for family of 5 before exact flights, lodging, and activities",
+        estimated_flight_hours=4.2,
+        direct_flight_friendliness=8,
+        base_family_fit=84,
+        base_comfort=86,
+        food_score=82,
+        crowd_risk=50,
+        tags={
+            "cayman",
+            "cayman islands",
+            "caribbean",
+            "beach",
+            "water",
+            "reef",
+            "snorkel",
+            "snorkeling",
+            "food",
+            "family",
+            "low-friction",
+            "short-flight",
+            "chill",
+        },
+        risks=[
+            "March break pricing can be high; value needs live validation.",
+            "Use smaller operators and beach timing to avoid crowded excursion windows.",
+        ],
+    ),
+    _ConceptTemplate(
+        concept_id="curacao-color-beach-drivable-short",
+        title="Curacao Color + Beach Base",
+        countries=["Curacao"],
+        destinations=["Willemstad", "Westpunt beaches", "Klein Curacao optional"],
+        recommended_duration_days=6,
+        best_season="winter, spring, or early fall outside peak holiday pricing",
+        estimated_cost_band_cad="CAD 9k-17k for a couple before final flights, lodging, and car",
+        estimated_flight_hours=5.8,
+        direct_flight_friendliness=7,
+        base_family_fit=78,
+        base_comfort=78,
+        food_score=76,
+        crowd_risk=40,
+        tags={
+            "curacao",
+            "curaçao",
+            "caribbean",
+            "beach",
+            "island",
+            "water",
+            "reef",
+            "snorkel",
+            "snorkeling",
+            "drivable",
+            "colorful",
+            "chill",
+            "rental",
+        },
+        risks=[
+            "Historical notes are mixed: colorful and drivable, but theft/safety, cost, and food consistency need careful validation.",
+            "Do not leave valuables in a car at beaches; lodging location and parking security matter.",
+        ],
+    ),
+    _ConceptTemplate(
+        concept_id="st-lucia-private-rental-food-short",
+        title="St Lucia Private Rental + Food Week",
+        countries=["St Lucia"],
+        destinations=["Soufriere", "Rodney Bay optional", "Marigot Bay optional"],
+        recommended_duration_days=6,
+        best_season="winter or spring shoulder windows",
+        estimated_cost_band_cad="CAD 10k-18k for a couple before exact villa/hotel and car choices",
+        estimated_flight_hours=5.4,
+        direct_flight_friendliness=6,
+        base_family_fit=76,
+        base_comfort=74,
+        food_score=84,
+        crowd_risk=42,
+        tags={
+            "st lucia",
+            "saint lucia",
+            "caribbean",
+            "beach",
+            "island",
+            "food",
+            "rental",
+            "scenery",
+            "chill",
+        },
+        risks=[
+            "Historical prior likes food and Airbnb/private-stay upside, but hard roads are a major caution.",
+            "This only works if transfers or driving routes avoid road-stress and night-driving friction.",
+        ],
+    ),
+    _ConceptTemplate(
+        concept_id="mexico-caribbean-food-beach-short",
+        title="Mexico Caribbean Food + Beach Base",
+        countries=["Mexico"],
+        destinations=["Isla Mujeres or Puerto Morelos", "Valladolid optional"],
+        recommended_duration_days=6,
+        best_season="winter or early spring before heavy heat and seaweed risk",
+        estimated_cost_band_cad="CAD 8k-16k for a couple depending on beach lodging and dining",
+        estimated_flight_hours=4.2,
+        direct_flight_friendliness=9,
+        base_family_fit=78,
+        base_comfort=76,
+        food_score=88,
+        crowd_risk=60,
+        tags={
+            "mexico",
+            "caribbean",
+            "beach",
+            "food",
+            "short-flight",
+            "water",
+            "reef",
+            "snorkel",
+            "snorkeling",
+            "chill",
+            "value",
+        },
+        risks=[
+            "Mexico is historically strong for food, value, and weather, but safety, crowding, and beach/seaweed conditions vary sharply by area.",
+            "Avoid overbuilt resort zones unless convenience clearly beats the crowd exposure.",
+        ],
     ),
     _ConceptTemplate(
         concept_id="portugal-food-cities-coast",
@@ -207,7 +359,11 @@ class TripIdeationService:
         self._country_priors = CountryPriorService()
 
     def compare(self, request: TripIdeaRequest, *, limit: int = 5) -> TripComparison:
-        concepts = [self._score_template(template, request) for template in _TEMPLATES]
+        region_intents = _explicit_region_intents(request)
+        experience_intents = _required_experience_intents(request)
+        templates = _region_filtered_templates(_TEMPLATES, region_intents)
+        templates = _experience_filtered_templates(templates, experience_intents)
+        concepts = [self._score_template(template, request) for template in templates]
         filtered = _duration_filtered_concepts(concepts, request, limit)
         if filtered:
             concepts = filtered
@@ -223,12 +379,32 @@ class TripIdeationService:
                 0,
                 f"Requested duration is {request.duration_days} day(s); suggestions are duration-fit first, not generic best trips.",
             )
-        return TripComparison(
+        if region_intents:
+            scoring_notes.insert(
+                0,
+                f"Explicit destination intent detected: {', '.join(sorted(region_intents))}. Off-region concepts are excluded before scoring.",
+            )
+        if experience_intents:
+            scoring_notes.insert(
+                0,
+                f"Required experience detected: {', '.join(sorted(experience_intents))}. Concepts without that experience are excluded before scoring.",
+            )
+        comparison = TripComparison(
             request=request,
             concepts=ranked,
             recommended_concept_id=recommendation,
             scoring_notes=scoring_notes,
         )
+        comparison.advisor = (
+            PlanningAdvisorService(
+                preferences=self._prefs,
+                memory=self._memory,
+                enabled=False,
+            )
+            .advise_trip_ideas(request, comparison)
+            .model_dump(mode="json")
+        )
+        return comparison
 
     def _score_template(self, template: _ConceptTemplate, request: TripIdeaRequest) -> TripConcept:
         score = template.base_family_fit + template.base_comfort + template.food_score
@@ -257,6 +433,17 @@ class TripIdeationService:
         score += len(matched_goals) * 8
         if matched_goals:
             rationale.append(f"Matches requested goals: {', '.join(sorted(matched_goals))}.")
+        experience_intents = _required_experience_intents(request)
+        matched_experiences = {
+            intent
+            for intent in experience_intents
+            if _template_matches_experience(template, intent)
+        }
+        if matched_experiences:
+            score += len(matched_experiences) * 18
+            rationale.append(
+                f"Matches required experience: {', '.join(sorted(matched_experiences))}."
+            )
 
         if request.duration_days:
             diff = abs(request.duration_days - template.recommended_duration_days)
@@ -343,6 +530,126 @@ def _travel_burden(flight_hours: float) -> str:
     if flight_hours <= 9:
         return "meaningful"
     return "high"
+
+
+def _explicit_region_intents(request: TripIdeaRequest) -> set[str]:
+    text = _request_text(request)
+    intents: set[str] = set()
+    if any(
+        term in text
+        for term in (
+            "caribbean",
+            "carribean",
+            "carribbean",
+            "west indies",
+            "antilles",
+        )
+    ):
+        intents.add("caribbean")
+    if "azores" in text:
+        intents.add("azores")
+    if "portugal" in text:
+        intents.add("portugal")
+    return intents
+
+
+def _region_filtered_templates(
+    templates: list[_ConceptTemplate],
+    region_intents: set[str],
+) -> list[_ConceptTemplate]:
+    if not region_intents:
+        return templates
+    matched = [
+        template
+        for template in templates
+        if all(_template_matches_region(template, intent) for intent in region_intents)
+    ]
+    return matched or templates
+
+
+def _template_matches_region(template: _ConceptTemplate, intent: str) -> bool:
+    haystack = _template_text(template)
+    if intent == "caribbean":
+        return "caribbean" in template.tags or any(
+            term in haystack
+            for term in (
+                "belize",
+                "curacao",
+                "curaçao",
+                "st lucia",
+                "saint lucia",
+                "st maarten",
+                "saint martin",
+                "st kitts",
+                "st thomas",
+                "cuba",
+                "dominican",
+                "barbados",
+                "jamaica",
+                "aruba",
+                "bonaire",
+                "puerto rico",
+                "isla mujeres",
+                "cancun",
+                "riviera maya",
+            )
+        )
+    return intent in template.tags or intent in haystack
+
+
+def _required_experience_intents(request: TripIdeaRequest) -> set[str]:
+    text = _request_text(request)
+    intents: set[str] = set()
+    if any(term in text for term in ("snorkel", "snorkeling", "snorkelling", "snorkling", "reef")):
+        intents.add("snorkeling")
+    if any(term in text for term in ("beach", "water", "swim", "ocean")):
+        intents.add("beach_water")
+    return intents
+
+
+def _experience_filtered_templates(
+    templates: list[_ConceptTemplate],
+    experience_intents: set[str],
+) -> list[_ConceptTemplate]:
+    if not experience_intents:
+        return templates
+    matched = [
+        template
+        for template in templates
+        if all(_template_matches_experience(template, intent) for intent in experience_intents)
+    ]
+    return matched or templates
+
+
+def _template_matches_experience(template: _ConceptTemplate, intent: str) -> bool:
+    if intent == "snorkeling":
+        return bool(template.tags & {"snorkel", "snorkeling", "reef"})
+    if intent == "beach_water":
+        return bool(template.tags & {"beach", "water", "reef", "snorkel", "snorkeling"})
+    return intent in template.tags
+
+
+def _request_text(request: TripIdeaRequest) -> str:
+    parts = [
+        request.time_of_year or "",
+        request.desired_vibe or "",
+        request.activity_level or "",
+        request.party_type or "",
+        *request.goals,
+        *request.avoid,
+    ]
+    return " ".join(parts).lower()
+
+
+def _template_text(template: _ConceptTemplate) -> str:
+    return " ".join(
+        [
+            template.title,
+            *template.countries,
+            *template.destinations,
+            *template.tags,
+        ]
+    ).lower()
 
 
 def _duration_filtered_concepts(

--- a/trippy/services/trip_ideation.py
+++ b/trippy/services/trip_ideation.py
@@ -31,6 +31,80 @@ class _ConceptTemplate:
 
 _TEMPLATES = [
     _ConceptTemplate(
+        concept_id="azores-sao-miguel-short-comfort",
+        title="Azores Sao Miguel Easy Week",
+        countries=["Portugal"],
+        destinations=["Ponta Delgada", "Furnas", "Sete Cidades"],
+        recommended_duration_days=6,
+        best_season="late summer or early fall",
+        estimated_cost_band_cad="CAD 12k-20k for a couple before final flights and lodging",
+        estimated_flight_hours=5.8,
+        direct_flight_friendliness=7,
+        base_family_fit=86,
+        base_comfort=84,
+        food_score=78,
+        crowd_risk=36,
+        tags={"nature", "food", "island", "short-flight", "low-crowd", "chill"},
+        risks=[
+            "Weather can disrupt outdoor plans; keep flexible hot springs, food, and scenic backup days."
+        ],
+    ),
+    _ConceptTemplate(
+        concept_id="quebec-city-montreal-food-short",
+        title="Quebec City + Montreal Food Long Weekend",
+        countries=["Canada"],
+        destinations=["Montreal", "Quebec City"],
+        recommended_duration_days=5,
+        best_season="summer or fall",
+        estimated_cost_band_cad="CAD 5k-10k for a couple depending on hotels and dining",
+        estimated_flight_hours=1.5,
+        direct_flight_friendliness=10,
+        base_family_fit=84,
+        base_comfort=88,
+        food_score=90,
+        crowd_risk=45,
+        tags={"food", "culture", "city", "walkable", "short-flight", "low-friction"},
+        risks=[
+            "Old Quebec can feel crowded in peak windows; pick shoulder dates and central lodging."
+        ],
+    ),
+    _ConceptTemplate(
+        concept_id="mexico-city-food-short",
+        title="Mexico City Food + Neighborhoods",
+        countries=["Mexico"],
+        destinations=["Roma Norte", "Condesa", "Centro or Polanco"],
+        recommended_duration_days=6,
+        best_season="winter or early spring",
+        estimated_cost_band_cad="CAD 8k-15k for a couple depending on dining and hotel level",
+        estimated_flight_hours=5.0,
+        direct_flight_friendliness=8,
+        base_family_fit=80,
+        base_comfort=82,
+        food_score=97,
+        crowd_risk=55,
+        tags={"food", "culture", "city", "walkable", "short-flight"},
+        risks=[
+            "Neighborhood choice and private transfers matter; avoid turning this into a stressful driving trip."
+        ],
+    ),
+    _ConceptTemplate(
+        concept_id="belize-reef-jungle-short",
+        title="Belize Reef + Easy Adventure",
+        countries=["Belize"],
+        destinations=["Ambergris Caye or Caye Caulker", "San Ignacio optional"],
+        recommended_duration_days=6,
+        best_season="winter or spring dry season",
+        estimated_cost_band_cad="CAD 9k-18k for a couple before final tours and lodging",
+        estimated_flight_hours=4.8,
+        direct_flight_friendliness=6,
+        base_family_fit=82,
+        base_comfort=78,
+        food_score=76,
+        crowd_risk=42,
+        tags={"beach", "nature", "adventure", "short-flight", "water", "chill"},
+        risks=["Extra hops to islands can eat time; keep the route simple for only six days."],
+    ),
+    _ConceptTemplate(
         concept_id="portugal-food-cities-coast",
         title="Portugal Food Cities + Coast",
         countries=["Portugal"],
@@ -134,23 +208,33 @@ class TripIdeationService:
 
     def compare(self, request: TripIdeaRequest, *, limit: int = 5) -> TripComparison:
         concepts = [self._score_template(template, request) for template in _TEMPLATES]
+        filtered = _duration_filtered_concepts(concepts, request, limit)
+        if filtered:
+            concepts = filtered
         ranked = sorted(concepts, key=lambda concept: concept.total_score, reverse=True)[:limit]
         recommendation = ranked[0].concept_id if ranked else None
+        scoring_notes = [
+            "Scores are deterministic first-pass estimates, not live prices or availability.",
+            "Visa, entry, vaccination, exact fare, and listing availability require live research before booking.",
+            "Family smoothness, central lodging, food access, bed fit, and crowd/transport friction are weighted above raw price.",
+        ]
+        if request.duration_days:
+            scoring_notes.insert(
+                0,
+                f"Requested duration is {request.duration_days} day(s); suggestions are duration-fit first, not generic best trips.",
+            )
         return TripComparison(
             request=request,
             concepts=ranked,
             recommended_concept_id=recommendation,
-            scoring_notes=[
-                "Scores are deterministic first-pass estimates, not live prices or availability.",
-                "Visa, entry, vaccination, exact fare, and listing availability require live research before booking.",
-                "Family smoothness, central lodging, food access, bed fit, and crowd/transport friction are weighted above raw price.",
-            ],
+            scoring_notes=scoring_notes,
         )
 
     def _score_template(self, template: _ConceptTemplate, request: TripIdeaRequest) -> TripConcept:
         score = template.base_family_fit + template.base_comfort + template.food_score
+        party_label = "family" if request.travelers >= 3 else "couple"
         rationale = [
-            "Fits comfort-first family travel better than lowest-price optimization.",
+            f"Fits comfort-first {party_label} travel better than lowest-price optimization.",
             "Food access is scored as a major trip objective.",
         ]
         why_not = list(template.risks)
@@ -176,12 +260,22 @@ class TripIdeationService:
 
         if request.duration_days:
             diff = abs(request.duration_days - template.recommended_duration_days)
-            if diff <= 2:
-                score += 12
-                rationale.append("Duration is close to the recommended pacing.")
+            if diff == 0:
+                score += 18
+                rationale.append("Duration matches the requested trip length.")
+            elif diff <= 1:
+                score += 10
+                rationale.append("Duration is close to the requested trip length.")
+            elif diff <= 2:
+                score += 4
+                rationale.append("Duration is workable but needs pacing discipline.")
             elif request.duration_days < template.recommended_duration_days:
-                score -= 14
-                why_not.append("Requested duration may compress the itinerary too much.")
+                score -= 20 + (template.recommended_duration_days - request.duration_days) * 8
+                why_not.append(
+                    f"Ideal version is {template.recommended_duration_days} days, which does not respect the requested {request.duration_days}-day constraint without cutting scope."
+                )
+            else:
+                score -= diff * 2
 
         if request.max_flight_hours and template.estimated_flight_hours > request.max_flight_hours:
             penalty = int((template.estimated_flight_hours - request.max_flight_hours) * 4)
@@ -249,3 +343,24 @@ def _travel_burden(flight_hours: float) -> str:
     if flight_hours <= 9:
         return "meaningful"
     return "high"
+
+
+def _duration_filtered_concepts(
+    concepts: list[TripConcept],
+    request: TripIdeaRequest,
+    limit: int,
+) -> list[TripConcept]:
+    """Prefer concepts that fit the requested trip length before generic ranking.
+
+    If the user asks for six days, a nine- or ten-day concept should not show up
+    just because it scores well on food or country priors. Longer concepts are
+    only allowed back in when there are not enough duration-fit ideas.
+    """
+    if not request.duration_days:
+        return []
+    tolerance = 0 if request.duration_days <= 6 else 1 if request.duration_days <= 8 else 2
+    max_days = request.duration_days + tolerance
+    duration_fit = [
+        concept for concept in concepts if concept.recommended_duration_days <= max_days
+    ]
+    return duration_fit if len(duration_fit) >= limit else []

--- a/trippy/services/trip_management.py
+++ b/trippy/services/trip_management.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from trippy import config
 from trippy.models.shortlists import ShortlistCategory
 from trippy.services.shortlist_store import ShortlistStore
+from trippy.services.trip_execution import TripExecutionService
 from trippy.services.trip_intake import TripIntakeService
 from trippy.services.trip_planner import TripPlannerService
 from trippy.services.trip_state import TripStateService
@@ -29,12 +30,16 @@ class TripManagementService:
         workspace_service: TripWorkspaceService | None = None,
         trip_state: TripStateService | None = None,
         shortlist_store: ShortlistStore | None = None,
+        execution_service: TripExecutionService | None = None,
     ) -> None:
         self._intakes = intake_service or TripIntakeService()
         self._planner = planner_service or TripPlannerService(self._intakes)
         self._workspace = workspace_service or TripWorkspaceService(self._intakes, self._planner)
         self._trip_state = trip_state or TripStateService()
         self._shortlists = shortlist_store or ShortlistStore()
+        self._execution = execution_service or TripExecutionService(
+            shortlist_store=self._shortlists
+        )
 
     def delete_trip(self, trip_id: str) -> dict[str, object]:
         """Delete local planning state for a trip and return a diagnostic summary."""
@@ -44,6 +49,7 @@ class TripManagementService:
         self._delete_path(self._intakes.path_for(trip_id), deleted, missing)
         self._delete_path(self._planner.path_for(trip_id), deleted, missing)
         self._delete_path(self._workspace.path_for(trip_id), deleted, missing)
+        self._delete_path(self._execution.path_for(trip_id), deleted, missing_if_absent=False)
 
         canonical_path = config.TRIPS_PATH / f"{trip_id}.json"
         if self._trip_state.delete(trip_id):

--- a/trippy/services/trip_map_builder.py
+++ b/trippy/services/trip_map_builder.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import csv
 import html
+import io
 import json
 from pathlib import Path
 from urllib.parse import quote_plus
 
 from trippy.models.maps import MapPin, MapPinCategory, MapRoute, MapRouteMode, TripMapArtifact
+from trippy.models.shortlists import ResearchShortlistState, ShortlistCategory, ShortlistRowStatus
 from trippy.models.trip_planning import TripPlanOption
+from trippy.services.shortlist_store import ShortlistStore
 from trippy.services.trip_intake import TripIntakeService
 from trippy.services.trip_planner import TripPlannerService
 
@@ -31,18 +35,25 @@ class TripMapBuilder:
         if option is None:
             raise ValueError(f"No selected or recommended plan option for trip {trip_id!r}")
 
-        pins = _pins_for_option(option)
-        routes = _routes_for_option(option)
+        shortlists = {state.category: state for state in ShortlistStore().load_all(trip_id)}
+        pins = _ordered_pins([*_pins_for_shortlists(shortlists), *_pins_for_option(option)])
+        primary_route = _primary_route_for_pins(pins)
+        routes = (
+            [primary_route, *_routes_for_option(option)]
+            if primary_route
+            else _routes_for_option(option)
+        )
         return TripMapArtifact(
             trip_id=trip_id,
             title=f"{intake.trip_name} Planning Map",
+            primary_google_maps_url=primary_route.google_maps_url if primary_route else None,
             pins=pins,
             routes=routes,
             day_groups=_groups(pins, routes),
             notes=[
-                "Map artifacts use Google Maps search/directions links and import-friendly KML/GeoJSON.",
-                "Coordinates are not guessed; geocoding/My Maps import should resolve exact pins later.",
-                "Use these maps to compare geography, drive load, food clusters, and activity grouping before booking.",
+                "The primary Google Maps route is the single ordered map preview for this trip.",
+                "The KML/CSV exports are Google My Maps-compatible and keep every pin numbered in planning order.",
+                "Coordinates are not guessed; Google My Maps should resolve exact pins during import.",
             ],
         )
 
@@ -58,13 +69,18 @@ class TripMapBuilder:
         json_path = output_dir / f"{trip_id}-planning-map.json"
         geojson_path = output_dir / f"{trip_id}-planning-map.geojson"
         kml_path = output_dir / f"{trip_id}-planning-map.kml"
+        csv_path = output_dir / f"{trip_id}-planning-map.csv"
         json_path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
         geojson_path.write_text(json.dumps(artifact.to_geojson(), indent=2), encoding="utf-8")
         kml_path.write_text(_to_kml(artifact), encoding="utf-8")
+        csv_path.write_text(_to_csv(artifact), encoding="utf-8")
         artifact.exports = {
             "json": str(json_path),
             "geojson": str(geojson_path),
             "kml": str(kml_path),
+            "csv": str(csv_path),
+            "google_maps_route": artifact.primary_google_maps_url or "",
+            "google_my_maps": artifact.google_my_maps_url,
         }
         json_path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
         return artifact
@@ -75,12 +91,112 @@ def _pins_for_option(option: TripPlanOption) -> list[MapPin]:
     for query in _dedupe(_expanded_queries(option)):
         pins.append(
             MapPin(
-                pin_id=f"pin-{len(pins) + 1}",
+                pin_id="",
                 label=_label(query),
                 category=_category(query),
                 query=query,
                 google_maps_url=_maps_search_url(query),
                 notes=_pin_notes(query, option),
+            )
+        )
+    return pins
+
+
+def _pins_for_shortlists(
+    shortlists: dict[ShortlistCategory, ResearchShortlistState],
+) -> list[MapPin]:
+    pins: list[MapPin] = []
+    flights = shortlists.get(ShortlistCategory.FLIGHTS)
+    flight = _chosen_option(getattr(flights, "flight_options", []), flights)
+    if flight is not None:
+        departure = str(getattr(flight, "departure_airport", "")).strip()
+        arrival = str(getattr(flight, "arrival_airport", "")).strip()
+        if departure:
+            pins.append(
+                _pin(
+                    label=f"Depart {departure}",
+                    category=MapPinCategory.AIRPORT,
+                    query=_airport_query(departure),
+                    source_id=str(getattr(flight, "option_id", "")) or None,
+                    notes="Selected or recommended departure airport.",
+                    day_index=1,
+                )
+            )
+        if arrival:
+            pins.append(
+                _pin(
+                    label=f"Arrive {arrival}",
+                    category=MapPinCategory.AIRPORT,
+                    query=_airport_query(arrival),
+                    source_id=str(getattr(flight, "option_id", "")) or None,
+                    notes="Selected or recommended arrival airport.",
+                    day_index=1,
+                )
+            )
+
+    lodging = shortlists.get(ShortlistCategory.LODGING)
+    for option in _map_options(getattr(lodging, "lodging_options", []), lodging, limit=6):
+        query = ", ".join(
+            part
+            for part in [
+                str(getattr(option, "name", "")).strip(),
+                str(getattr(option, "location_area", "")).strip(),
+                str(getattr(option, "island_or_region", "")).strip(),
+            ]
+            if part
+        )
+        if not query:
+            continue
+        pins.append(
+            _pin(
+                label=f"Stay: {getattr(option, 'name', 'Lodging')}",
+                category=MapPinCategory.LODGING,
+                query=query,
+                source_id=str(getattr(option, "option_id", "")) or None,
+                notes=str(getattr(option, "comfort_fit", "") or getattr(option, "price_band", "")),
+                day_index=1,
+            )
+        )
+
+    cars = shortlists.get(ShortlistCategory.CARS)
+    car = _chosen_option(getattr(cars, "car_options", []), cars)
+    if car is not None:
+        for label, query in (
+            ("Car pickup", str(getattr(car, "pickup_location", "")).strip()),
+            ("Car dropoff", str(getattr(car, "dropoff_location", "")).strip()),
+        ):
+            if query:
+                pins.append(
+                    _pin(
+                        label=label,
+                        category=MapPinCategory.TRANSFER,
+                        query=query,
+                        source_id=str(getattr(car, "option_id", "")) or None,
+                        notes=str(getattr(car, "vehicle_class", "") or "Car rental logistics."),
+                        day_index=1 if "pickup" in label.lower() else None,
+                    )
+                )
+
+    activities = shortlists.get(ShortlistCategory.ACTIVITIES)
+    for option in _map_options(getattr(activities, "activity_options", []), activities, limit=12):
+        name = str(getattr(option, "activity_name", "")).strip()
+        location = str(getattr(option, "island_location", "")).strip()
+        query = ", ".join(part for part in [name, location] if part)
+        if not query:
+            continue
+        pins.append(
+            _pin(
+                label=f"Activity: {name}",
+                category=MapPinCategory.ACTIVITY,
+                query=query,
+                source_id=str(getattr(option, "option_id", "")) or None,
+                notes=str(
+                    getattr(option, "scheduling_rationale", "")
+                    or getattr(option, "review_safety_signal", "")
+                    or "Activity candidate."
+                ),
+                day_index=getattr(option, "scheduled_day", None)
+                or getattr(option, "suggested_day", None),
             )
         )
     return pins
@@ -134,6 +250,159 @@ def _routes_for_option(option: TripPlanOption) -> list[MapRoute]:
             )
         )
     return routes
+
+
+def _pin(
+    *,
+    label: str,
+    category: MapPinCategory,
+    query: str,
+    notes: str,
+    source_id: str | None = None,
+    day_index: int | None = None,
+) -> MapPin:
+    return MapPin(
+        pin_id="",
+        label=label,
+        category=category,
+        query=query,
+        google_maps_url=_maps_search_url(query),
+        source_id=source_id,
+        notes=notes,
+        day_index=day_index,
+    )
+
+
+def _chosen_option(options: list[object], state: ResearchShortlistState | None) -> object | None:
+    if not options:
+        return None
+    approved = [
+        option
+        for option in options
+        if getattr(option, "row_status", None) == ShortlistRowStatus.APPROVED
+    ]
+    if approved:
+        return sorted(approved, key=lambda option: int(getattr(option, "rank", 999)))[0]
+    recommended_id = getattr(state, "recommended_option_id", None)
+    if recommended_id:
+        for option in options:
+            if getattr(option, "option_id", None) == recommended_id:
+                return option
+    return sorted(options, key=lambda option: int(getattr(option, "rank", 999)))[0]
+
+
+def _map_options(
+    options: list[object],
+    state: ResearchShortlistState | None,
+    *,
+    limit: int,
+) -> list[object]:
+    if not options:
+        return []
+    recommended_id = getattr(state, "recommended_option_id", None)
+
+    def sort_key(option: object) -> tuple[int, int]:
+        status = getattr(option, "row_status", None)
+        option_id = getattr(option, "option_id", None)
+        if status == ShortlistRowStatus.APPROVED:
+            priority = 0
+        elif recommended_id and option_id == recommended_id:
+            priority = 1
+        else:
+            priority = 2
+        return (priority, int(getattr(option, "rank", 999)))
+
+    filtered = [
+        option
+        for option in options
+        if getattr(option, "row_status", None) != ShortlistRowStatus.REJECTED
+    ]
+    return sorted(filtered, key=sort_key)[:limit]
+
+
+def _ordered_pins(pins: list[MapPin]) -> list[MapPin]:
+    deduped: list[MapPin] = []
+    seen: set[str] = set()
+    for pin in pins:
+        key = " ".join(pin.query.lower().split())
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(pin)
+
+    ordered = sorted(
+        enumerate(deduped),
+        key=lambda item: (
+            item[1].day_index if item[1].day_index is not None else 999,
+            _category_order(item[1].category),
+            item[0],
+        ),
+    )
+    numbered: list[MapPin] = []
+    for index, (_, pin) in enumerate(ordered, start=1):
+        numbered.append(
+            pin.model_copy(
+                update={
+                    "pin_id": f"pin-{index:02d}",
+                    "label": f"{index:02d} · {_strip_order_prefix(pin.label)}",
+                }
+            )
+        )
+    return numbered
+
+
+def _category_order(category: MapPinCategory) -> int:
+    order = {
+        MapPinCategory.AIRPORT: 10,
+        MapPinCategory.LODGING: 20,
+        MapPinCategory.TRANSFER: 30,
+        MapPinCategory.ACTIVITY: 40,
+        MapPinCategory.FOOD: 50,
+        MapPinCategory.LOGISTICS: 60,
+        MapPinCategory.OTHER: 70,
+    }
+    return order.get(category, 99)
+
+
+def _strip_order_prefix(label: str) -> str:
+    parts = label.split(" · ", 1)
+    if len(parts) == 2 and parts[0].isdigit():
+        return parts[1]
+    return label
+
+
+def _primary_route_for_pins(pins: list[MapPin]) -> MapRoute | None:
+    route_pins = [
+        pin
+        for pin in pins
+        if pin.category
+        in {
+            MapPinCategory.AIRPORT,
+            MapPinCategory.LODGING,
+            MapPinCategory.TRANSFER,
+            MapPinCategory.ACTIVITY,
+            MapPinCategory.FOOD,
+            MapPinCategory.LOGISTICS,
+        }
+    ]
+    if len(route_pins) < 2:
+        return None
+    route_pins = route_pins[:10]
+    origin = route_pins[0].query
+    destination = route_pins[-1].query
+    waypoints = [pin.query for pin in route_pins[1:-1]]
+    return MapRoute(
+        route_id="route-primary",
+        label="Single ordered Google Map",
+        origin_query=origin,
+        destination_query=destination,
+        google_maps_url=_directions_url(origin, destination, MapRouteMode.DRIVING, waypoints),
+        mode=MapRouteMode.DRIVING,
+        notes=(
+            "Opens the current trip points in planning order. "
+            "Use the KML/CSV export for a full Google My Maps import with every numbered pin."
+        ),
+    )
 
 
 def _expanded_queries(option: TripPlanOption) -> list[str]:
@@ -224,13 +493,28 @@ def _maps_search_url(query: str) -> str:
     return f"https://www.google.com/maps/search/?api=1&query={quote_plus(query)}"
 
 
-def _directions_url(origin: str, destination: str, mode: MapRouteMode) -> str:
-    return (
+def _airport_query(code_or_city: str) -> str:
+    value = code_or_city.strip()
+    if len(value) == 3 and value.isalpha():
+        return f"{value.upper()} airport"
+    return value
+
+
+def _directions_url(
+    origin: str,
+    destination: str,
+    mode: MapRouteMode,
+    waypoints: list[str] | None = None,
+) -> str:
+    url = (
         "https://www.google.com/maps/dir/?api=1"
         f"&origin={quote_plus(origin)}"
         f"&destination={quote_plus(destination)}"
         f"&travelmode={mode.value}"
     )
+    if waypoints:
+        url += f"&waypoints={quote_plus('|'.join(waypoints))}"
+    return url
 
 
 def _to_kml(artifact: TripMapArtifact) -> str:
@@ -259,6 +543,35 @@ def _to_kml(artifact: TripMapArtifact) -> str:
             "",
         ]
     )
+
+
+def _to_csv(artifact: TripMapArtifact) -> str:
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        [
+            "Sequence",
+            "Label",
+            "Category",
+            "Day",
+            "Search Query",
+            "Notes",
+            "Google Maps URL",
+        ]
+    )
+    for index, pin in enumerate(artifact.pins, start=1):
+        writer.writerow(
+            [
+                f"{index:02d}",
+                _strip_order_prefix(pin.label),
+                pin.category.value,
+                pin.day_index or "",
+                pin.address or pin.query,
+                pin.notes or "",
+                pin.google_maps_url,
+            ]
+        )
+    return output.getvalue()
 
 
 def _dedupe(items: list[str]) -> list[str]:

--- a/trippy/services/trip_planner.py
+++ b/trippy/services/trip_planner.py
@@ -13,6 +13,7 @@ from trippy.models.trip_planning import (
     TripPlanOption,
 )
 from trippy.services.country_priors import CountryPriorService
+from trippy.services.planning_advisor import PlanningAdvisorService
 from trippy.services.trip_ideation import TripIdeationService
 from trippy.services.trip_intake import TripIntakeService
 
@@ -40,6 +41,14 @@ class TripPlannerService:
     def draft(self, trip_id: str) -> TripPlanDraft:
         intake = self._intakes.require(trip_id)
         draft = self._build_draft(intake)
+        draft.advisor = (
+            PlanningAdvisorService(enabled=False)
+            .advise_trip_shape(
+                intake,
+                draft,
+            )
+            .model_dump(mode="json")
+        )
         self.save_draft(draft)
         return draft
 
@@ -53,7 +62,7 @@ class TripPlannerService:
         if not path.exists():
             return None
         data = json.loads(path.read_text(encoding="utf-8"))
-        return TripPlanDraft.model_validate(data)
+        return _normalize_loaded_draft(TripPlanDraft.model_validate(data))
 
     def require_draft(self, trip_id: str) -> TripPlanDraft:
         draft = self.load_draft(trip_id)
@@ -111,6 +120,9 @@ class TripPlannerService:
                 duration_days=intake.duration_days,
                 budget_cad=intake.budget_cad,
                 travelers=intake.party.total_travelers,
+                party_type=intake.party.party_type.value,
+                adults=intake.party.adults,
+                children=intake.party.children,
                 max_flight_hours=intake.max_travel_time_hours,
                 direct_flight_preferred=intake.flight_preferences.prefer_direct,
                 goals=intake.goals,
@@ -157,7 +169,11 @@ class TripPlannerService:
 
     def _build_generic_selected_destination_draft(self, intake: TripIntake) -> TripPlanDraft:
         duration = intake.duration_days or 8
-        destination = ", ".join(intake.destination_seeds)
+        destination = ", ".join(intake.destination_seeds) or intake.trip_name or "Destination"
+        single_base_region = (
+            intake.destination_seeds[0] if intake.destination_seeds else destination
+        )
+        balanced_regions = intake.destination_seeds[:2] or [single_base_region]
         signals = [
             signal.rationale
             for seed in intake.destination_seeds
@@ -170,11 +186,11 @@ class TripPlannerService:
         options = [
             TripPlanOption(
                 option_id="single-base-easy",
-                title=f"{destination} Single-Base Easy Version",
+                title=f"{single_base_region} Single-Base Easy Version",
                 summary="Minimize logistics by choosing one strong home base and doing selective day trips.",
                 duration_days=duration,
-                regions=intake.destination_seeds,
-                nights_by_region=_even_nights(intake.destination_seeds, duration),
+                regions=[single_base_region],
+                nights_by_region={single_base_region: max(1, duration - 1)},
                 rationale=[
                     f"Lowest movement friction and easiest to make comfortable for {intake.party.summary()}.",
                     "Best first draft when exact transport and lodging options are not yet validated.",
@@ -202,10 +218,8 @@ class TripPlannerService:
                 title=f"{destination} Two-Region Balanced Version",
                 summary="Use two bases to improve coverage while preserving downtime.",
                 duration_days=duration,
-                regions=intake.destination_seeds,
-                nights_by_region=_even_nights(
-                    intake.destination_seeds[:2] or intake.destination_seeds, duration
-                ),
+                regions=balanced_regions,
+                nights_by_region=_even_nights(balanced_regions, duration),
                 rationale=[
                     "Balances depth with a broader sense of place.",
                     "Usually the best pattern if the trip is at least 8-10 days.",
@@ -411,6 +425,24 @@ def _even_nights(regions: list[str], duration_days: int) -> dict[str, int]:
     base = nights // len(regions)
     extra = nights % len(regions)
     return {region: base + (1 if idx < extra else 0) for idx, region in enumerate(regions)}
+
+
+def _normalize_loaded_draft(draft: TripPlanDraft) -> TripPlanDraft:
+    """Repair older generic drafts whose labels and stay regions disagreed."""
+    for option in draft.options:
+        if option.option_id == "single-base-easy" and len(option.regions) > 1:
+            primary = option.regions[0]
+            total_nights = sum(option.nights_by_region.values()) or max(
+                1, option.duration_days - 1
+            )
+            option.title = option.title.replace(
+                ", ".join(option.regions), primary, 1
+            )
+            option.regions = [primary]
+            option.nights_by_region = {primary: total_nights}
+        if option.option_id == "two-region-balanced" and option.nights_by_region:
+            option.regions = list(option.nights_by_region)
+    return draft
 
 
 def _required_research() -> list[str]:

--- a/trippy/services/trip_workspace.py
+++ b/trippy/services/trip_workspace.py
@@ -23,6 +23,12 @@ from trippy.models.trip import (
     Trip,
     TripStatus,
 )
+from trippy.models.trip_execution import (
+    ExecutionCategory,
+    ExecutionStatus,
+    TripPacketItem,
+    TripPacketState,
+)
 from trippy.models.trip_planning import (
     TripIntake,
     TripPlanDraft,
@@ -94,6 +100,7 @@ class TripWorkspaceService:
             self._planner,
             validate_live=validate_live,
         )
+        packet = _load_trip_packet(intake.trip_id)
         trip = self._build_canonical_trip(intake, option, shortlists)
         if existing_sync is not None:
             trip.sync = existing_sync.model_copy(deep=True)
@@ -111,6 +118,7 @@ class TripWorkspaceService:
             trip,
             validate_live=validate_live,
             shortlists=shortlists,
+            packet=packet,
         )
 
         state = TripWorkspaceState(
@@ -263,6 +271,7 @@ class TripWorkspaceService:
         *,
         validate_live: bool | None = None,
         shortlists: dict[str, Any] | None = None,
+        packet: TripPacketState | None = None,
     ) -> list[WorkspaceTab]:
         if shortlists is None:
             shortlists = _load_or_build_shortlists(
@@ -272,11 +281,13 @@ class TripWorkspaceService:
                 validate_live=validate_live,
             )
         map_artifact = _build_planning_map(intake.trip_id, self._intakes, self._planner)
+        if packet is None:
+            packet = _load_trip_packet(intake.trip_id)
         return [
             WorkspaceTab(
                 name="Overview",
                 headers=["Field", "Value"],
-                rows=_overview_rows(intake, option, shortlists, trip),
+                rows=_overview_rows(intake, option, shortlists, trip, packet),
             ),
             WorkspaceTab(
                 name="Master Timeline",
@@ -302,7 +313,24 @@ class TripWorkspaceService:
                     "Notes",
                     "Link",
                 ],
-                rows=_timeline_rows(intake, option, shortlists),
+                rows=_timeline_rows(intake, option, shortlists, packet),
+            ),
+            WorkspaceTab(
+                name="Trip Packet",
+                headers=[
+                    "Category",
+                    "Status",
+                    "Title",
+                    "Provider",
+                    "Confirmation",
+                    "Date",
+                    "Time",
+                    "Address",
+                    "Cost CAD",
+                    "Booking Link",
+                    "Notes",
+                ],
+                rows=_trip_packet_rows(packet, shortlists),
             ),
             WorkspaceTab(
                 name="Plan Options",
@@ -340,8 +368,11 @@ class TripWorkspaceService:
                     "Recommended",
                     "Recommendation",
                     "Airline",
-                    "Departure",
-                    "Arrival",
+                    "Flight Numbers",
+                    "Departure Date",
+                    "Departure Time",
+                    "Arrival Date",
+                    "Arrival Time",
                     "Route",
                     "Stops",
                     "Layovers",
@@ -901,6 +932,7 @@ def _overview_rows(
     option: TripPlanOption,
     shortlists: dict[str, Any],
     trip: Trip,
+    packet: TripPacketState | None = None,
 ) -> list[list[Any]]:
     best_flight = _recommended_option(shortlists.get("flights"))
     best_lodging = _recommended_option(shortlists.get("lodging"))
@@ -915,6 +947,8 @@ def _overview_rows(
         ["Selected Option", f"{option.option_id} - {option.title}"],
         ["Selected Plan Summary", option.summary],
         ["Planning Completeness", f"{_workspace_completeness(shortlists, trip)}%"],
+        ["Trip Packet Readiness", _packet_readiness(packet)],
+        ["Trip Packet Status", packet.status_label if packet else "not started"],
         ["Destination Seeds", ", ".join(intake.destination_seeds)],
         ["Travel Window", intake.travel_window.display()],
         ["Duration", intake.duration_display()],
@@ -936,6 +970,7 @@ def _overview_rows(
         ["Best Activities", "; ".join(_option_summary(option) for option in activities)],
         ["Top Friction Warnings", "; ".join(warnings[:4])],
         ["Unresolved Blockers", "; ".join(unresolved[:5])],
+        ["Missing Confirmation Details", "; ".join((packet.missing_items if packet else [])[:5])],
         ["Next Actions", "; ".join(_workspace_next_actions(shortlists, trip)[:5])],
     ]
 
@@ -951,7 +986,10 @@ def _flight_rows(state: Any | None) -> list[list[Any]]:
                 _yes_no(option.option_id == recommended_id),
                 option.recommendation_label,
                 option.airline,
+                " + ".join(getattr(option, "flight_numbers", [])),
+                getattr(option, "departure_date", ""),
                 option.departure_time,
+                getattr(option, "arrival_date", ""),
                 option.arrival_time,
                 f"{option.departure_airport} to {option.arrival_airport}",
                 option.stops,
@@ -1164,6 +1202,104 @@ def _evidence_summary(artifacts: list[Any]) -> str:
         url = getattr(artifact, "url", "")
         values.append(path or url)
     return "; ".join(value for value in values if value)
+
+
+def _load_trip_packet(trip_id: str) -> TripPacketState | None:
+    from trippy import config
+
+    path = config.WORKSPACES_PATH / "trip_packets" / f"{trip_id}.packet.json"
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return TripPacketState.model_validate(data)
+
+
+def _trip_packet_rows(
+    packet: TripPacketState | None,
+    shortlists: dict[str, Any],
+) -> list[list[Any]]:
+    items = list(packet.items if packet else [])
+    if not items:
+        for state in shortlists.values():
+            for option in _typed_options(state):
+                row_status = getattr(getattr(option, "row_status", ""), "value", "")
+                if row_status in {"approved", "booked", "confirmed"}:
+                    items.append(
+                        TripPacketItem(
+                            item_id=f"{state.category.value}:{getattr(option, 'option_id', '')}",
+                            category=_packet_category_for_state(state),
+                            option_id=str(getattr(option, "option_id", "")),
+                            title=_option_summary(option),
+                            provider=str(
+                                getattr(option, "booking_source", "")
+                                or getattr(option, "source", "")
+                            ),
+                            status=(
+                                ExecutionStatus.CONFIRMED
+                                if row_status == "confirmed"
+                                else ExecutionStatus.BOOKED
+                                if row_status == "booked"
+                                else ExecutionStatus.SELECTED
+                            ),
+                            source_url=str(getattr(option, "deep_link", "") or ""),
+                            booking_link=str(getattr(option, "deep_link", "") or ""),
+                        )
+                    )
+    rows = [
+        [
+            item.category.value,
+            item.status.value,
+            item.title,
+            item.provider,
+            item.confirmation_code,
+            item.date,
+            _time_range(item.start_time, item.end_time),
+            item.address,
+            item.cost_cad or "",
+            item.booking_link or item.source_url,
+            item.notes,
+        ]
+        for item in items
+    ]
+    return rows or [
+        [
+            "flight",
+            "missing",
+            "No selected flight yet",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Select and book a flight, then add the confirmation code.",
+        ],
+        [
+            "lodging",
+            "missing",
+            "No selected lodging yet",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Select and book lodging, then add confirmation and check-in details.",
+        ],
+    ]
+
+
+def _packet_category_for_state(state: Any) -> ExecutionCategory:
+    category = getattr(state, "category", "")
+    value = getattr(category, "value", category)
+    return {
+        "flights": ExecutionCategory.FLIGHT,
+        "lodging": ExecutionCategory.LODGING,
+        "cars": ExecutionCategory.CAR,
+        "activities": ExecutionCategory.ACTIVITY,
+    }.get(str(value), ExecutionCategory.OTHER)
 
 
 def _car_rows(state: Any | None) -> list[list[Any]]:
@@ -1380,12 +1516,16 @@ def _timeline_rows(
     intake: TripIntake,
     option: TripPlanOption,
     shortlists: dict[str, Any],
+    packet: TripPacketState | None = None,
 ) -> list[list[Any]]:
     rows: list[list[Any]] = []
     start = intake.travel_window.start_date
     best_flight = _recommended_option(shortlists.get("flights"))
     best_car = _recommended_option(shortlists.get("cars"))
     best_lodging = _recommended_option(shortlists.get("lodging"))
+    flight_packet = _packet_item_for(packet, ExecutionCategory.FLIGHT, best_flight)
+    car_packet = _packet_item_for(packet, ExecutionCategory.CAR, best_car)
+    lodging_packet = _packet_item_for(packet, ExecutionCategory.LODGING, best_lodging)
     activities = _timeline_activity_options(shortlists.get("activities"), limit=4)
     rows.append(
         _timeline_row(
@@ -1400,11 +1540,17 @@ def _timeline_rows(
             to_value=best_flight.arrival_airport
             if best_flight is not None
             else "destination gateway",
-            provider=getattr(best_flight, "booking_source", ""),
-            status="recommended" if best_flight is not None else "seeded",
-            fixed="flexible",
-            start_time=getattr(best_flight, "departure_time", ""),
-            end_time=getattr(best_flight, "arrival_time", ""),
+            provider=_packet_provider(best_flight, flight_packet),
+            status=_packet_status(
+                "recommended" if best_flight is not None else "seeded", flight_packet
+            ),
+            fixed="fixed" if flight_packet and flight_packet.is_booked else "flexible",
+            start_time=flight_packet.start_time
+            if flight_packet
+            else getattr(best_flight, "departure_time", ""),
+            end_time=flight_packet.end_time
+            if flight_packet
+            else getattr(best_flight, "arrival_time", ""),
             travel_time=getattr(best_flight, "total_travel_duration", ""),
             buffer_after="same-day lodging/car buffer required",
             friction_flags=_combine_flags(
@@ -1416,8 +1562,9 @@ def _timeline_rows(
                 [getattr(best_flight, "recommendation_rationale", "")],
                 [getattr(best_flight, "timing_implication", "")],
                 [getattr(best_flight, "date_viability_signal", "")],
+                [_packet_notes(flight_packet)],
             ),
-            link=getattr(best_flight, "deep_link", ""),
+            link=_packet_link(best_flight, flight_packet),
         )
     )
     if best_car is not None:
@@ -1428,17 +1575,19 @@ def _timeline_rows(
                 event_type="car pickup",
                 title=f"Pick up {best_car.vehicle_class}",
                 location=best_car.pickup_location,
-                provider=best_car.booking_source,
-                status=_row_status(shortlists.get("cars"), best_car.option_id),
-                fixed="flexible",
+                provider=_packet_provider(best_car, car_packet),
+                status=_packet_status(
+                    _row_status(shortlists.get("cars"), best_car.option_id), car_packet
+                ),
+                fixed="fixed" if car_packet and car_packet.is_booked else "flexible",
                 buffer_before="after baggage/arrival",
                 friction_flags=_combine_flags(
                     best_car.friction_flags,
                     ["pickup timing must account for baggage and arrival delay"],
                 ),
                 confidence=_option_confidence(best_car),
-                notes=best_car.passenger_fit,
-                link=best_car.deep_link,
+                notes=_notes([best_car.passenger_fit], [_packet_notes(car_packet)]),
+                link=_packet_link(best_car, car_packet),
             )
         )
     cursor_day = 1
@@ -1447,6 +1596,9 @@ def _timeline_rows(
         region = str(stay["region"])
         nights = int(stay["nights"])
         linked_lodging = _lodging_for_stay(shortlists.get("lodging"), stay) or best_lodging
+        linked_packet = (
+            _packet_item_for(packet, ExecutionCategory.LODGING, linked_lodging) or lodging_packet
+        )
         rows.append(
             _timeline_row(
                 day=cursor_day,
@@ -1454,9 +1606,11 @@ def _timeline_rows(
                 event_type="lodging",
                 title=f"Check in: {region}",
                 location=region,
-                provider=_option_summary(linked_lodging),
-                status="recommended" if linked_lodging is not None else "seeded",
-                fixed="flexible",
+                provider=_packet_provider(linked_lodging, linked_packet),
+                status=_packet_status(
+                    "recommended" if linked_lodging is not None else "seeded", linked_packet
+                ),
+                fixed="fixed" if linked_packet and linked_packet.is_booked else "flexible",
                 buffer_before="avoid late-arrival access risk",
                 buffer_after=f"{nights} night(s)",
                 friction_flags=_combine_flags(
@@ -1464,11 +1618,16 @@ def _timeline_rows(
                     ["check-in time must be aligned to arrival"],
                 ),
                 confidence=_option_confidence(linked_lodging),
-                notes=str(
-                    stay.get("notes")
-                    or getattr(linked_lodging, "adult_child_fit", option.lodging_strategy)
+                notes=_notes(
+                    [
+                        str(
+                            stay.get("notes")
+                            or getattr(linked_lodging, "adult_child_fit", option.lodging_strategy)
+                        )
+                    ],
+                    [_packet_notes(linked_packet)],
                 ),
-                link=getattr(linked_lodging, "deep_link", ""),
+                link=_packet_link(linked_lodging, linked_packet),
             )
         )
         cursor_day += max(1, nights)
@@ -1494,6 +1653,7 @@ def _timeline_rows(
             activity.scheduled_date or activity.suggested_date
         ) or _add_days(start, activity_day - 1)
         activity_status = _row_status(shortlists.get("activities"), activity.option_id)
+        activity_packet = _packet_item_for(packet, ExecutionCategory.ACTIVITY, activity)
         is_scheduled = activity.row_status.value in {"approved", "booked"} or bool(
             activity.scheduled_day
         )
@@ -1506,9 +1666,13 @@ def _timeline_rows(
                 event_type="activity",
                 title=activity.activity_name,
                 location=activity.island_location,
-                provider=activity.source,
-                status=activity_status,
-                fixed=activity.scheduled_flexibility if is_scheduled else "flexible",
+                provider=_packet_provider(activity, activity_packet) or activity.source,
+                status=_packet_status(activity_status, activity_packet),
+                fixed="fixed"
+                if activity_packet and activity_packet.is_booked
+                else activity.scheduled_flexibility
+                if is_scheduled
+                else "flexible",
                 travel_time=activity.duration,
                 buffer_before="half-day slack",
                 buffer_after="downtime / meal buffer",
@@ -1523,8 +1687,9 @@ def _timeline_rows(
                     [activity.scheduling_notes],
                     [activity.scheduling_rationale],
                     [activity.age_family_fit],
+                    [_packet_notes(activity_packet)],
                 ),
-                link=activity.deep_link,
+                link=_packet_link(activity, activity_packet),
             )
         )
     rows.append(
@@ -1692,7 +1857,8 @@ def _timeline_activity_options(state: Any | None, *, limit: int) -> list[Any]:
     approved = [
         option
         for option in options
-        if getattr(getattr(option, "row_status", ""), "value", "") in {"approved", "booked"}
+        if getattr(getattr(option, "row_status", ""), "value", "")
+        in {"approved", "booked", "confirmed"}
         or getattr(option, "scheduled_day", None)
     ]
     if approved:
@@ -1719,7 +1885,8 @@ def _approved_activities(state: Any | None) -> list[Any]:
     return [
         option
         for option in getattr(state, "activity_options", [])
-        if getattr(getattr(option, "row_status", ""), "value", "") in {"approved", "booked"}
+        if getattr(getattr(option, "row_status", ""), "value", "")
+        in {"approved", "booked", "confirmed"}
         or getattr(option, "scheduled_day", None)
     ]
 
@@ -1759,6 +1926,66 @@ def _option_confidence(option: Any | None) -> str:
     return f"{validation.confidence:.0%}"
 
 
+def _packet_item_for(
+    packet: TripPacketState | None,
+    category: ExecutionCategory,
+    option: Any | None,
+) -> TripPacketItem | None:
+    if packet is None or option is None:
+        return None
+    option_id = str(getattr(option, "option_id", ""))
+    return next(
+        (
+            item
+            for item in packet.items
+            if item.category == category and item.option_id == option_id
+        ),
+        None,
+    )
+
+
+def _packet_provider(option: Any | None, packet_item: TripPacketItem | None) -> str:
+    if packet_item is not None:
+        pieces = [packet_item.provider or _option_summary(option)]
+        if packet_item.confirmation_code:
+            pieces.append(f"confirmation {packet_item.confirmation_code}")
+        return " · ".join(piece for piece in pieces if piece)
+    return (
+        str(getattr(option, "booking_source", "") or getattr(option, "source", ""))
+        if option is not None
+        else ""
+    )
+
+
+def _packet_status(default: str, packet_item: TripPacketItem | None) -> str:
+    return packet_item.status.value if packet_item is not None else default
+
+
+def _packet_notes(packet_item: TripPacketItem | None) -> str:
+    if packet_item is None:
+        return ""
+    notes = []
+    if packet_item.confirmation_code:
+        notes.append(f"confirmation {packet_item.confirmation_code}")
+    if packet_item.address:
+        notes.append(f"address {packet_item.address}")
+    if packet_item.notes:
+        notes.append(packet_item.notes)
+    return "; ".join(notes)
+
+
+def _packet_link(option: Any | None, packet_item: TripPacketItem | None) -> str:
+    if packet_item is not None:
+        return packet_item.booking_link or packet_item.source_url
+    return str(getattr(option, "deep_link", "") or "")
+
+
+def _packet_readiness(packet: TripPacketState | None) -> str:
+    if packet is None:
+        return "0% - confirmations not started"
+    return f"{packet.readiness_percent}% - {packet.status_label}"
+
+
 def _combine_flags(existing: list[str], extra: list[str]) -> str:
     return ", ".join([*existing, *extra])
 
@@ -1775,7 +2002,7 @@ def _row_status(state: Any | None, option_id: str) -> str:
             None,
         )
     row_status = getattr(getattr(option, "row_status", None), "value", "")
-    if row_status in {"approved", "booked", "rejected", "verified_live", "stale"}:
+    if row_status in {"approved", "booked", "confirmed", "rejected", "verified_live", "stale"}:
         return row_status
     if state is not None and option_id == getattr(state, "recommended_option_id", None):
         return "recommended"
@@ -1834,17 +2061,23 @@ def _party_lodging_notes(intake: TripIntake) -> str:
 
 
 def _workspace_completeness(shortlists: dict[str, Any], trip: Trip) -> int:
+    flight = _recommended_option(shortlists.get("flights"))
+    lodging = _recommended_option(shortlists.get("lodging"))
     checks = [
         bool(trip.travelers),
-        bool(trip.segments),
-        bool(trip.stays),
-        all(category in shortlists for category in ("flights", "lodging", "cars", "activities")),
-        any(
-            item.category in {"document", "logistics", "health", "money"} for item in trip.checklist
-        ),
-        bool(trip.risk_flags),
+        all(category in shortlists for category in ("flights", "lodging")),
+        _status_at_least(flight, {"approved", "booked", "confirmed"}),
+        _status_at_least(lodging, {"approved", "booked", "confirmed"}),
+        _status_at_least(flight, {"booked", "confirmed"}),
+        _status_at_least(lodging, {"booked", "confirmed"}),
+        _status_at_least(flight, {"confirmed"}),
+        _status_at_least(lodging, {"confirmed"}),
     ]
     return int(sum(1 for item in checks if item) / len(checks) * 100)
+
+
+def _status_at_least(option: Any | None, accepted: set[str]) -> bool:
+    return getattr(getattr(option, "row_status", ""), "value", "") in accepted
 
 
 def _unresolved_blockers(shortlists: dict[str, Any], trip: Trip) -> list[str]:
@@ -1852,10 +2085,16 @@ def _unresolved_blockers(shortlists: dict[str, Any], trip: Trip) -> list[str]:
     for category in ("flights", "lodging", "cars", "activities"):
         if category not in shortlists:
             blockers.append(f"{category} shortlist missing")
-    if trip.unconfirmed_segments:
-        blockers.append("flight confirmations not booked")
-    if trip.unconfirmed_stays:
-        blockers.append("lodging confirmations not booked")
+    flight = _recommended_option(shortlists.get("flights"))
+    lodging = _recommended_option(shortlists.get("lodging"))
+    if not _status_at_least(flight, {"booked", "confirmed"}):
+        blockers.append("selected flight not marked booked")
+    if not _status_at_least(lodging, {"booked", "confirmed"}):
+        blockers.append("selected lodging not marked booked")
+    if not _status_at_least(flight, {"confirmed"}):
+        blockers.append("flight confirmation details missing")
+    if not _status_at_least(lodging, {"confirmed"}):
+        blockers.append("lodging confirmation details missing")
     blockers.append("live prices/availability still need human verification")
     return blockers
 
@@ -1874,11 +2113,17 @@ def _workspace_next_actions(shortlists: dict[str, Any], trip: Trip) -> list[str]
         if state is None:
             actions.append(f"Generate {category} shortlist")
         elif getattr(state, "recommended_option_id", None):
-            actions.append(
-                f"Open and live-verify recommended {category}: {state.recommended_option_id}"
-            )
-    if trip.unconfirmed_segments or trip.unconfirmed_stays:
-        actions.append("Promote selected recommendations to approved/booked once human confirms.")
+            selected = _recommended_option(state)
+            if not _status_at_least(selected, {"approved", "booked", "confirmed"}):
+                actions.append(f"Choose preferred {category}: {state.recommended_option_id}")
+            elif not _status_at_least(selected, {"booked", "confirmed"}):
+                actions.append(
+                    f"Book selected {category} externally, then add confirmation details."
+                )
+            elif not _status_at_least(selected, {"confirmed"}):
+                actions.append(f"Add {category} confirmation code and exact trip-day details.")
+    if not actions:
+        actions.append("Review the trip packet, map, and chronological timeline.")
     return actions
 
 

--- a/trippy/services/trip_workspace.py
+++ b/trippy/services/trip_workspace.py
@@ -67,15 +67,59 @@ class TripWorkspaceService:
         intake = self._intakes.require(trip_id)
         draft = self._planner.require_draft(trip_id)
         option, draft, warnings = self._resolve_option(draft, option_id)
-        trip = self._build_canonical_trip(intake, option)
+        existing_workspace = self.load(trip_id)
+        existing_trip = self._trip_state.load(trip_id)
+        existing_sync = (
+            existing_trip.sync
+            if existing_trip is not None and existing_trip.sync.google_sheet_id
+            else None
+        )
+        existing_sheet_id = (
+            existing_sync.google_sheet_id
+            if existing_sync is not None
+            else existing_workspace.google_sheet_id
+            if existing_workspace is not None
+            else None
+        )
+        existing_sheet_url = (
+            existing_sync.google_sheet_url
+            if existing_sync is not None
+            else existing_workspace.google_sheet_url
+            if existing_workspace is not None
+            else None
+        )
+        shortlists = _load_or_build_shortlists(
+            intake.trip_id,
+            self._intakes,
+            self._planner,
+            validate_live=validate_live,
+        )
+        trip = self._build_canonical_trip(intake, option, shortlists)
+        if existing_sync is not None:
+            trip.sync = existing_sync.model_copy(deep=True)
+        elif existing_sheet_id:
+            trip.sync = SyncMetadata(
+                google_sheet_id=existing_sheet_id,
+                google_sheet_url=existing_sheet_url,
+                last_synced_by="trip-workspace",
+            )
         canonical_path = self._trip_state.save(trip)
-        tabs = self._build_tabs(intake, draft, option, trip, validate_live=validate_live)
+        tabs = self._build_tabs(
+            intake,
+            draft,
+            option,
+            trip,
+            validate_live=validate_live,
+            shortlists=shortlists,
+        )
 
         state = TripWorkspaceState(
             trip_id=trip_id,
             plan_option_id=option.option_id,
             status=WorkspaceStatus.PREPARED_LOCAL,
             canonical_trip_path=str(canonical_path),
+            google_sheet_id=existing_sheet_id,
+            google_sheet_url=existing_sheet_url,
             tabs=tabs,
             warnings=warnings,
             next_actions=[
@@ -86,7 +130,13 @@ class TripWorkspaceService:
         )
 
         if create_google_sheet:
-            sheet = self._try_create_google_sheet(trip, tabs, folder_id=folder_id)
+            sheet = self._try_create_google_sheet(
+                trip,
+                tabs,
+                folder_id=folder_id,
+                existing_sheet_id=existing_sheet_id,
+                existing_sheet_url=existing_sheet_url,
+            )
             if sheet.get("spreadsheet_id"):
                 state.status = WorkspaceStatus.SHEET_CREATED
                 state.google_sheet_id = str(sheet["spreadsheet_id"])
@@ -99,7 +149,15 @@ class TripWorkspaceService:
                     last_synced_by="trip-workspace",
                 )
                 self._trip_state.save(trip)
-                state.next_actions.insert(0, "Open the generated Google Sheet planning workspace.")
+                operation = str(sheet.get("operation", "created"))
+                state.next_actions.insert(
+                    0,
+                    (
+                        "Open the updated Google Sheet planning workspace."
+                        if operation == "updated"
+                        else "Open the generated Google Sheet planning workspace."
+                    ),
+                )
             else:
                 state.status = WorkspaceStatus.SHEET_FAILED
                 error = str(sheet.get("error", "Google Sheet was not created."))
@@ -155,7 +213,12 @@ class TripWorkspaceService:
             )
         return option, draft, warnings
 
-    def _build_canonical_trip(self, intake: TripIntake, option: TripPlanOption) -> Trip:
+    def _build_canonical_trip(
+        self,
+        intake: TripIntake,
+        option: TripPlanOption,
+        shortlists: dict[str, Any] | None = None,
+    ) -> Trip:
         start = intake.travel_window.start_date
         end = (
             start + timedelta(days=option.duration_days - 1)
@@ -163,8 +226,8 @@ class TripWorkspaceService:
             else intake.travel_window.end_date
         )
         travelers = _travelers_for_intake(intake)
-        segments = _placeholder_segments(intake, option)
-        stays = _placeholder_stays(intake, option, start)
+        segments = _placeholder_segments(intake, option, shortlists)
+        stays = _placeholder_stays(intake, option, start, shortlists)
         checklist = _workspace_checklist(option)
         budgets = _workspace_budgets(intake)
         risks = _risk_flags(option)
@@ -199,13 +262,15 @@ class TripWorkspaceService:
         trip: Trip,
         *,
         validate_live: bool | None = None,
+        shortlists: dict[str, Any] | None = None,
     ) -> list[WorkspaceTab]:
-        shortlists = _load_or_build_shortlists(
-            intake.trip_id,
-            self._intakes,
-            self._planner,
-            validate_live=validate_live,
-        )
+        if shortlists is None:
+            shortlists = _load_or_build_shortlists(
+                intake.trip_id,
+                self._intakes,
+                self._planner,
+                validate_live=validate_live,
+            )
         map_artifact = _build_planning_map(intake.trip_id, self._intakes, self._planner)
         return [
             WorkspaceTab(
@@ -253,6 +318,19 @@ class TripWorkspaceService:
                     ]
                     for plan in draft.options
                 ],
+            ),
+            WorkspaceTab(
+                name="Stay Plan",
+                headers=[
+                    "Order",
+                    "Region / Base",
+                    "Nights",
+                    "Selected Lodging Option",
+                    "Strategy",
+                    "Status",
+                    "Notes",
+                ],
+                rows=_stay_plan_rows(option, shortlists.get("lodging")),
             ),
             WorkspaceTab(
                 name="Flights",
@@ -328,6 +406,7 @@ class TripWorkspaceService:
                     "Pickup",
                     "Dropoff",
                     "Vehicle Class",
+                    "Price Band",
                     "Seats",
                     "Passenger Fit",
                     "Luggage Fit",
@@ -354,6 +433,13 @@ class TripWorkspaceService:
                     "Area",
                     "Source",
                     "Duration",
+                    "Suggested Day",
+                    "Suggested Date",
+                    "Suggested Time",
+                    "Scheduled Day",
+                    "Scheduled Date",
+                    "Scheduled Time",
+                    "Fixed vs Flexible",
                     "Traveler Fit",
                     "Group Size",
                     "Review / Safety",
@@ -418,6 +504,8 @@ class TripWorkspaceService:
         tabs: list[WorkspaceTab],
         *,
         folder_id: str | None,
+        existing_sheet_id: str | None = None,
+        existing_sheet_url: str | None = None,
     ) -> dict[str, Any]:
         from trippy import config
         from trippy.ingest.google_auth import DRIVE_SCOPES, SHEETS_SCOPES, missing_required_scopes
@@ -444,33 +532,95 @@ class TripWorkspaceService:
 
                 auth = GoogleAuthManager()
             service = auth.build_service("sheets", "v4")
-            title = f"Trippy - {trip.name}"
-            resp = (
-                service.spreadsheets()
-                .create(
-                    body={
-                        "properties": {"title": title},
-                        "sheets": [{"properties": {"title": tab.name}} for tab in tabs],
+            operation = "updated" if existing_sheet_id else "created"
+            tabs_to_write = tabs
+            if existing_sheet_id:
+                sheet_id = existing_sheet_id
+                try:
+                    meta = (
+                        service.spreadsheets()
+                        .get(
+                            spreadsheetId=sheet_id,
+                            fields="spreadsheetUrl,sheets.properties(sheetId,title)",
+                        )
+                        .execute()
+                    )
+                except Exception as exc:
+                    return {
+                        "error": (
+                            "Existing Google Sheet could not be opened for update: "
+                            f"{exc}. Check sharing/auth, or create a fresh workspace."
+                        )
                     }
+                url = str(
+                    meta.get(
+                        "spreadsheetUrl",
+                        existing_sheet_url or f"https://docs.google.com/spreadsheets/d/{sheet_id}",
+                    )
                 )
-                .execute()
-            )
-            sheet_id = str(resp["spreadsheetId"])
-            url = str(
-                resp.get("spreadsheetUrl", f"https://docs.google.com/spreadsheets/d/{sheet_id}")
-            )
+                existing_tabs = {
+                    str(sheet["properties"]["title"])
+                    for sheet in meta.get("sheets", [])
+                    if "properties" in sheet and "title" in sheet["properties"]
+                }
+                missing_tabs = [tab for tab in tabs if tab.name not in existing_tabs]
+                if missing_tabs:
+                    try:
+                        service.spreadsheets().batchUpdate(
+                            spreadsheetId=sheet_id,
+                            body={
+                                "requests": [
+                                    {"addSheet": {"properties": {"title": tab.name}}}
+                                    for tab in missing_tabs
+                                ]
+                            },
+                        ).execute()
+                    except Exception as exc:
+                        partial_failures.append(f"Sheet update could not add missing tabs: {exc}")
+                        tabs_to_write = [tab for tab in tabs if tab.name in existing_tabs]
+            else:
+                title = f"Trippy - {trip.name}"
+                resp = (
+                    service.spreadsheets()
+                    .create(
+                        body={
+                            "properties": {"title": title},
+                            "sheets": [{"properties": {"title": tab.name}} for tab in tabs],
+                        }
+                    )
+                    .execute()
+                )
+                sheet_id = str(resp["spreadsheetId"])
+                url = str(
+                    resp.get(
+                        "spreadsheetUrl",
+                        f"https://docs.google.com/spreadsheets/d/{sheet_id}",
+                    )
+                )
 
             updates = [
                 {"range": f"{_sheet_tab_name(tab.name)}!A1", "values": [tab.headers, *tab.rows]}
-                for tab in tabs
+                for tab in tabs_to_write
             ]
+            if existing_sheet_id:
+                try:
+                    service.spreadsheets().values().batchClear(
+                        spreadsheetId=sheet_id,
+                        body={
+                            "ranges": [f"{_sheet_tab_name(tab.name)}!A:Z" for tab in tabs_to_write]
+                        },
+                    ).execute()
+                except Exception as exc:
+                    partial_failures.append(
+                        f"Existing sheet was opened but clearing old tab values failed: {exc}"
+                    )
             try:
                 service.spreadsheets().values().batchUpdate(
                     spreadsheetId=sheet_id,
                     body={"valueInputOption": "USER_ENTERED", "data": updates},
                 ).execute()
             except Exception as exc:
-                partial_failures.append(f"Sheet was created but tab values failed: {exc}")
+                partial_failures.append(f"Sheet was {operation} but tab values failed: {exc}")
 
             try:
                 meta = (
@@ -487,12 +637,12 @@ class TripWorkspaceService:
                 }
                 service.spreadsheets().batchUpdate(
                     spreadsheetId=sheet_id,
-                    body={"requests": _sheet_formatting_requests(tabs, sheet_ids)},
+                    body={"requests": _sheet_formatting_requests(tabs_to_write, sheet_ids)},
                 ).execute()
             except Exception as exc:
                 partial_failures.append(f"Sheet values were written but formatting failed: {exc}")
 
-            if folder_id:
+            if folder_id and not existing_sheet_id:
                 try:
                     drive = auth.build_service("drive", "v3")
                     meta = drive.files().get(fileId=sheet_id, fields="parents").execute()
@@ -508,7 +658,12 @@ class TripWorkspaceService:
                         f"Sheet was created but Drive folder move failed: {exc}"
                     )
 
-            return {"spreadsheet_id": sheet_id, "url": url, "partial_failures": partial_failures}
+            return {
+                "spreadsheet_id": sheet_id,
+                "url": url,
+                "operation": operation,
+                "partial_failures": partial_failures,
+            }
         except Exception as exc:
             return {"error": str(exc)}
 
@@ -547,9 +702,13 @@ def _travelers_for_intake(intake: TripIntake) -> list[Traveler]:
     ]
 
 
-def _placeholder_segments(intake: TripIntake, option: TripPlanOption) -> list[Segment]:
+def _placeholder_segments(
+    intake: TripIntake,
+    option: TripPlanOption,
+    shortlists: dict[str, Any] | None = None,
+) -> list[Segment]:
     origin = intake.departure_airports[0] if intake.departure_airports else "YYZ"
-    return [
+    segments = [
         Segment(
             segment_id="flight-outbound-research",
             segment_type=SegmentType.FLIGHT,
@@ -567,31 +726,69 @@ def _placeholder_segments(intake: TripIntake, option: TripPlanOption) -> list[Se
             notes="Research return with family-friendly departure time and baggage/seat clarity.",
         ),
     ]
+    for activity in _approved_activities((shortlists or {}).get("activities")):
+        scheduled_date = _parse_iso_date(activity.scheduled_date or activity.suggested_date)
+        depart_at = _combine_date_time(
+            scheduled_date,
+            activity.scheduled_start_time or activity.suggested_start_time,
+        )
+        arrive_at = _combine_date_time(
+            scheduled_date,
+            activity.scheduled_end_time or activity.suggested_end_time,
+        )
+        segments.append(
+            Segment(
+                segment_id=f"activity-{activity.option_id}",
+                segment_type=SegmentType.OTHER,
+                carrier=activity.source,
+                origin=activity.island_location,
+                destination=activity.island_location,
+                depart_at=depart_at,
+                arrive_at=arrive_at,
+                confirmation_code="UNCONFIRMED",
+                notes=(
+                    f"Approved activity: {activity.activity_name}. "
+                    f"{activity.scheduling_notes or activity.scheduling_rationale}"
+                ).strip(),
+            )
+        )
+    return segments
 
 
 def _placeholder_stays(
     intake: TripIntake,
     option: TripPlanOption,
     start: date | None,
+    shortlists: dict[str, Any] | None = None,
 ) -> list[Stay]:
     stays: list[Stay] = []
     cursor = start
-    for idx, (region, nights) in enumerate(option.nights_by_region.items(), start=1):
+    lodging_state = (shortlists or {}).get("lodging")
+    best_lodging = _recommended_option(lodging_state)
+    for idx, stay in enumerate(_lodging_night_plan(option, lodging_state), start=1):
+        region = str(stay["region"])
+        nights = int(stay["nights"])
         check_in = cursor
         check_out = cursor + timedelta(days=nights) if cursor else None
-        stay_type = StayType.AIRBNB if len(option.regions) <= 2 else StayType.HOTEL
+        linked_lodging = _lodging_for_stay(lodging_state, stay) or best_lodging
+        stay_type = (
+            StayType.AIRBNB
+            if "rental" in str(getattr(linked_lodging, "lodging_type", "")).lower()
+            or len(_lodging_night_plan(option, lodging_state)) <= 2
+            else StayType.HOTEL
+        )
         stays.append(
             Stay(
                 stay_id=f"stay-research-{idx}",
                 stay_type=stay_type,
-                property_name=f"{region} lodging shortlist",
+                property_name=_option_summary(linked_lodging) or f"{region} lodging shortlist",
                 city=region,
                 country="Portugal",
                 check_in=check_in,
                 check_out=check_out,
                 confirmation_code="UNCONFIRMED",
                 room_type=f"{intake.party.summary()}, 3+ beds if applicable, king preferred",
-                notes=option.lodging_strategy,
+                notes=str(stay.get("notes") or option.lodging_strategy),
             )
         )
         cursor = check_out
@@ -795,6 +992,7 @@ def _flight_rows(state: Any | None) -> list[list[Any]]:
             "",
             "",
             "",
+            "",
             "Run trip-plan flights.",
             "",
             "",
@@ -874,6 +1072,91 @@ def _lodging_rows(state: Any | None) -> list[list[Any]]:
     ]
 
 
+def _stay_plan_rows(option: TripPlanOption, lodging_state: Any | None) -> list[list[Any]]:
+    structure = _lodging_structure(lodging_state)
+    strategy = str(structure.get("strategy") or "single_stay")
+    status = str(structure.get("data_status") or "plan-based")
+    rows = []
+    for index, stay in enumerate(_lodging_night_plan(option, lodging_state), start=1):
+        linked_lodging = _lodging_for_stay(lodging_state, stay)
+        rows.append(
+            [
+                index,
+                stay["region"],
+                stay["nights"],
+                _option_summary(linked_lodging) or str(stay.get("lodging_option_id") or ""),
+                strategy,
+                status,
+                stay.get("notes", ""),
+            ]
+        )
+    return rows
+
+
+def _lodging_structure(lodging_state: Any | None) -> dict[str, Any]:
+    structure = getattr(lodging_state, "artifacts", {}).get("lodging_structure", {})
+    return structure if isinstance(structure, dict) else {}
+
+
+def _lodging_night_plan(
+    option: TripPlanOption,
+    lodging_state: Any | None,
+) -> list[dict[str, Any]]:
+    structure = _lodging_structure(lodging_state)
+    rows = structure.get("night_plan", [])
+    normalized = []
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        region = str(row.get("region") or row.get("location") or "").strip()
+        try:
+            nights = int(row.get("nights") or 0)
+        except (TypeError, ValueError):
+            nights = 0
+        if region and nights > 0:
+            normalized.append(
+                {
+                    "region": region,
+                    "nights": nights,
+                    "lodging_option_id": str(row.get("lodging_option_id") or "").strip(),
+                    "notes": str(row.get("notes") or "").strip(),
+                }
+            )
+    if normalized:
+        return normalized
+    return [
+        {"region": region, "nights": nights, "lodging_option_id": "", "notes": ""}
+        for region, nights in option.nights_by_region.items()
+        if nights
+    ] or [
+        {"region": region, "nights": 1, "lodging_option_id": "", "notes": ""}
+        for region in option.regions
+    ]
+
+
+def _lodging_for_stay(lodging_state: Any | None, stay: dict[str, Any]) -> Any | None:
+    if lodging_state is None:
+        return None
+    explicit_id = str(stay.get("lodging_option_id") or "").strip()
+    options = list(getattr(lodging_state, "lodging_options", []))
+    if explicit_id:
+        for option in options:
+            if getattr(option, "option_id", None) == explicit_id:
+                return option
+    region = str(stay.get("region") or "").lower()
+    for option in options:
+        option_region = (
+            f"{getattr(option, 'location_area', '')} {getattr(option, 'island_or_region', '')}"
+        ).lower()
+        if region and region in option_region:
+            return option
+    recommended_id = getattr(lodging_state, "recommended_option_id", None)
+    for option in options:
+        if getattr(option, "option_id", None) == recommended_id:
+            return option
+    return None
+
+
 def _evidence_summary(artifacts: list[Any]) -> str:
     values = []
     for artifact in artifacts[:3]:
@@ -896,6 +1179,7 @@ def _car_rows(state: Any | None) -> list[list[Any]]:
                 option.pickup_location,
                 option.dropoff_location,
                 option.vehicle_class,
+                option.current_price_signal or option.price_band,
                 option.seating_capacity or "",
                 option.passenger_fit,
                 option.luggage_fit,
@@ -949,6 +1233,13 @@ def _activity_rows(state: Any | None) -> list[list[Any]]:
                 option.island_location,
                 option.source,
                 option.duration,
+                option.suggested_day or "",
+                option.suggested_date,
+                _time_range(option.suggested_start_time, option.suggested_end_time),
+                option.scheduled_day or "",
+                option.scheduled_date,
+                _time_range(option.scheduled_start_time, option.scheduled_end_time),
+                option.scheduled_flexibility if option.scheduled_day else "",
                 option.age_family_fit,
                 option.group_size_signal,
                 option.review_safety_signal,
@@ -979,6 +1270,13 @@ def _activity_rows(state: Any | None) -> list[list[Any]]:
             "",
             "",
             "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
             "Run trip-plan activities.",
             "",
             "",
@@ -990,9 +1288,36 @@ def _activity_rows(state: Any | None) -> list[list[Any]]:
 
 
 def _map_rows(map_artifact: Any, shortlists: dict[str, Any]) -> list[list[Any]]:
+    primary_url = str(getattr(map_artifact, "primary_google_maps_url", "") or "")
+    rows = []
+    if primary_url:
+        rows.append(
+            [
+                "Single ordered Google Map",
+                "custom map",
+                "current",
+                "Primary map preview for the trip; KML/CSV exports keep every pin numbered in order.",
+                primary_url,
+            ]
+        )
+    exports = getattr(map_artifact, "exports", {}) or {}
+    kml_path = str(exports.get("kml", ""))
+    if kml_path:
+        rows.append(
+            [
+                "Google My Maps KML import",
+                "custom map",
+                "current",
+                "Import this file into Google My Maps for one custom map with all numbered pins.",
+                kml_path,
+            ]
+        )
     rows = [
-        [pin.label, pin.category.value, "seeded", pin.notes, pin.google_maps_url]
-        for pin in getattr(map_artifact, "pins", [])
+        *rows,
+        *[
+            [pin.label, pin.category.value, "seeded", pin.notes, pin.google_maps_url]
+            for pin in getattr(map_artifact, "pins", [])
+        ],
     ]
     rows.extend(
         [route.label, "route", "seeded", route.notes, route.google_maps_url]
@@ -1061,7 +1386,7 @@ def _timeline_rows(
     best_flight = _recommended_option(shortlists.get("flights"))
     best_car = _recommended_option(shortlists.get("cars"))
     best_lodging = _recommended_option(shortlists.get("lodging"))
-    activities = _top_options(shortlists.get("activities"), limit=4)
+    activities = _timeline_activity_options(shortlists.get("activities"), limit=4)
     rows.append(
         _timeline_row(
             day=1,
@@ -1104,7 +1429,7 @@ def _timeline_rows(
                 title=f"Pick up {best_car.vehicle_class}",
                 location=best_car.pickup_location,
                 provider=best_car.booking_source,
-                status="recommended",
+                status=_row_status(shortlists.get("cars"), best_car.option_id),
                 fixed="flexible",
                 buffer_before="after baggage/arrival",
                 friction_flags=_combine_flags(
@@ -1117,7 +1442,11 @@ def _timeline_rows(
             )
         )
     cursor_day = 1
-    for region, nights in option.nights_by_region.items():
+    lodging_plan = _lodging_night_plan(option, shortlists.get("lodging"))
+    for stay in lodging_plan:
+        region = str(stay["region"])
+        nights = int(stay["nights"])
+        linked_lodging = _lodging_for_stay(shortlists.get("lodging"), stay) or best_lodging
         rows.append(
             _timeline_row(
                 day=cursor_day,
@@ -1125,18 +1454,21 @@ def _timeline_rows(
                 event_type="lodging",
                 title=f"Check in: {region}",
                 location=region,
-                provider=_option_summary(best_lodging),
-                status="recommended" if best_lodging is not None else "seeded",
+                provider=_option_summary(linked_lodging),
+                status="recommended" if linked_lodging is not None else "seeded",
                 fixed="flexible",
                 buffer_before="avoid late-arrival access risk",
                 buffer_after=f"{nights} night(s)",
                 friction_flags=_combine_flags(
-                    getattr(best_lodging, "friction_flags", []),
+                    getattr(linked_lodging, "friction_flags", []),
                     ["check-in time must be aligned to arrival"],
                 ),
-                confidence=_option_confidence(best_lodging),
-                notes=getattr(best_lodging, "adult_child_fit", option.lodging_strategy),
-                link=getattr(best_lodging, "deep_link", ""),
+                confidence=_option_confidence(linked_lodging),
+                notes=str(
+                    stay.get("notes")
+                    or getattr(linked_lodging, "adult_child_fit", option.lodging_strategy)
+                ),
+                link=getattr(linked_lodging, "deep_link", ""),
             )
         )
         cursor_day += max(1, nights)
@@ -1157,25 +1489,41 @@ def _timeline_rows(
             )
         )
     for idx, activity in enumerate(activities, start=2):
+        activity_day = activity.scheduled_day or activity.suggested_day or idx
+        activity_date = _parse_iso_date(
+            activity.scheduled_date or activity.suggested_date
+        ) or _add_days(start, activity_day - 1)
+        activity_status = _row_status(shortlists.get("activities"), activity.option_id)
+        is_scheduled = activity.row_status.value in {"approved", "booked"} or bool(
+            activity.scheduled_day
+        )
         rows.append(
             _timeline_row(
-                day=min(idx, max(2, option.duration_days - 1)),
-                date_value=_add_days(start, idx - 1),
+                day=min(activity_day, max(2, option.duration_days - 1)),
+                date_value=activity_date,
+                start_time=activity.scheduled_start_time or activity.suggested_start_time,
+                end_time=activity.scheduled_end_time or activity.suggested_end_time,
                 event_type="activity",
                 title=activity.activity_name,
                 location=activity.island_location,
                 provider=activity.source,
-                status=_row_status(shortlists.get("activities"), activity.option_id),
-                fixed="flexible",
+                status=activity_status,
+                fixed=activity.scheduled_flexibility if is_scheduled else "flexible",
                 travel_time=activity.duration,
                 buffer_before="half-day slack",
                 buffer_after="downtime / meal buffer",
                 friction_flags=_combine_flags(
                     activity.friction_flags,
-                    ["timeline placement tentative until flight/lodging times are fixed"],
+                    []
+                    if is_scheduled
+                    else ["timeline placement tentative until flight/lodging times are fixed"],
                 ),
                 confidence=_option_confidence(activity),
-                notes=activity.age_family_fit,
+                notes=_notes(
+                    [activity.scheduling_notes],
+                    [activity.scheduling_rationale],
+                    [activity.age_family_fit],
+                ),
                 link=activity.deep_link,
             )
         )
@@ -1196,7 +1544,7 @@ def _timeline_rows(
             notes="Validate exact return after final lodging sequence is settled.",
         )
     )
-    return rows
+    return _finalize_timeline_rows(rows, intake)
 
 
 def _timeline_row(
@@ -1245,6 +1593,83 @@ def _timeline_row(
     ]
 
 
+def _finalize_timeline_rows(rows: list[list[Any]], intake: TripIntake) -> list[list[Any]]:
+    """Fill readable date labels and sort rows into chronological trip order."""
+    finalized: list[list[Any]] = []
+    for row in rows:
+        copied = list(row)
+        day = _row_day(copied)
+        if not copied[1]:
+            copied[1] = _timeline_date_label(intake, day)
+        finalized.append(copied)
+    return sorted(finalized, key=_timeline_sort_key)
+
+
+def _timeline_date_label(intake: TripIntake, day: int) -> str:
+    if intake.travel_window.start_date:
+        exact = _add_days(intake.travel_window.start_date, day - 1)
+        return exact.isoformat() if exact else ""
+    timing = intake.travel_window.display()
+    if timing and timing != "timing TBD":
+        return f"{timing} - Day {day}"
+    return f"Day {day} date TBD"
+
+
+def _timeline_sort_key(row: list[Any]) -> tuple[int, int, int, str]:
+    return (
+        _row_day(row),
+        _time_sort_value(str(row[2] or "")),
+        _event_sort_priority(row),
+        str(row[6] or ""),
+    )
+
+
+def _row_day(row: list[Any]) -> int:
+    try:
+        return max(1, int(str(row[0] or "1")))
+    except ValueError:
+        return 1
+
+
+def _time_sort_value(value: str) -> int:
+    value = value.strip().lower()
+    if not value:
+        return 24 * 60
+    for fmt in ("%H:%M", "%I:%M %p", "%I %p"):
+        try:
+            parsed = datetime.strptime(value.upper(), fmt)
+            return parsed.hour * 60 + parsed.minute
+        except ValueError:
+            continue
+    if "morning" in value:
+        return 9 * 60
+    if "afternoon" in value:
+        return 14 * 60
+    if "evening" in value:
+        return 19 * 60
+    if "night" in value:
+        return 21 * 60
+    return 24 * 60
+
+
+def _event_sort_priority(row: list[Any]) -> int:
+    event_type = str(row[5] or "").lower()
+    title = str(row[6] or "").lower()
+    if event_type == "flight" and "return" not in title:
+        return 10
+    if "check out" in title:
+        return 20
+    if event_type == "car pickup":
+        return 30
+    if "check in" in title:
+        return 40
+    if event_type == "activity":
+        return 50
+    if event_type == "flight" and "return" in title:
+        return 90
+    return 60
+
+
 def _recommended_option(state: Any | None) -> Any | None:
     if state is None or not getattr(state, "recommended_option_id", None):
         return None
@@ -1260,6 +1685,43 @@ def _recommended_option(state: Any | None) -> Any | None:
 
 def _top_options(state: Any | None, *, limit: int) -> list[Any]:
     return _typed_options(state)[:limit] if state is not None else []
+
+
+def _timeline_activity_options(state: Any | None, *, limit: int) -> list[Any]:
+    options = list(getattr(state, "activity_options", [])) if state is not None else []
+    approved = [
+        option
+        for option in options
+        if getattr(getattr(option, "row_status", ""), "value", "") in {"approved", "booked"}
+        or getattr(option, "scheduled_day", None)
+    ]
+    if approved:
+        return sorted(
+            approved,
+            key=lambda option: (
+                getattr(option, "scheduled_day", None)
+                or getattr(option, "suggested_day", None)
+                or 999,
+                getattr(option, "scheduled_start_time", "")
+                or getattr(option, "suggested_start_time", ""),
+            ),
+        )
+    return sorted(
+        options[:limit],
+        key=lambda option: (
+            getattr(option, "suggested_day", None) or 999,
+            getattr(option, "suggested_start_time", ""),
+        ),
+    )
+
+
+def _approved_activities(state: Any | None) -> list[Any]:
+    return [
+        option
+        for option in getattr(state, "activity_options", [])
+        if getattr(getattr(option, "row_status", ""), "value", "") in {"approved", "booked"}
+        or getattr(option, "scheduled_day", None)
+    ]
 
 
 def _typed_options(state: Any | None) -> list[Any]:
@@ -1302,9 +1764,22 @@ def _combine_flags(existing: list[str], extra: list[str]) -> str:
 
 
 def _row_status(state: Any | None, option_id: str) -> str:
+    option = None
+    if state is not None:
+        option = next(
+            (
+                item
+                for item in _typed_options(state)
+                if getattr(item, "option_id", None) == option_id
+            ),
+            None,
+        )
+    row_status = getattr(getattr(option, "row_status", None), "value", "")
+    if row_status in {"approved", "booked", "rejected", "verified_live", "stale"}:
+        return row_status
     if state is not None and option_id == getattr(state, "recommended_option_id", None):
         return "recommended"
-    return "researched"
+    return row_status or "researched"
 
 
 def _yes_no(value: bool) -> str:
@@ -1322,6 +1797,31 @@ def _notes(*groups: list[str]) -> str:
     for group in groups:
         items.extend(str(item) for item in group if item)
     return "; ".join(items)
+
+
+def _time_range(start_time: str, end_time: str) -> str:
+    if start_time and end_time:
+        return f"{start_time}-{end_time}"
+    return start_time or end_time
+
+
+def _parse_iso_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _combine_date_time(date_value: date | None, time_value: str) -> datetime | None:
+    if date_value is None or not time_value:
+        return None
+    try:
+        parsed_time = datetime.strptime(time_value, "%H:%M").time()
+    except ValueError:
+        return None
+    return datetime.combine(date_value, parsed_time)
 
 
 def _party_lodging_notes(intake: TripIntake) -> str:

--- a/trippy/ui/server.py
+++ b/trippy/ui/server.py
@@ -382,6 +382,113 @@ class TrippyUIService:
             "next_step": "Review lodging check-in, car pickup, Master Timeline, and date-fit implications.",
         }
 
+    def select_lodging(self, payload: dict[str, Any]) -> dict[str, Any]:
+        trip_id = _trip_id(payload)
+        option_id = str(payload.get("option_id") or "")
+        state = LodgingShortlistService(self._intakes, self._planner).select_lodging(
+            trip_id,
+            option_id,
+        )
+        workflow = self._record_workflow(
+            workflow_name="ui-trip-plan-lodging-select",
+            skill_name="trippy-family-itinerary-builder",
+            trip_id=trip_id,
+            summary=f"Selected lodging option {option_id} for planning",
+            result=state.model_dump(mode="json"),
+        )
+        return {
+            "workflow_id": workflow.id,
+            "shortlist": state.model_dump(mode="json"),
+            "next_step": "Review whether the trip should use one stay or split stays.",
+        }
+
+    def update_lodging_structure(self, payload: dict[str, Any]) -> dict[str, Any]:
+        trip_id = _trip_id(payload)
+        state = LodgingShortlistService(self._intakes, self._planner).update_stay_structure(
+            trip_id,
+            strategy=str(payload.get("strategy") or "split_stay"),
+            night_plan=list(payload.get("night_plan") or []),
+            notes=str(payload.get("notes") or "").strip(),
+        )
+        workflow = self._record_workflow(
+            workflow_name="ui-trip-plan-lodging-structure",
+            skill_name="trippy-family-itinerary-builder",
+            trip_id=trip_id,
+            summary="Updated manual lodging stay structure",
+            result=state.model_dump(mode="json"),
+        )
+        return {
+            "workflow_id": workflow.id,
+            "shortlist": state.model_dump(mode="json"),
+            "next_step": "Build or refresh the workspace so the Master Timeline uses this stay structure.",
+        }
+
+    def select_activity(self, payload: dict[str, Any]) -> dict[str, Any]:
+        trip_id = _trip_id(payload)
+        option_id = str(payload.get("option_id") or "")
+        state = ActivityShortlistService(self._intakes, self._planner).select_activity(
+            trip_id,
+            option_id,
+        )
+        workflow = self._record_workflow(
+            workflow_name="ui-trip-plan-activity-select",
+            skill_name="trippy-family-itinerary-builder",
+            trip_id=trip_id,
+            summary=f"Approved activity option {option_id} for the trip timeline",
+            result=state.model_dump(mode="json"),
+        )
+        return {
+            "workflow_id": workflow.id,
+            "shortlist": state.model_dump(mode="json"),
+            "next_step": "Review or adjust the activity day/time, then refresh the workspace timeline.",
+        }
+
+    def schedule_activity(self, payload: dict[str, Any]) -> dict[str, Any]:
+        trip_id = _trip_id(payload)
+        option_id = str(payload.get("option_id") or "")
+        state = ActivityShortlistService(self._intakes, self._planner).schedule_activity(
+            trip_id,
+            option_id,
+            day=_int_or_none(payload.get("day")),
+            date_value=_optional_str(payload.get("date")),
+            start_time=_optional_str(payload.get("start_time")),
+            end_time=_optional_str(payload.get("end_time")),
+            fixed=bool(payload.get("fixed", False)),
+            notes=str(payload.get("notes") or "").strip(),
+        )
+        workflow = self._record_workflow(
+            workflow_name="ui-trip-plan-activity-schedule",
+            skill_name="trippy-family-itinerary-builder",
+            trip_id=trip_id,
+            summary=f"Scheduled activity option {option_id} into the trip timeline",
+            result=state.model_dump(mode="json"),
+        )
+        return {
+            "workflow_id": workflow.id,
+            "shortlist": state.model_dump(mode="json"),
+            "next_step": "Refresh the workspace to see this activity in the Master Timeline.",
+        }
+
+    def select_car(self, payload: dict[str, Any]) -> dict[str, Any]:
+        trip_id = _trip_id(payload)
+        option_id = str(payload.get("option_id") or "")
+        state = CarShortlistService(self._intakes, self._planner).select_car(
+            trip_id,
+            option_id,
+        )
+        workflow = self._record_workflow(
+            workflow_name="ui-trip-plan-car-select",
+            skill_name="trippy-family-itinerary-builder",
+            trip_id=trip_id,
+            summary=f"Selected car rental option {option_id} for planning",
+            result=state.model_dump(mode="json"),
+        )
+        return {
+            "workflow_id": workflow.id,
+            "shortlist": state.model_dump(mode="json"),
+            "next_step": "Review pickup/dropoff timing, luggage fit, fees, and driving/parking friction.",
+        }
+
     def delete_trip(self, trip_id: str) -> dict[str, Any]:
         result = TripManagementService(
             intake_service=self._intakes,
@@ -444,8 +551,28 @@ class TrippyUIService:
         return {
             "workflow_id": workflow.id,
             "map": artifact.model_dump(mode="json"),
-            "next_step": "Open the map links from the dashboard or planning workspace.",
+            "next_step": "Open the single ordered Google Map or import the KML into Google My Maps.",
         }
+
+    def map_file_path(self, trip_id: str, kind: str) -> Path:
+        allowed = {
+            "json": f"{trip_id}-planning-map.json",
+            "geojson": f"{trip_id}-planning-map.geojson",
+            "kml": f"{trip_id}-planning-map.kml",
+            "csv": f"{trip_id}-planning-map.csv",
+        }
+        filename = allowed.get(kind)
+        if filename is None:
+            raise ValueError("kind must be one of: json, geojson, kml, csv")
+        path = (config.EXPORT_PATH / "maps" / filename).resolve()
+        maps_root = (config.EXPORT_PATH / "maps").resolve()
+        if maps_root not in path.parents and path != maps_root:
+            raise ValueError("Invalid map file path")
+        if not path.exists():
+            self.build_map(trip_id)
+        if not path.exists():
+            raise FileNotFoundError(f"Map file was not generated: {kind}")
+        return path
 
     def add_feedback(self, payload: dict[str, Any]) -> dict[str, Any]:
         workflow_id = str(payload.get("workflow_id") or "")
@@ -552,6 +679,15 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
                     return
                 self._send_json(self._ui.trip_state(trip_id))
                 return
+            if path == "/api/map-file":
+                query = parse_qs(urlparse(self.path).query)
+                trip_id = query.get("trip_id", [""])[0]
+                kind = query.get("kind", [""])[0]
+                if not trip_id:
+                    self._send_error("trip_id is required", HTTPStatus.BAD_REQUEST)
+                    return
+                self._send_file(self._ui.map_file_path(trip_id, kind))
+                return
             if path.startswith("/static/"):
                 self._send_static(path.removeprefix("/static/"))
                 return
@@ -598,6 +734,21 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
                 return
             if path == "/api/select-flight":
                 self._send_json(self._ui.select_flight(payload))
+                return
+            if path == "/api/select-lodging":
+                self._send_json(self._ui.select_lodging(payload))
+                return
+            if path == "/api/lodging-structure":
+                self._send_json(self._ui.update_lodging_structure(payload))
+                return
+            if path == "/api/select-activity":
+                self._send_json(self._ui.select_activity(payload))
+                return
+            if path == "/api/schedule-activity":
+                self._send_json(self._ui.schedule_activity(payload))
+                return
+            if path == "/api/select-car":
+                self._send_json(self._ui.select_car(payload))
                 return
             if path == "/api/workspace":
                 self._send_json(

--- a/trippy/ui/server.py
+++ b/trippy/ui/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import mimetypes
 import webbrowser
@@ -43,7 +44,9 @@ from trippy.services.learning import (
     WorkflowStatus,
 )
 from trippy.services.lodging_shortlist import LodgingShortlistService
+from trippy.services.planning_advisor import PlanningAdvisorService
 from trippy.services.shortlist_store import ShortlistStore
+from trippy.services.trip_execution import TripExecutionService
 from trippy.services.trip_ideation import TripIdeationService
 from trippy.services.trip_intake import TripIntakeService
 from trippy.services.trip_management import TripManagementService
@@ -89,6 +92,7 @@ class TrippyUIService:
         intake = self._intakes.load(trip_id)
         draft = self._planner.load_draft(trip_id)
         workspace = TripWorkspaceService(self._intakes, self._planner).load(trip_id)
+        trip_packet = TripExecutionService().build(trip_id, save=False) if intake else None
         shortlists = ShortlistStore().load_all(trip_id)
         workflows = [
             workflow for workflow in self._learning.list_workflows() if workflow.trip_id == trip_id
@@ -100,6 +104,7 @@ class TrippyUIService:
             "draft": draft.model_dump(mode="json") if draft else None,
             "workspace": workspace.model_dump(mode="json") if workspace else None,
             "map_artifact": _load_map_artifact(trip_id),
+            "trip_packet": trip_packet.model_dump(mode="json") if trip_packet else None,
             "shortlists": [shortlist.model_dump(mode="json") for shortlist in shortlists],
             "recent_workflows": [workflow.model_dump(mode="json") for workflow in workflows],
             "run_log": logs["events"],
@@ -140,6 +145,9 @@ class TrippyUIService:
             duration_days=_int_or_none(payload.get("duration_days")),
             budget_cad=_float_or_none(payload.get("budget_cad")),
             travelers=_int(payload.get("travelers"), 5),
+            party_type=_optional_str(payload.get("party_type")),
+            adults=_int_or_none(payload.get("adults")),
+            children=_int_or_none(payload.get("children")),
             max_flight_hours=_float_or_none(
                 payload.get("max_flight_hours") or payload.get("max_travel_time_hours")
             ),
@@ -343,7 +351,7 @@ class TrippyUIService:
         state = FlightShortlistService(self._intakes, self._planner).add_candidate(
             trip_id,
             link=str(payload.get("link") or ""),
-            notes=str(payload.get("notes") or ""),
+            notes=_flight_candidate_notes(payload),
             name=str(payload.get("name") or ""),
             validate_live=bool(payload.get("validate_live", False)),
             deep_research=bool(payload.get("deep_research", False)),
@@ -423,6 +431,75 @@ class TrippyUIService:
             "next_step": "Build or refresh the workspace so the Master Timeline uses this stay structure.",
         }
 
+    def suggest_lodging_structures(self, payload: dict[str, Any]) -> dict[str, Any]:
+        trip_id = _trip_id(payload)
+        state = LodgingShortlistService(self._intakes, self._planner).suggest_stay_structures(
+            trip_id,
+            use_llm=bool(payload.get("use_llm", True)),
+        )
+        workflow = self._record_workflow(
+            workflow_name="ui-trip-plan-lodging-structure-suggest",
+            skill_name="trippy-family-itinerary-builder",
+            trip_id=trip_id,
+            summary="Generated stay-structure options for review",
+            result=state.model_dump(mode="json"),
+        )
+        structure = state.artifacts.get("lodging_structure", {})
+        option_count = len(structure.get("options", [])) if isinstance(structure, dict) else 0
+        return {
+            "workflow_id": workflow.id,
+            "shortlist": state.model_dump(mode="json"),
+            "option_count": option_count,
+            "next_step": "Pick a stay option or edit the night split before selecting exact lodging.",
+        }
+
+    def planning_advice(self, payload: dict[str, Any]) -> dict[str, Any]:
+        from trippy.models.planning_advice import PlanningAdviceKind
+
+        trip_id = _optional_str(payload.get("trip_id"))
+        kind = PlanningAdviceKind(str(payload.get("planning_question") or "next_steps"))
+        intake = self._intakes.load(trip_id) if trip_id else None
+        draft = self._planner.load_draft(trip_id) if trip_id else None
+        advisor = PlanningAdvisorService()
+        if kind == PlanningAdviceKind.LODGING_STRUCTURE and intake is not None and draft:
+            option = draft.get_option()
+            lodging_state = (
+                ShortlistStore().load(trip_id, ShortlistCategory.LODGING) if trip_id else None
+            )
+            result = (
+                advisor.advise_lodging_structure(intake, option, lodging_state)
+                if option is not None
+                else advisor.advise_next_steps(
+                    intake,
+                    draft,
+                    ShortlistStore().load_all(trip_id) if trip_id else [],
+                    user_question=str(payload.get("notes") or ""),
+                )
+            )
+        elif kind == PlanningAdviceKind.ISLAND_EXPERIENCE and intake is not None and draft:
+            result = advisor.advise_island_experience(intake, draft)
+        elif kind == PlanningAdviceKind.TRIP_SHAPE and intake is not None and draft:
+            result = advisor.advise_trip_shape(intake, draft)
+        else:
+            result = advisor.advise_next_steps(
+                intake,
+                draft,
+                ShortlistStore().load_all(trip_id) if trip_id else [],
+                user_question=str(payload.get("notes") or ""),
+            )
+        workflow = self._record_workflow(
+            workflow_name="ui-planning-advice",
+            skill_name="trippy-family-itinerary-builder",
+            trip_id=trip_id,
+            summary=f"Generated planning-advisor guidance for {kind.value}",
+            result=result.model_dump(mode="json"),
+        )
+        return {
+            "workflow_id": workflow.id,
+            "advice": result.model_dump(mode="json"),
+            "next_step": "Use this guidance to choose the next planning action; do not treat missing evidence as verified.",
+        }
+
     def select_activity(self, payload: dict[str, Any]) -> dict[str, Any]:
         trip_id = _trip_id(payload)
         option_id = str(payload.get("option_id") or "")
@@ -487,6 +564,38 @@ class TrippyUIService:
             "workflow_id": workflow.id,
             "shortlist": state.model_dump(mode="json"),
             "next_step": "Review pickup/dropoff timing, luggage fit, fees, and driving/parking friction.",
+        }
+
+    def update_trip_packet_item(self, payload: dict[str, Any]) -> dict[str, Any]:
+        trip_id = _trip_id(payload)
+        packet = TripExecutionService().update_item(
+            trip_id,
+            category=str(payload.get("category") or ""),
+            option_id=str(payload.get("option_id") or ""),
+            status=str(payload.get("status") or "booked"),
+            provider=str(payload.get("provider") or ""),
+            booking_link=str(payload.get("booking_link") or payload.get("source_url") or ""),
+            confirmation_code=str(payload.get("confirmation_code") or ""),
+            date=str(payload.get("date") or ""),
+            start_time=str(payload.get("start_time") or ""),
+            end_time=str(payload.get("end_time") or ""),
+            address=str(payload.get("address") or ""),
+            cost_cad=_float_or_none(payload.get("cost_cad")),
+            notes=str(payload.get("notes") or ""),
+        )
+        workflow = self._record_workflow(
+            workflow_name="ui-trip-packet-update",
+            trip_id=trip_id,
+            summary=(
+                f"Updated {payload.get('category') or 'trip'} booking packet "
+                f"item {payload.get('option_id') or ''}"
+            ),
+            result=packet.model_dump(mode="json"),
+        )
+        return {
+            "workflow_id": workflow.id,
+            "trip_packet": packet.model_dump(mode="json"),
+            "next_step": "Refresh the timeline, map, and Google Sheet so confirmations are visible.",
         }
 
     def delete_trip(self, trip_id: str) -> dict[str, Any]:
@@ -741,6 +850,12 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
             if path == "/api/lodging-structure":
                 self._send_json(self._ui.update_lodging_structure(payload))
                 return
+            if path == "/api/lodging-structure-suggestions":
+                self._send_json(self._ui.suggest_lodging_structures(payload))
+                return
+            if path == "/api/planning-advice":
+                self._send_json(self._ui.planning_advice(payload))
+                return
             if path == "/api/select-activity":
                 self._send_json(self._ui.select_activity(payload))
                 return
@@ -749,6 +864,9 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
                 return
             if path == "/api/select-car":
                 self._send_json(self._ui.select_car(payload))
+                return
+            if path == "/api/trip-packet/item":
+                self._send_json(self._ui.update_trip_packet_item(payload))
                 return
             if path == "/api/workspace":
                 self._send_json(
@@ -818,6 +936,29 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
         self._send_file(candidate)
 
 
+def _create_ui_server(
+    host: str,
+    port: int,
+    handler: Any,
+    *,
+    port_retries: int = 10,
+) -> ThreadingHTTPServer:
+    """Bind the UI server, falling forward when the preferred port is busy."""
+    candidates = [0] if port == 0 else range(port, port + port_retries + 1)
+    for candidate in candidates:
+        try:
+            server = ThreadingHTTPServer((host, candidate), handler)
+        except OSError as exc:
+            if exc.errno != errno.EADDRINUSE or candidate == port + port_retries:
+                raise
+            continue
+        if port != 0 and server.server_port != port:
+            print(f"Port {port} is in use; using {server.server_port} instead.")
+        return server
+    msg = f"No available UI port found from {port} to {port + port_retries}."
+    raise OSError(errno.EADDRINUSE, msg)
+
+
 def serve_ui(host: str = "127.0.0.1", port: int = 8787, *, open_browser: bool = True) -> None:
     """Serve the local Trippy UI until interrupted."""
     service = TrippyUIService()
@@ -827,7 +968,7 @@ def serve_ui(host: str = "127.0.0.1", port: int = 8787, *, open_browser: bool = 
         static_dir=STATIC_DIR,
         template_dir=TEMPLATE_DIR,
     )
-    server = ThreadingHTTPServer((host, port), handler)
+    server = _create_ui_server(host, port, handler)
     url = f"http://{host}:{server.server_port}"
     print(f"Trippy UI running at {url}")
     if open_browser:
@@ -1032,6 +1173,31 @@ def _parse_roster(value: object) -> list[TripTraveler]:
                 age_band = TravelerAgeBand(_normalise_enum(parts[1], "adult"))
         travelers.append(TripTraveler(name=name, age=age, age_band=age_band))
     return travelers
+
+
+def _flight_candidate_notes(payload: dict[str, Any]) -> str:
+    parts = []
+    notes = _optional_str(payload.get("notes"))
+    if notes:
+        parts.append(notes)
+    field_labels = {
+        "flight_numbers": "flight numbers",
+        "departure_date": "departure date",
+        "departure_time": "depart",
+        "arrival_date": "arrival date",
+        "arrival_time": "arrive",
+        "total_duration": "duration",
+        "stops": "stops",
+        "layover_airports": "via",
+        "layover_duration": "layover",
+        "price_band": "price",
+        "baggage_notes": "baggage",
+    }
+    for key, label in field_labels.items():
+        value = _optional_str(payload.get(key))
+        if value:
+            parts.append(f"{label}: {value}")
+    return ". ".join(parts)
 
 
 def _trip_id(payload: dict[str, Any]) -> str:

--- a/trippy/ui/static/app.css
+++ b/trippy/ui/static/app.css
@@ -305,21 +305,75 @@ main {
 }
 
 .stage-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 6px;
   margin: 18px 0;
 }
 
 .stage-tabs button {
-  background: #fff2d2;
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  min-height: 58px;
+  padding: 7px;
+  background: #fff7df;
   color: #743500;
   border: 1px solid #ffd380;
+  font-size: 12px;
 }
 
 .stage-tabs button.active {
   background: var(--sun);
   color: var(--ink);
+}
+
+.stage-tabs button.complete {
+  background: #e8fff2;
+  color: #14633c;
+  border-color: rgba(45, 185, 111, 0.35);
+}
+
+.stage-tabs button.locked {
+  background: #f4f7fb;
+  color: #98a2b3;
+  border-color: #e4e7ec;
+}
+
+.stage-tabs button.active {
+  background: var(--sun);
+  color: var(--ink);
+  border-color: #e4a700;
+}
+
+.stage-tabs button span {
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: #ffffff;
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.start-screen,
+.guided-step-layout {
+  display: grid;
+  gap: 14px;
+}
+
+.start-hero {
+  padding: 18px;
+  border: 1px solid rgba(0, 141, 163, 0.18);
+  border-radius: 8px;
+  background: linear-gradient(135deg, #e4fbff 0%, #fff9dd 58%, #ffe5ef 100%);
+}
+
+.start-hero p:last-child {
+  max-width: 760px;
+  margin-bottom: 0;
+  color: var(--muted);
 }
 
 .progressive-form {
@@ -436,6 +490,65 @@ textarea {
   aspect-ratio: 16 / 9;
   overflow: hidden;
   background: #f7d46b;
+}
+
+.option-map-thumb {
+  position: relative;
+  display: grid;
+  align-content: space-between;
+  min-height: 190px;
+  overflow: hidden;
+  padding: 16px;
+  background:
+    linear-gradient(135deg, rgba(0, 141, 163, 0.18), rgba(255, 201, 40, 0.22)),
+    radial-gradient(circle at 18% 22%, rgba(45, 185, 111, 0.55), transparent 18%),
+    radial-gradient(circle at 80% 68%, rgba(255, 103, 77, 0.38), transparent 20%),
+    #e8fbff;
+}
+
+.option-map-thumb.option-2 {
+  background:
+    linear-gradient(135deg, rgba(105, 82, 214, 0.12), rgba(0, 141, 163, 0.24)),
+    radial-gradient(circle at 22% 28%, rgba(45, 185, 111, 0.5), transparent 17%),
+    radial-gradient(circle at 72% 58%, rgba(255, 201, 40, 0.5), transparent 18%),
+    #f4fbff;
+}
+
+.option-map-thumb.option-3 {
+  background:
+    linear-gradient(135deg, rgba(255, 79, 147, 0.12), rgba(255, 201, 40, 0.22)),
+    radial-gradient(circle at 20% 25%, rgba(45, 185, 111, 0.5), transparent 15%),
+    radial-gradient(circle at 50% 52%, rgba(0, 141, 163, 0.3), transparent 16%),
+    radial-gradient(circle at 82% 68%, rgba(255, 103, 77, 0.36), transparent 17%),
+    #fff7e2;
+}
+
+.map-route-line {
+  position: absolute;
+  inset: 52px 40px auto;
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(18, 35, 51, 0.2);
+}
+
+.map-pin-row {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.map-pin {
+  max-width: 44%;
+  padding: 8px 10px;
+  border: 2px solid #ffffff;
+  border-radius: 999px;
+  background: var(--ocean);
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 900;
+  box-shadow: 0 8px 16px rgba(18, 35, 51, 0.14);
 }
 
 .image-wrap::after {
@@ -571,6 +684,30 @@ textarea {
   border-left: 6px solid var(--pink);
 }
 
+.quiet-details {
+  padding: 0;
+}
+
+.quiet-details > summary,
+.log-disclosure > summary {
+  cursor: pointer;
+  font-weight: 850;
+}
+
+.quiet-details > summary {
+  padding: 14px;
+}
+
+.quiet-details .candidate-form {
+  margin: 0;
+  border-width: 0;
+  border-top: 1px solid var(--line);
+}
+
+.step-forward-row {
+  justify-content: flex-end;
+}
+
 .flight-candidate-form {
   border-left-color: var(--ocean);
 }
@@ -625,6 +762,40 @@ textarea {
   padding: 14px;
   border-bottom: 1px solid var(--line);
   background: linear-gradient(90deg, #e8fbff 0%, #fff8dd 100%);
+}
+
+.truth-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.truth-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: #f4f7fb;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.truth-chip.verified {
+  background: #e6fff0;
+  color: #11623a;
+}
+
+.truth-chip.partial {
+  background: #fff3ce;
+  color: #6b4200;
+}
+
+.truth-chip.review {
+  background: #eef5ff;
+  color: #174a85;
 }
 
 .recommendation-panel h4,
@@ -737,6 +908,23 @@ textarea {
   font-size: 12px;
 }
 
+.source-link-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.source-link-list a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 7px;
+  border: 1px solid rgba(5, 138, 160, 0.18);
+  border-radius: 8px;
+  background: #f8fdff;
+  font-size: 12px;
+}
+
 .evidence-details {
   margin-top: 7px;
   color: var(--muted);
@@ -758,6 +946,157 @@ textarea {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 12px;
   padding: 14px;
+}
+
+.structure-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid rgba(0, 141, 163, 0.22);
+  border-radius: 8px;
+  background: linear-gradient(135deg, #f6fdff 0%, #fff8df 100%);
+}
+
+.structure-panel h3 {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.structure-panel h3 span {
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.structure-panel p {
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+.night-plan {
+  display: grid;
+  gap: 8px;
+}
+
+.night-plan article {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid rgba(0, 141, 163, 0.16);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.night-plan.mini {
+  position: relative;
+  z-index: 1;
+  margin-top: 18px;
+}
+
+.night-plan.mini article {
+  background: rgba(255, 255, 255, 0.88);
+  font-size: 12px;
+}
+
+.stay-structure-form {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(5, 138, 160, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.stay-structure-form textarea {
+  min-height: 76px;
+  font-family: inherit;
+}
+
+.stay-structure-form .button-row {
+  align-items: center;
+}
+
+.schedule-strip {
+  display: flex;
+  grid-column: 1 / -1;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.schedule-chip {
+  min-width: 150px;
+  padding: 10px;
+  border: 1px solid rgba(5, 138, 160, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.schedule-chip.is-approved {
+  border-color: rgba(24, 164, 94, 0.35);
+  background: #ecfff4;
+}
+
+.schedule-chip strong,
+.schedule-chip span,
+.schedule-chip small {
+  display: block;
+}
+
+.schedule-chip span,
+.schedule-chip small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.inline-schedule-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(70px, 1fr));
+  gap: 6px;
+  min-width: 260px;
+}
+
+.inline-schedule-form label {
+  display: grid;
+  gap: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.inline-schedule-form input {
+  min-height: 32px;
+  padding: 5px 7px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 12px;
+}
+
+.inline-schedule-form .checkbox-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.inline-schedule-form .checkbox-line input {
+  min-height: auto;
+}
+
+.inline-schedule-form input[name="notes"] {
+  grid-column: 1 / -1;
+}
+
+.inline-schedule-form button {
+  grid-column: 1 / -1;
 }
 
 .compact-option {
@@ -804,6 +1143,35 @@ textarea {
   gap: 10px;
   margin: 12px 0;
   padding-left: 22px;
+}
+
+.map-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0 16px;
+}
+
+.map-actions a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.map-actions .primary-link {
+  border-color: transparent;
+  background: var(--ocean);
+  color: #ffffff;
+}
+
+.map-actions .secondary-link {
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--ocean-dark);
 }
 
 .map-sequence li {
@@ -967,6 +1335,17 @@ textarea {
   padding: 18px;
 }
 
+.log-disclosure summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  list-style: none;
+}
+
+.log-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
 .empty-state {
   padding: 18px;
   border: 1px dashed var(--line);
@@ -983,8 +1362,13 @@ textarea {
   .layout,
   .form-grid,
   .form-section,
-  .map-panel {
+  .map-panel,
+  .structure-panel {
     grid-template-columns: 1fr;
+  }
+
+  .stage-tabs {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .command-band,
@@ -994,9 +1378,8 @@ textarea {
     flex-direction: column;
   }
 
-  .status-strip {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    width: 100%;
+  .progress-track {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .map-side {
@@ -1020,6 +1403,10 @@ textarea {
     width: 100%;
   }
 
+  .stage-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .top-actions button,
   .top-actions a {
     flex: 1;
@@ -1033,4 +1420,1198 @@ textarea {
   .log-meta {
     justify-items: start;
   }
+}
+
+/* Consumer planner shell, inspired by Compass without changing Trippy's service-backed flow. */
+:root {
+  --ink: #162331;
+  --muted: #637083;
+  --line: #d7e6ec;
+  --paper: #eef8fb;
+  --surface: rgba(255, 255, 255, 0.88);
+  --surface-strong: #ffffff;
+  --sun: #ffc93d;
+  --coral: #ff6d59;
+  --ocean: #058aa0;
+  --ocean-dark: #056a79;
+  --sky: #dff7fb;
+  --leaf: #20a36b;
+  --plum: #5865c7;
+  --pink: #f45188;
+  --sidebar: #172330;
+  --sidebar-soft: #243446;
+  --shadow-soft: 0 18px 54px rgba(31, 76, 92, 0.12);
+  --shadow-tight: 0 10px 24px rgba(31, 76, 92, 0.1);
+}
+
+html {
+  min-height: 100%;
+  background: var(--paper);
+}
+
+body {
+  min-height: 100vh;
+  background:
+    linear-gradient(to right, rgba(5, 138, 160, 0.055) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(5, 138, 160, 0.055) 1px, transparent 1px),
+    linear-gradient(135deg, #f6fdff 0%, #edf9fb 48%, #fff8e5 100%);
+  background-size: 36px 36px, 36px 36px, auto;
+  font-family: "DM Sans", Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+h1,
+h2,
+h3 {
+  letter-spacing: 0;
+}
+
+h1,
+h2 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 700;
+}
+
+h3 {
+  font-size: 20px;
+  line-height: 1.18;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 104px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  min-height: 100vh;
+  height: 100vh;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 18px;
+  padding: 22px 10px;
+  background:
+    linear-gradient(180deg, rgba(50, 83, 101, 0.5), transparent 190px),
+    var(--sidebar);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 0;
+  box-shadow: 16px 0 42px rgba(10, 25, 36, 0.16);
+}
+
+.brand-lockup {
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+}
+
+.brand-logo {
+  width: 66px;
+  height: 66px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+}
+
+.brand-copy {
+  min-width: 0;
+  text-align: center;
+}
+
+.brand-copy .eyebrow {
+  display: none;
+}
+
+.brand-copy h1 {
+  margin: 0;
+  color: #ffffff;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 19px;
+  line-height: 1;
+}
+
+.brand-copy span {
+  display: block;
+  margin-top: 4px;
+  color: rgba(255, 255, 255, 0.56);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.top-actions {
+  display: grid;
+  gap: 10px;
+  width: 100%;
+  margin-top: 10px;
+}
+
+button,
+a.button,
+.top-actions a,
+.top-actions button {
+  border-radius: 8px;
+}
+
+.top-actions button,
+.top-actions a {
+  display: grid;
+  min-height: 46px;
+  place-items: center;
+  padding: 8px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(95, 209, 207, 0.14);
+  color: rgba(255, 255, 255, 0.78);
+  box-shadow: none;
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.top-actions button:hover,
+.top-actions a:hover {
+  background: #5fd1cf;
+  color: #10222c;
+  box-shadow: 0 12px 28px rgba(95, 209, 207, 0.26);
+}
+
+main {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 26px clamp(18px, 3vw, 42px) 48px;
+}
+
+.hero-shell,
+.command-band {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(240px, 0.45fr) minmax(0, 1fr);
+  gap: clamp(14px, 2vw, 26px);
+  align-items: center;
+  min-height: 112px;
+  overflow: hidden;
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(255, 255, 255, 0.95), rgba(232, 249, 252, 0.9) 54%, rgba(255, 249, 224, 0.82)),
+    var(--surface-strong);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-shell::after {
+  content: "";
+  position: absolute;
+  right: 42px;
+  top: 28px;
+  width: 140px;
+  height: 140px;
+  background: url("/static/trippy-logo.png") center / contain no-repeat;
+  opacity: 0.04;
+  pointer-events: none;
+  transform: rotate(5deg);
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-logo-start {
+  position: relative;
+  z-index: 1;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  min-height: 220px;
+}
+
+.hero-logo-start img {
+  width: min(420px, 72vw);
+  max-height: 280px;
+  object-fit: contain;
+  filter: drop-shadow(0 24px 34px rgba(23, 35, 48, 0.16));
+}
+
+.command-band.no-active-trip {
+  grid-template-columns: 1fr;
+  place-items: center;
+  min-height: 310px;
+  padding: clamp(24px, 5vw, 46px);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(95, 209, 207, 0.16), transparent 34%),
+    radial-gradient(circle at 78% 66%, rgba(255, 201, 61, 0.22), transparent 32%),
+    rgba(255, 255, 255, 0.86);
+}
+
+.command-band.no-active-trip .hero-copy,
+.command-band.no-active-trip .planning-progress,
+.command-band.no-active-trip .status-strip {
+  display: none;
+}
+
+.command-band.no-active-trip .hero-logo-start {
+  display: flex;
+}
+
+.eyebrow {
+  color: var(--ocean);
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.13em;
+}
+
+.hero-shell h2,
+.command-band h2 {
+  margin-bottom: 5px;
+  font-size: clamp(30px, 4vw, 48px);
+  line-height: 0.95;
+  color: var(--ink);
+}
+
+.subhead {
+  max-width: 740px;
+  color: var(--muted);
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.planning-progress {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.progress-track {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid rgba(5, 138, 160, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.progress-step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "icon label"
+    "icon detail";
+  column-gap: 7px;
+  align-items: center;
+  min-height: 48px;
+  padding: 7px;
+  border: 1px solid rgba(215, 230, 236, 0.9);
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--muted);
+  box-shadow: none;
+  text-align: left;
+}
+
+.progress-step:hover {
+  transform: none;
+  box-shadow: 0 8px 16px rgba(31, 76, 92, 0.08);
+}
+
+.progress-icon {
+  grid-area: icon;
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: #edf3f7;
+  color: inherit;
+  font-size: 13px;
+  font-weight: 950;
+}
+
+.progress-label {
+  grid-area: label;
+  min-width: 0;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.progress-step small {
+  grid-area: detail;
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  font-size: 11px;
+  font-weight: 750;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.progress-step.done {
+  border-color: rgba(45, 185, 111, 0.35);
+  background: #ecfff4;
+  color: #1c7350;
+}
+
+.progress-step.done .progress-icon {
+  background: #2db96f;
+  color: #ffffff;
+}
+
+.progress-step.active {
+  border-color: rgba(255, 201, 61, 0.75);
+  background: #fff7d8;
+  color: #7a4b00;
+}
+
+.progress-step.active .progress-icon {
+  background: var(--sun);
+  color: var(--ink);
+}
+
+.progress-step.todo {
+  opacity: 0.78;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(236px, 296px) minmax(0, 1fr);
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.trip-rail,
+.wizard-panel,
+.visual-section {
+  border: 1px solid rgba(215, 230, 236, 0.9);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow-tight);
+  backdrop-filter: blur(10px);
+}
+
+.trip-rail {
+  position: sticky;
+  top: 26px;
+  display: grid;
+  gap: 12px;
+  align-self: start;
+  padding: 18px;
+}
+
+.rail-head h2,
+.wizard-head h2,
+.section-head h2 {
+  margin: 0;
+  font-size: clamp(28px, 3vw, 42px);
+  line-height: 1;
+}
+
+.rail-head {
+  align-items: stretch;
+}
+
+.rail-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  width: 100%;
+}
+
+.rail-actions button {
+  min-height: 44px;
+  padding: 10px 12px;
+  font-size: 15px;
+}
+
+.rail-head .eyebrow,
+.wizard-head .eyebrow,
+.section-head .eyebrow {
+  margin-bottom: 4px;
+}
+
+.trip-list {
+  gap: 8px;
+  margin-top: 0;
+}
+
+.trip-list-item {
+  grid-template-columns: minmax(0, 1fr) 42px;
+  gap: 8px;
+}
+
+.trip-button {
+  padding: 12px 14px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ink);
+  box-shadow: none;
+}
+
+.trip-button:hover {
+  background: rgba(5, 138, 160, 0.08);
+  color: var(--ink);
+  box-shadow: none;
+}
+
+.trip-list-item.active .trip-button {
+  border-color: rgba(5, 138, 160, 0.44);
+  background: rgba(223, 247, 251, 0.75);
+  box-shadow: inset 4px 0 0 var(--ocean);
+}
+
+.trip-menu-button {
+  min-height: 48px;
+  border-color: rgba(215, 230, 236, 0.9);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--muted);
+}
+
+.trip-menu-button:hover {
+  background: rgba(255, 201, 61, 0.18);
+  color: var(--ink);
+  box-shadow: none;
+}
+
+.wizard-panel {
+  min-height: 680px;
+  padding: clamp(18px, 2.2vw, 28px);
+}
+
+.wizard-head {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(280px, 1fr);
+  align-items: end;
+  gap: 18px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(215, 230, 236, 0.8);
+}
+
+.next-step {
+  max-width: 620px;
+  justify-self: end;
+  color: var(--muted);
+  font-size: 19px;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.stage-tabs {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 0;
+  margin: 18px 0 20px;
+  padding: 8px;
+  overflow: visible;
+  border: 1px solid rgba(5, 138, 160, 0.14);
+  border-radius: 8px;
+  background: rgba(238, 248, 251, 0.72);
+}
+
+.stage-tabs button {
+  position: relative;
+  display: inline-flex;
+  min-width: 0;
+  min-height: 46px;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 7px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  box-shadow: none;
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.stage-tabs button:hover {
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--ink);
+  box-shadow: none;
+  transform: none;
+}
+
+.stage-tabs button span {
+  width: 24px;
+  height: 24px;
+  background: rgba(255, 255, 255, 0.88);
+  color: inherit;
+  font-size: 12px;
+}
+
+.stage-tabs button.complete {
+  background: transparent;
+  color: #1c7350;
+  border: 0;
+}
+
+.stage-tabs button.complete span {
+  background: rgba(32, 163, 107, 0.12);
+  color: #1c7350;
+}
+
+.stage-tabs button.locked {
+  background: transparent;
+  color: rgba(99, 112, 131, 0.5);
+  border: 0;
+}
+
+.stage-tabs button.active,
+.stage-tabs button.active.complete {
+  background: var(--sidebar);
+  color: #ffffff;
+  border: 0;
+  box-shadow: 0 12px 24px rgba(23, 35, 48, 0.18);
+}
+
+.stage-tabs button.active span {
+  background: var(--sun);
+  color: var(--ink);
+}
+
+.start-screen,
+.guided-step-layout,
+.research-stack {
+  gap: 16px;
+}
+
+.start-hero,
+.stage-card,
+.option-card,
+.pick-card,
+.suggestion-card,
+.idea-action-card,
+.comparison-panel,
+.structure-panel,
+.map-panel,
+.compact-option,
+.empty-state {
+  border-radius: 8px;
+}
+
+.start-hero,
+.stage-card,
+.idea-action-card,
+.suggest-form,
+.structure-panel {
+  border: 1px solid rgba(215, 230, 236, 0.9);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 8px 22px rgba(31, 76, 92, 0.06);
+}
+
+.start-hero {
+  padding: 20px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(223, 247, 251, 0.78));
+}
+
+.start-hero h3 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(26px, 4vw, 38px);
+}
+
+.idea-action-grid,
+.suggestion-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.idea-action-card {
+  display: grid;
+  min-height: 168px;
+  align-content: space-between;
+  padding: 18px;
+}
+
+.idea-action-card.suggest {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 249, 224, 0.86));
+}
+
+.action-card {
+  align-items: flex-start;
+  padding: 16px;
+}
+
+.action-card p {
+  max-width: 760px;
+  color: var(--muted);
+}
+
+.form-section {
+  grid-template-columns: minmax(130px, 190px) minmax(0, 1fr);
+  padding: 16px;
+  border-color: rgba(215, 230, 236, 0.82);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+input,
+select,
+textarea {
+  border-color: rgba(183, 207, 216, 0.9);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 3px solid rgba(95, 209, 207, 0.24);
+  border-color: rgba(5, 138, 160, 0.58);
+}
+
+button,
+a.button {
+  background: var(--ocean);
+  box-shadow: 0 10px 20px rgba(5, 138, 160, 0.16);
+}
+
+button:hover,
+a.button:hover {
+  background: var(--ocean-dark);
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--ocean-dark);
+  box-shadow: none;
+}
+
+.option-grid,
+.shortlist-grid,
+.pick-grid {
+  grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+}
+
+.option-card,
+.pick-card,
+.suggestion-card {
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 8px 22px rgba(31, 76, 92, 0.08);
+}
+
+.option-card.selected,
+.recommended-row {
+  outline: 0;
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 201, 61, 0.9),
+    0 14px 32px rgba(31, 76, 92, 0.12);
+}
+
+.option-map-thumb {
+  min-height: 158px;
+  background:
+    linear-gradient(135deg, rgba(223, 247, 251, 0.96), rgba(255, 249, 224, 0.92));
+}
+
+.comparison-panel {
+  border-color: rgba(215, 230, 236, 0.9);
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 8px 22px rgba(31, 76, 92, 0.07);
+}
+
+.comparison-head {
+  background: rgba(247, 252, 253, 0.88);
+}
+
+.comparison-table {
+  font-size: 13px;
+}
+
+.comparison-table th {
+  background: rgba(23, 35, 48, 0.92);
+  color: rgba(255, 255, 255, 0.84);
+}
+
+.comparison-table td {
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.comparison-table tr:hover td {
+  background: rgba(223, 247, 251, 0.5);
+}
+
+.recommendation-panel,
+.structure-panel {
+  background:
+    linear-gradient(120deg, rgba(255, 255, 255, 0.92), rgba(223, 247, 251, 0.82) 58%, rgba(255, 249, 224, 0.72));
+}
+
+.visual-section {
+  margin-top: 18px;
+  padding: 20px;
+}
+
+.section-head {
+  align-items: end;
+  padding-bottom: 14px;
+}
+
+.log-disclosure {
+  background: rgba(255, 255, 255, 0.64);
+  box-shadow: none;
+}
+
+.map-panel iframe {
+  min-height: 500px;
+}
+
+@media (max-width: 1100px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .app-header {
+    position: static;
+    min-height: auto;
+    height: auto;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 18px;
+  }
+
+  .brand-lockup {
+    display: flex;
+    justify-items: start;
+  }
+
+  .brand-copy {
+    text-align: left;
+  }
+
+  .brand-copy .eyebrow {
+    display: block;
+    color: rgba(255, 255, 255, 0.56);
+  }
+
+  .top-actions {
+    display: flex;
+    width: auto;
+    margin-top: 0;
+  }
+
+  .top-actions button,
+  .top-actions a {
+    min-height: 40px;
+    padding: 8px 12px;
+  }
+
+  .hero-shell,
+  .command-band {
+    grid-template-columns: 1fr;
+  }
+
+  .trip-rail {
+    position: static;
+  }
+}
+
+@media (max-width: 760px) {
+  main {
+    padding: 14px 12px 34px;
+  }
+
+  .hero-shell h2,
+  .command-band h2 {
+    font-size: clamp(34px, 12vw, 54px);
+  }
+
+  .command-band.no-active-trip {
+    min-height: 230px;
+  }
+
+  .progress-track {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero-logo-start {
+    min-height: 160px;
+  }
+
+  .status-strip,
+  .layout,
+  .form-grid,
+  .form-section,
+  .map-panel,
+  .structure-panel,
+  .recommendation-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .stage-tabs {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stage-tabs button {
+    flex: none;
+  }
+
+  .map-side {
+    max-height: none;
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+}
+
+.idea-feedback {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(215, 230, 236, 0.86);
+}
+
+.idea-feedback label {
+  gap: 5px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.idea-feedback textarea {
+  min-height: 56px;
+  margin-top: 5px;
+  font-size: 13px;
+}
+
+.idea-feedback-result {
+  min-height: 16px;
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.suggestion-card .metric.warn {
+  border-color: rgba(255, 107, 74, 0.45);
+  background: #fff1ed;
+  color: #99371f;
+}
+
+/* Icon-only planner progress. Labels are available on hover/focus and to screen readers. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.planning-progress {
+  justify-self: end;
+}
+
+.progress-track {
+  display: inline-flex;
+  width: auto;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 6px 8px;
+}
+
+.progress-step {
+  position: relative;
+  display: inline-grid;
+  width: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  flex: 0 0 auto;
+  grid-template-columns: 1fr;
+  grid-template-areas: "icon";
+  place-items: center;
+  padding: 0;
+}
+
+.progress-step::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  right: 50%;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  max-width: 220px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: var(--sidebar);
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(23, 35, 48, 0.18);
+  font-size: 12px;
+  font-weight: 850;
+  line-height: 1.2;
+  opacity: 0;
+  pointer-events: none;
+  text-align: center;
+  transform: translate(50%, 4px);
+  transition: opacity 120ms ease, transform 120ms ease;
+  white-space: nowrap;
+}
+
+.progress-step:hover::after,
+.progress-step:focus-visible::after {
+  opacity: 1;
+  transform: translate(50%, 0);
+}
+
+.progress-icon {
+  width: 28px;
+  height: 28px;
+}
+
+.progress-icon svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.progress-label,
+.progress-step small {
+  display: none;
+}
+
+.progress-step.active {
+  width: 44px;
+  min-width: 44px;
+}
+
+.wizard-panel > .stage-tabs,
+#stageTabs {
+  display: none;
+}
+
+@media (max-width: 760px) {
+  .planning-progress {
+    justify-self: stretch;
+  }
+
+  .progress-track {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .progress-step {
+    width: 34px;
+    min-width: 34px;
+    min-height: 34px;
+  }
+
+  .progress-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .progress-icon svg {
+    width: 17px;
+    height: 17px;
+  }
+}
+
+/* Final planner chrome overrides: keep the main flow compact and on-rails. */
+.hero-shell,
+.command-band {
+  grid-template-columns: minmax(220px, 0.38fr) minmax(0, 1fr);
+  min-height: 92px;
+  padding: 12px 14px;
+}
+
+.hero-shell h2,
+.command-band h2 {
+  margin-bottom: 3px;
+  font-size: clamp(28px, 3.3vw, 42px);
+}
+
+.subhead {
+  font-size: 13px;
+}
+
+.planning-progress {
+  align-self: center;
+}
+
+.progress-track {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  padding: 7px;
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, rgba(0, 138, 161, 0.1), rgba(255, 201, 61, 0.16)),
+    rgba(255, 255, 255, 0.72);
+}
+
+.progress-step {
+  display: inline-grid;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 38px;
+  grid-template-columns: 26px minmax(0, auto);
+  grid-template-areas: "icon label";
+  justify-content: center;
+  column-gap: 7px;
+  padding: 6px 9px;
+  border-radius: 999px;
+  border: 0;
+  background: transparent;
+}
+
+.progress-step small {
+  display: none;
+}
+
+.progress-icon {
+  width: 24px;
+  height: 24px;
+  font-size: 11px;
+}
+
+.progress-label {
+  align-self: center;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.progress-step.done {
+  background: rgba(32, 163, 107, 0.13);
+}
+
+.progress-step.active {
+  background: #172330;
+  color: #ffffff;
+  box-shadow: 0 10px 22px rgba(23, 35, 48, 0.16);
+}
+
+.progress-step.active .progress-label {
+  color: #ffffff;
+}
+
+.progress-step.active .progress-icon {
+  background: var(--sun);
+  color: var(--ink);
+}
+
+.wizard-panel > .stage-tabs {
+  display: none;
+}
+
+@media (max-width: 1100px) {
+  .hero-shell,
+  .command-band {
+    grid-template-columns: 1fr;
+  }
+
+  .progress-track {
+    border-radius: 8px;
+  }
+}
+
+@media (max-width: 760px) {
+  .hero-shell,
+  .command-band {
+    min-height: 82px;
+  }
+
+  .hero-shell h2,
+  .command-band h2 {
+    font-size: clamp(28px, 10vw, 44px);
+  }
+
+  .progress-track {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .progress-step {
+    min-height: 34px;
+    grid-template-columns: 22px;
+    grid-template-areas: "icon";
+    padding: 5px;
+  }
+
+  .progress-label {
+    display: none;
+  }
+}
+
+/* Must stay last: the planner progress is icon-only, with words only on hover/focus. */
+.planning-progress {
+  justify-self: end;
+}
+
+.progress-track {
+  display: inline-flex;
+  width: auto;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 6px 8px;
+}
+
+.progress-step {
+  position: relative;
+  width: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  flex: 0 0 auto;
+  grid-template-columns: 1fr;
+  grid-template-areas: "icon";
+  place-items: center;
+  padding: 0;
+}
+
+.progress-step::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  right: 50%;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: var(--sidebar);
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(23, 35, 48, 0.18);
+  font-size: 12px;
+  font-weight: 850;
+  line-height: 1.2;
+  opacity: 0;
+  pointer-events: none;
+  text-align: center;
+  transform: translate(50%, 4px);
+  transition: opacity 120ms ease, transform 120ms ease;
+  white-space: nowrap;
+}
+
+.progress-step:hover::after,
+.progress-step:focus-visible::after {
+  opacity: 1;
+  transform: translate(50%, 0);
+}
+
+.progress-icon {
+  width: 28px;
+  height: 28px;
+}
+
+.progress-icon svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.progress-label,
+.progress-step small,
+#stageTabs {
+  display: none;
 }

--- a/trippy/ui/static/app.css
+++ b/trippy/ui/static/app.css
@@ -603,6 +603,26 @@ textarea {
   color: var(--muted);
 }
 
+.guided-notice {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border: 1px solid rgba(45, 185, 111, 0.28);
+  border-radius: 8px;
+  background: linear-gradient(135deg, #edfff5 0%, #e4fbff 100%);
+  color: var(--ink);
+}
+
+.guided-notice strong {
+  color: #10613b;
+}
+
+.guided-notice span {
+  color: var(--muted);
+}
+
 .idea-action-grid,
 .suggestion-grid {
   display: grid;
@@ -708,6 +728,18 @@ textarea {
   justify-content: flex-end;
 }
 
+.inline-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  min-height: 42px;
+}
+
+.inline-toolbar .inline-result {
+  margin: 0;
+}
+
 .flight-candidate-form {
   border-left-color: var(--ocean);
 }
@@ -727,6 +759,30 @@ textarea {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+}
+
+.comparison-head.compact-head {
+  align-items: center;
+  padding: 10px 12px;
+}
+
+.recommended-inline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.recommended-inline strong,
+.recommended-inline small {
+  min-width: 0;
+}
+
+.recommended-inline small {
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .comparison-head p {
@@ -941,6 +997,121 @@ textarea {
   font-size: 12px;
 }
 
+.booking-details {
+  margin-top: 8px;
+}
+
+.booking-details summary {
+  cursor: pointer;
+  color: var(--ocean-dark);
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.booking-form {
+  display: grid;
+  gap: 8px;
+  min-width: 250px;
+  margin-top: 8px;
+  padding: 10px;
+  border: 1px solid rgba(0, 141, 163, 0.2);
+  border-radius: 8px;
+  background: #f8fdff;
+}
+
+.booking-form label {
+  font-size: 12px;
+}
+
+.inline-two {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.packet-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  background: linear-gradient(135deg, #e4fbff 0%, #fff8df 68%, #ffe8f2 100%);
+}
+
+.readiness-meter {
+  display: grid;
+  place-items: center;
+  min-width: 170px;
+  min-height: 112px;
+  border: 1px solid rgba(0, 141, 163, 0.22);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.readiness-meter strong {
+  font-size: 36px;
+  line-height: 1;
+}
+
+.readiness-meter span {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.blocker-card {
+  border-left: 6px solid var(--sun);
+}
+
+.blocker-card.is-clear {
+  border-left-color: var(--leaf);
+  background: #f0fff6;
+}
+
+.packet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  padding: 14px;
+}
+
+.packet-item-card {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.packet-item-card.confirmed {
+  border-color: rgba(45, 185, 111, 0.55);
+  background: #f3fff7;
+}
+
+.packet-item-card.booked {
+  border-color: rgba(255, 201, 40, 0.65);
+  background: #fff9df;
+}
+
+.status-badge.confirmed,
+.truth-chip.confirmed {
+  background: #e4fff0;
+  color: #0d6b3e;
+}
+
+.status-badge.booked,
+.truth-chip.booked,
+.truth-chip.selected,
+.status-badge.selected {
+  background: #fff3ce;
+  color: #6b4200;
+}
+
+.truth-chip.idea,
+.status-badge.idea {
+  background: #eef5ff;
+  color: #174a85;
+}
+
 .compact-card-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -1002,6 +1173,116 @@ textarea {
 .night-plan.mini article {
   background: rgba(255, 255, 255, 0.88);
   font-size: 12px;
+}
+
+.stay-option-grid {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 12px;
+}
+
+.stay-option-card {
+  overflow: hidden;
+  border: 1px solid rgba(0, 141, 163, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.stay-option-card.recommended-row {
+  outline-width: 2px;
+}
+
+.stay-map-thumb {
+  min-height: 118px;
+  padding: 12px;
+}
+
+.stay-map-thumb .map-route-line {
+  inset: 42px 28px auto;
+}
+
+.stay-map-thumb .map-pin {
+  max-width: 48%;
+  font-size: 11px;
+}
+
+.stay-option-body {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.stay-option-body h4,
+.stay-option-body p,
+.stay-option-body ul {
+  margin: 0;
+}
+
+.stay-option-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.stay-option-actions button {
+  min-height: 38px;
+  padding: 8px 12px;
+}
+
+.lodging-group-stack {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+}
+
+.lodging-region-panel {
+  overflow: hidden;
+  border: 1px solid rgba(0, 141, 163, 0.2);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(232, 249, 252, 0.62), rgba(255, 248, 223, 0.5)),
+    #ffffff;
+}
+
+.lodging-region-panel.secondary-region {
+  background: #ffffff;
+}
+
+.lodging-region-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(215, 230, 236, 0.9);
+}
+
+.lodging-region-head h4,
+.lodging-region-head p {
+  margin: 0;
+}
+
+.lodging-region-head h4 {
+  font-size: 20px;
+}
+
+.lodging-region-head span {
+  color: var(--muted);
+  font-weight: 850;
+}
+
+.lodging-region-head > p {
+  max-width: 460px;
+  color: var(--muted);
+}
+
+.lodging-region-panel .comparison-table-wrap {
+  border: 0;
+  border-radius: 0;
+}
+
+.lodging-region-panel .comparison-table {
+  margin: 0;
 }
 
 .stay-structure-form {
@@ -1478,7 +1759,7 @@ h3 {
 
 .app-shell {
   display: grid;
-  grid-template-columns: 104px minmax(0, 1fr);
+  grid-template-columns: 156px minmax(0, 1fr);
   min-height: 100vh;
 }
 
@@ -1491,8 +1772,8 @@ h3 {
   height: 100vh;
   flex-direction: column;
   justify-content: flex-start;
-  gap: 18px;
-  padding: 22px 10px;
+  gap: 10px;
+  padding: 14px 8px;
   background:
     linear-gradient(180deg, rgba(50, 83, 101, 0.5), transparent 190px),
     var(--sidebar);
@@ -1504,12 +1785,12 @@ h3 {
 .brand-lockup {
   display: grid;
   justify-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
 .brand-logo {
-  width: 66px;
-  height: 66px;
+  width: 62px;
+  height: 62px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.08);
@@ -1529,15 +1810,15 @@ h3 {
   margin: 0;
   color: #ffffff;
   font-family: Georgia, "Times New Roman", serif;
-  font-size: 19px;
+  font-size: 17px;
   line-height: 1;
 }
 
 .brand-copy span {
   display: block;
-  margin-top: 4px;
+  margin-top: 3px;
   color: rgba(255, 255, 255, 0.56);
-  font-size: 10px;
+  font-size: 8px;
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1545,9 +1826,10 @@ h3 {
 
 .top-actions {
   display: grid;
-  gap: 10px;
+  grid-template-columns: 1fr;
+  gap: 6px;
   width: 100%;
-  margin-top: 10px;
+  margin-top: 4px;
 }
 
 button,
@@ -1560,14 +1842,14 @@ a.button,
 .top-actions button,
 .top-actions a {
   display: grid;
-  min-height: 46px;
+  min-height: 32px;
   place-items: center;
-  padding: 8px 6px;
+  padding: 6px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(95, 209, 207, 0.14);
   color: rgba(255, 255, 255, 0.78);
   box-shadow: none;
-  font-size: 12px;
+  font-size: 10px;
   font-weight: 850;
 }
 
@@ -1779,7 +2061,7 @@ main {
 
 .layout {
   display: grid;
-  grid-template-columns: minmax(236px, 296px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: 18px;
   margin-top: 18px;
 }
@@ -1796,11 +2078,17 @@ main {
 
 .trip-rail {
   position: sticky;
-  top: 26px;
+  top: 12px;
   display: grid;
-  gap: 12px;
+  gap: 8px;
   align-self: start;
-  padding: 18px;
+  max-height: calc(100vh - 160px);
+  overflow-y: auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
 }
 
 .rail-head h2,
@@ -1817,15 +2105,15 @@ main {
 
 .rail-actions {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
+  grid-template-columns: 1fr;
+  gap: 6px;
   width: 100%;
 }
 
 .rail-actions button {
-  min-height: 44px;
-  padding: 10px 12px;
-  font-size: 15px;
+  min-height: 32px;
+  padding: 7px 8px;
+  font-size: 11px;
 }
 
 .rail-head .eyebrow,
@@ -1835,40 +2123,69 @@ main {
 }
 
 .trip-list {
-  gap: 8px;
+  display: grid;
+  gap: 6px;
   margin-top: 0;
 }
 
 .trip-list-item {
-  grid-template-columns: minmax(0, 1fr) 42px;
-  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 28px;
+  gap: 5px;
 }
 
 .trip-button {
-  padding: 12px 14px;
+  min-height: 38px;
+  padding: 7px 8px;
   border: 1px solid transparent;
-  background: transparent;
-  color: var(--ink);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.88);
   box-shadow: none;
+  font-size: 11px;
+  line-height: 1.15;
 }
 
 .trip-button:hover {
-  background: rgba(5, 138, 160, 0.08);
-  color: var(--ink);
+  background: rgba(95, 209, 207, 0.18);
+  color: #ffffff;
   box-shadow: none;
 }
 
 .trip-list-item.active .trip-button {
   border-color: rgba(5, 138, 160, 0.44);
   background: rgba(223, 247, 251, 0.75);
-  box-shadow: inset 4px 0 0 var(--ocean);
+  color: var(--ink);
+  box-shadow: inset 3px 0 0 var(--ocean);
+}
+
+.trip-button small {
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.54);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trip-list-item.active .trip-button small {
+  color: var(--muted);
 }
 
 .trip-menu-button {
-  min-height: 48px;
+  width: 28px;
+  min-height: 38px;
+  padding: 0;
   border-color: rgba(215, 230, 236, 0.9);
   background: rgba(255, 255, 255, 0.72);
   color: var(--muted);
+  font-size: 13px;
+}
+
+.rail-empty {
+  padding: 8px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 11px;
+  font-weight: 750;
+  text-align: center;
 }
 
 .trip-menu-button:hover {
@@ -2170,6 +2487,7 @@ button.secondary {
     min-height: auto;
     height: auto;
     flex-direction: row;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
     padding: 12px 18px;
@@ -2208,6 +2526,16 @@ button.secondary {
 
   .trip-rail {
     position: static;
+    flex-basis: 100%;
+    max-height: none;
+  }
+
+  .rail-actions {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .trip-list {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 }
 
@@ -2614,4 +2942,306 @@ button.secondary {
 .progress-step small,
 #stageTabs {
   display: none;
+}
+
+/* Final usability pass: wider rail, data-first compare tables, sheet-first planning surface. */
+:root {
+  --rail-width: 232px;
+}
+
+.app-shell {
+  grid-template-columns: var(--rail-width) minmax(0, 1fr);
+}
+
+.app-header {
+  position: sticky;
+  min-width: var(--rail-width);
+  width: var(--rail-width);
+  padding: 18px 12px;
+  gap: 12px;
+}
+
+.rail-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -6px;
+  width: 12px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.rail-resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 2px;
+  width: 3px;
+  height: 64px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-50%);
+}
+
+body.is-resizing-rail {
+  cursor: col-resize;
+  user-select: none;
+}
+
+.brand-lockup {
+  gap: 10px;
+}
+
+.brand-logo {
+  width: clamp(78px, calc(var(--rail-width) * 0.42), 118px);
+  height: clamp(78px, calc(var(--rail-width) * 0.42), 118px);
+}
+
+.brand-copy h1 {
+  font-size: clamp(26px, calc(var(--rail-width) * 0.16), 42px);
+}
+
+.brand-copy span {
+  font-size: 11px;
+}
+
+.top-actions button,
+.top-actions a,
+.rail-actions button {
+  min-height: 42px;
+  font-size: 15px;
+}
+
+.trip-button,
+.trip-menu-button {
+  min-height: 54px;
+  font-size: 14px;
+}
+
+.trip-button {
+  padding: 10px 12px;
+}
+
+.trip-button small {
+  font-size: 11px;
+}
+
+.compare-header-tight {
+  align-items: center;
+}
+
+.compare-header-tight p {
+  max-width: 720px;
+}
+
+.comparison-table.flight-table th,
+.comparison-table.flight-table td,
+.comparison-table.lodging-table th,
+.comparison-table.lodging-table td {
+  vertical-align: top;
+}
+
+.flight-table th:nth-child(1),
+.lodging-table th:nth-child(1) {
+  width: 110px;
+}
+
+.flight-table th:nth-child(2) {
+  width: 250px;
+}
+
+.flight-table th:nth-child(3),
+.flight-table th:nth-child(4) {
+  width: 170px;
+}
+
+.flight-table th:nth-child(5) {
+  width: 160px;
+}
+
+.flight-table th:nth-child(6) {
+  width: 170px;
+}
+
+.lodging-table th:nth-child(2) {
+  width: 270px;
+}
+
+.lodging-table th:nth-child(3) {
+  width: 160px;
+}
+
+.lodging-table th:nth-child(4) {
+  width: 190px;
+}
+
+.lodging-table th:nth-child(5) {
+  width: 180px;
+}
+
+.lodging-table th:nth-child(6) {
+  width: 220px;
+}
+
+.action-stack {
+  display: grid;
+  gap: 8px;
+  justify-items: start;
+}
+
+.sheet-frame-panel {
+  padding: 16px 18px 18px;
+}
+
+.sheet-frame-wrap {
+  overflow: hidden;
+  border: 1px solid rgba(215, 230, 236, 0.9);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.sheet-frame-wrap iframe {
+  width: 100%;
+  min-height: 820px;
+  border: 0;
+}
+
+.compact-stage-actions p {
+  max-width: 760px;
+}
+
+.packet-summary-strip {
+  padding: 16px 18px;
+}
+
+.packet-mini-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.packet-item-card.compact {
+  min-height: auto;
+}
+
+.activity-card-stack {
+  display: grid;
+  gap: 14px;
+  padding: 0 14px 14px;
+}
+
+.activity-card {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 16px;
+  padding: 14px;
+  border-top: 1px solid rgba(215, 230, 236, 0.9);
+  background: rgba(255, 255, 255, 0.74);
+}
+
+.activity-card-image .image-wrap {
+  height: 100%;
+  min-height: 140px;
+  border-radius: 8px;
+}
+
+.activity-card-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.activity-card-head h4 {
+  margin: 2px 0 4px;
+}
+
+.activity-card-head p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.activity-data-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.activity-data-grid strong,
+.activity-data-grid small {
+  display: block;
+}
+
+.activity-link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.activity-card-actions {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  margin-top: 14px;
+  align-items: start;
+}
+
+.inline-schedule-form.compact {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px 10px;
+  align-items: end;
+}
+
+.inline-schedule-form.compact .checkbox-line {
+  align-self: center;
+}
+
+.inline-schedule-form.compact input[name="notes"] {
+  grid-column: span 2;
+}
+
+.lodging-region-head span {
+  display: inline-block;
+  margin-top: 4px;
+}
+
+@media (max-width: 1100px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .app-header {
+    width: auto;
+    min-width: 0;
+  }
+
+  .rail-resize-handle {
+    display: none;
+  }
+
+  .activity-card {
+    grid-template-columns: 1fr;
+  }
+
+  .activity-data-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .activity-card-actions {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .sheet-frame-wrap iframe {
+    min-height: 640px;
+  }
+
+  .activity-data-grid,
+  .inline-schedule-form.compact {
+    grid-template-columns: 1fr;
+  }
 }

--- a/trippy/ui/static/app.js
+++ b/trippy/ui/static/app.js
@@ -13,6 +13,10 @@ const state = {
   showSuggestForm: false,
   openTripMenuId: null,
   flightSort: "best",
+  guidedNotice: null,
+  isAutoDrafting: false,
+  isAutoBuildingLodging: false,
+  pendingScrollTarget: null,
 };
 
 const stages = [
@@ -23,7 +27,7 @@ const stages = [
   { id: "lodging", label: "Lodging" },
   { id: "activities", label: "Activities" },
   { id: "plan", label: "Plan" },
-  { id: "review", label: "Review" },
+  { id: "packet", label: "Packet" },
 ];
 
 const partyOptions = [
@@ -36,6 +40,7 @@ const partyOptions = [
 ];
 
 document.addEventListener("DOMContentLoaded", () => {
+  initRailResize();
   document.getElementById("refreshButton").addEventListener("click", refresh);
   document.getElementById("generateTripButton").addEventListener("click", () => startGenerateIdeas());
   document.getElementById("newTripButton").addEventListener("click", () => startNewTrip());
@@ -48,6 +53,55 @@ document.addEventListener("DOMContentLoaded", () => {
   });
   refresh();
 });
+
+function initRailResize() {
+  const handle = document.getElementById("railResizeHandle");
+  const savedWidth = Number(window.localStorage.getItem("trippyRailWidth"));
+  if (savedWidth) {
+    setRailWidth(savedWidth);
+  }
+  if (!handle) {
+    return;
+  }
+  let startX = 0;
+  let startWidth = 0;
+  const onPointerMove = (event) => {
+    const next = startWidth + (event.clientX - startX);
+    setRailWidth(next);
+  };
+  const onPointerUp = () => {
+    document.body.classList.remove("is-resizing-rail");
+    window.removeEventListener("mousemove", onPointerMove);
+    window.removeEventListener("mouseup", onPointerUp);
+    const currentWidth = Number.parseInt(
+      getComputedStyle(document.documentElement).getPropertyValue("--rail-width"),
+      10,
+    );
+    if (currentWidth) {
+      window.localStorage.setItem("trippyRailWidth", String(currentWidth));
+    }
+  };
+  handle.addEventListener("mousedown", (event) => {
+    startX = event.clientX;
+    startWidth =
+      Number.parseInt(
+        getComputedStyle(document.documentElement).getPropertyValue("--rail-width"),
+        10,
+      ) || 232;
+    document.body.classList.add("is-resizing-rail");
+    window.addEventListener("mousemove", onPointerMove);
+    window.addEventListener("mouseup", onPointerUp);
+  });
+  handle.addEventListener("dblclick", () => {
+    setRailWidth(232);
+    window.localStorage.setItem("trippyRailWidth", "232");
+  });
+}
+
+function setRailWidth(width) {
+  const clamped = Math.max(188, Math.min(320, Math.round(Number(width) || 232)));
+  document.documentElement.style.setProperty("--rail-width", `${clamped}px`);
+}
 
 async function refresh() {
   state.app = await apiGet("/api/state");
@@ -72,7 +126,9 @@ async function loadTrip(tripId, options = {}) {
   state.openTripMenuId = null;
   state.activeTripId = tripId;
   state.trip = await apiGet(`/api/trip?trip_id=${encodeURIComponent(tripId)}`);
-  if (options.gotoNext) {
+  if (options.stage) {
+    state.activeStage = options.stage;
+  } else if (options.gotoNext) {
     state.activeStage = nextUnlockedStage();
   }
   render();
@@ -133,6 +189,25 @@ function render() {
   renderPicks();
   renderRunLog();
   wireProgressBar();
+  scrollToPendingTarget();
+}
+
+function scrollToPendingTarget() {
+  if (!state.pendingScrollTarget) {
+    return;
+  }
+  const selector = state.pendingScrollTarget;
+  state.pendingScrollTarget = null;
+  window.requestAnimationFrame(() => {
+    const target = document.querySelector(selector);
+    if (!target) {
+      return;
+    }
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (typeof target.focus === "function") {
+      target.focus({ preventScroll: true });
+    }
+  });
 }
 
 function renderHeader() {
@@ -156,7 +231,8 @@ function normalizeActiveStage() {
     research: "flights",
     workspace: "plan",
     maps: "plan",
-    feedback: "review",
+    feedback: "packet",
+    review: "packet",
   };
   state.activeStage = legacyStageMap[state.activeStage] || state.activeStage;
   if (!stages.some((stage) => stage.id === state.activeStage)) {
@@ -175,7 +251,7 @@ function isStageUnlocked(stageId) {
   if (stageId === "intake") return state.isCreatingTrip || hasTrip;
   if (stageId === "options") return hasIntake;
   if (["flights", "lodging", "activities", "plan"].includes(stageId)) return hasSelectedPlan;
-  if (stageId === "review") return hasTrip || Boolean(state.trip?.recent_workflows?.length);
+  if (stageId === "packet") return hasSelectedPlan;
   return false;
 }
 
@@ -192,7 +268,8 @@ function isStageComplete(stageId) {
     );
   }
   if (stageId === "plan") return Boolean(state.trip?.workspace || state.trip?.map_artifact);
-  return Boolean(state.trip?.recent_workflows?.length);
+  if (stageId === "packet") return tripPacketReadiness() >= 100;
+  return false;
 }
 
 function nextUnlockedStage() {
@@ -203,7 +280,8 @@ function nextUnlockedStage() {
   if (!shortlistByCategory("flights")?.flight_options?.length) return "flights";
   if (!shortlistByCategory("lodging")?.lodging_options?.length) return "lodging";
   if (!shortlistByCategory("activities")?.activity_options?.length) return "activities";
-  return "plan";
+  if (!state.trip?.workspace && !state.trip?.map_artifact) return "plan";
+  return "packet";
 }
 
 function guidedNextStep() {
@@ -216,7 +294,7 @@ function guidedNextStep() {
     lodging: "Decide one stay vs split stays, then compare places that fit the party.",
     activities: "Pick activities and car logic that fit the chosen trip shape.",
     plan: "Build the timeline, map, risks, and planning workspace.",
-    review: "Send feedback only when a workflow should teach Trippy.",
+    packet: "Add booking confirmations and review what is still missing before departure.",
   };
   return state.trip?.next_step || messages[stage] || messages.start;
 }
@@ -278,35 +356,38 @@ function shortlistMilestone(category, icon, label) {
     return { key: category, icon, label, state: "todo", detail: "needed" };
   }
   const options = shortlistOptions(shortlist);
-  const approved = options.some((option) => option.row_status === "approved" || option.row_status === "booked");
-  const booked = options.some((option) => option.row_status === "booked");
+  const approved = options.some((option) =>
+    ["approved", "booked", "confirmed"].includes(option.row_status),
+  );
+  const booked = options.some((option) => ["booked", "confirmed"].includes(option.row_status));
+  const confirmed = options.some((option) => option.row_status === "confirmed");
   return {
     key: category,
     icon,
     label,
-    state: booked || approved ? "done" : options.length ? "active" : "todo",
-    detail: booked ? "booked" : approved ? "approved" : `${options.length} found`,
+    state: confirmed || booked || approved ? "done" : options.length ? "active" : "todo",
+    detail: confirmed ? "confirmed" : booked ? "booked" : approved ? "selected" : `${options.length} found`,
   };
 }
 
 function bookingMilestoneState() {
-  const options = (state.trip?.shortlists || []).flatMap(shortlistOptions);
-  const flightBooked = options.some((option) => option.row_status === "booked" && option.airline);
-  const lodgingBooked = options.some((option) => option.row_status === "booked" && option.name);
-  const workspaceRows = state.trip?.workspace?.tabs || [];
-  const hasConfirmation = JSON.stringify(workspaceRows).toLowerCase().includes("confirmation");
-  return flightBooked && lodgingBooked && hasConfirmation ? "done" : "todo";
+  const readiness = tripPacketReadiness();
+  if (readiness >= 100) return "done";
+  if (readiness > 0) return "active";
+  return "todo";
 }
 
 function bookingMilestoneDetail() {
-  return bookingMilestoneState() === "done" ? "confirmed" : "confirmations needed";
+  const packet = state.trip?.trip_packet;
+  if (!packet) return "confirmations needed";
+  return `${packet.readiness_percent || 0}% ${packet.status_label || ""}`.trim();
 }
 
 function renderTripList() {
   const trips = collectTrips();
   const list = document.getElementById("tripList");
   if (!trips.length) {
-    list.innerHTML = `<div class="empty-state">No trip state yet.</div>`;
+    list.innerHTML = `<div class="rail-empty">No trips yet</div>`;
     return;
   }
   list.innerHTML = trips
@@ -419,7 +500,7 @@ function progressStageForMilestone(key) {
     cars: "activities",
     activities: "activities",
     workspace: "plan",
-    booked: "plan",
+    booked: "packet",
   };
   return map[key] || "start";
 }
@@ -447,6 +528,9 @@ function renderStage() {
   } else if (state.activeStage === "plan") {
     body.innerHTML = planStage();
     wirePlanStage(body);
+  } else if (state.activeStage === "packet") {
+    body.innerHTML = packetStage();
+    wirePacketStage(body);
   } else {
     body.innerHTML = learningStage();
     wireFeedbackForms(body, "review");
@@ -560,8 +644,7 @@ function intakeStage() {
       </section>
 
       <div class="button-row">
-        <button type="submit">Save intake</button>
-        <button type="button" class="secondary" id="draftFromIntake">Save and build options</button>
+        <button type="submit">Save and start planning</button>
       </div>
       <p class="inline-result"></p>
     </form>
@@ -575,19 +658,12 @@ function draftStage() {
     return `<div class="empty-state">Create or select a trip first.</div>`;
   }
   const options = draft?.options || [];
-  const buttonLabel = options.length ? "Refresh from intake" : "Build options";
   return `
-    <div class="stage-card action-card">
-      <div>
-        <h3>${options.length ? "Planning shapes are deterministic from the saved intake" : "Build planning shapes"}</h3>
-        <p>${options.length ? "Refresh only after changing constraints. Choosing one shape moves directly into flights." : "Trippy will build a small set of planning shapes from the saved intake."}</p>
-      </div>
-      <button id="draftButton" type="button">${buttonLabel}</button>
-      <p class="inline-result"></p>
-    </div>
+    ${stageNotice("options")}
     <div class="option-grid">
-      ${options.length ? options.map(planOptionCard).join("") : `<div class="empty-state">No options yet.</div>`}
+      ${options.length ? options.map(planOptionCard).join("") : `<div class="empty-state">Building planning shapes...</div>`}
     </div>
+    <p class="inline-result"></p>
     ${feedbackBlock("draft")}
   `;
 }
@@ -627,7 +703,18 @@ function flightCandidateForm() {
     <div class="form-grid">
       ${input("name", "Airline / label", "", "text")}
       ${input("link", "Link", "", "url")}
-      ${textarea("notes", "Flight notes", "", "Example: Air Canada AC123 + TAP TP1861, depart 9:15 PM, arrive 2:20 PM, duration 10h 35m, 1 stop via LIS, layover 2h 20m, CAD 1180 pp, checked bag included.")}
+      ${input("flight_numbers", "Flight number(s)", "", "text")}
+      ${input("departure_date", "Depart date", "", "date")}
+      ${input("departure_time", "Depart time", "", "text")}
+      ${input("arrival_date", "Arrive date", "", "date")}
+      ${input("arrival_time", "Arrive time", "", "text")}
+      ${input("total_duration", "Total duration", "", "text")}
+      ${input("stops", "Stops", "", "number")}
+      ${input("layover_airports", "Layover airport(s)", "", "text")}
+      ${input("layover_duration", "Layover duration", "", "text")}
+      ${input("price_band", "Price", "", "text")}
+      ${input("baggage_notes", "Baggage / cabin", "", "text")}
+      ${textarea("notes", "Flight notes", "", "Paste exact itinerary text if you have it. Example: AC880 + TP1861, depart 2026-08-24 9:15 PM, arrive 2026-08-25 2:20 PM, duration 10h 35m, 1 stop via LIS, layover 2h 20m, CAD 1180 pp.")}
     </div>
     <div class="button-row">
       <button type="submit">Evaluate flight</button>
@@ -662,18 +749,10 @@ function flightsStage() {
   const shortlist = shortlistByCategory("flights");
   return `
     <div class="guided-step-layout">
-      <section class="stage-card action-card">
-        <div>
-          <p class="eyebrow">Step 4</p>
-          <h3>Find the best flight fit</h3>
-          <p>Compare timing, route pain, price bands, and source confidence. Trippy recommends the lowest-friction option from current evidence.</p>
-          ${truthLegend()}
-        </div>
-        <div class="button-row compact-buttons">
-          <button data-shortlist="flights" data-auto-research="true" type="button">${shortlist ? "Refresh flights" : "Find flights"}</button>
-        </div>
+      <div class="inline-toolbar">
+        <button data-shortlist="flights" data-auto-research="true" type="button">${shortlist ? "Refresh flights" : "Find flights"}</button>
         <p class="inline-result"></p>
-      </section>
+      </div>
       ${shortlist ? flightComparison(shortlist) : `<div class="empty-state">Flight suggestions appear here after you choose a trip shape.</div>`}
       <details class="stage-card quiet-details">
         <summary>Add a flight you found</summary>
@@ -701,9 +780,6 @@ function lodgingStage() {
           <h3>Choose the stay structure</h3>
           <p>Trippy checks whether one base or split stays better matches the chosen trip shape, then compares properties against party fit.</p>
           ${truthLegend()}
-        </div>
-        <div class="button-row compact-buttons">
-          <button data-shortlist="lodging" data-auto-research="true" type="button">${shortlist ? "Refresh lodging" : "Find lodging"}</button>
         </div>
         <p class="inline-result"></p>
       </section>
@@ -737,7 +813,7 @@ function activitiesStage() {
           <p>Keep the days balanced: safe, well-reviewed activities, practical driving, and enough downtime.</p>
         </div>
         <div class="button-row compact-buttons">
-          <button data-shortlist="activities" type="button">${activities ? "Refresh activities" : "Find activities"}</button>
+          <button data-shortlist="activities" data-auto-research="true" type="button">${activities ? "Research activities" : "Find activities"}</button>
           <button data-shortlist="cars" type="button">${cars ? "Refresh cars" : "Find cars"}</button>
         </div>
         <p class="inline-result"></p>
@@ -767,12 +843,11 @@ function planStage() {
   const sheetButtonLabel = hasGoogleSheet ? "Update Google Sheet" : "Create Google Sheet";
   return `
     <div class="guided-step-layout">
-      ${structureGuidancePanel()}
-      <section class="stage-card action-card">
+      <section class="stage-card action-card compact-stage-actions">
         <div>
           <p class="eyebrow">Step 7</p>
-          <h3>Google Sheet and custom map</h3>
-          <p>Keep the planning sheet, timeline, map anchors, risks, and next actions current.</p>
+          <h3>Google Sheet and trip map</h3>
+          <p>Use the sheet as the real planning surface. Keep the map aligned to the chosen flight, stay plan, and activity sequence.</p>
         </div>
         <div class="button-row compact-buttons">
           <button id="googleWorkspaceButton" type="button">${sheetButtonLabel}</button>
@@ -780,15 +855,92 @@ function planStage() {
         </div>
         <p class="inline-result"></p>
       </section>
-      ${workspace ? workspaceSummary(workspace) : `<div class="empty-state">Create the Google Sheet to build the Master Timeline, map anchors, and risks.</div>`}
+      ${
+        workspace?.google_sheet_url
+          ? googleSheetPanel(workspace, "Trip planning workspace", "The live sheet should stay ahead of this UI for timeline, links, confirmations, and logistics.")
+          : `<div class="empty-state">Create the Google Sheet to make the trip timeline, confirmations, and logistics editable in one place.</div>`
+      }
       ${artifact ? embeddedMapPanel(artifact) : fallbackMapPanel(mapRows)}
       <div class="button-row step-forward-row">
         <button type="button" class="secondary" data-next-stage="activities">Back to activities</button>
-        <button type="button" data-next-stage="review">Next: feedback</button>
+        <button type="button" data-next-stage="packet">Next: trip packet</button>
       </div>
     </div>
     ${feedbackBlock("plan")}
   `;
+}
+
+function packetStage() {
+  if (!state.activeTripId) {
+    return `<div class="empty-state">Create or select a trip first.</div>`;
+  }
+  const packet = state.trip?.trip_packet || {};
+  const items = packet.items || [];
+  const workspace = state.trip?.workspace;
+  return `
+    <div class="guided-step-layout">
+      <section class="stage-card packet-hero compact-packet-hero">
+        <div>
+          <p class="eyebrow">Trip packet</p>
+          <h3>${escapeHtml(packet.status_label || "Still needs confirmations")}</h3>
+          <p>${escapeHtml(packet.summary || "Use the sheet to capture booking details, confirmations, check-in instructions, and the final day-by-day operating plan.")}</p>
+        </div>
+        <div class="readiness-meter" aria-label="Trip packet readiness">
+          <strong>${escapeHtml(packet.readiness_percent || 0)}%</strong>
+          <span>confirmed readiness</span>
+        </div>
+      </section>
+      ${
+        (packet.missing_items || []).length
+          ? `<section class="stage-card blocker-card">
+              <p class="eyebrow">Still missing</p>
+              <ul class="tight-list">${packet.missing_items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
+            </section>`
+          : `<section class="stage-card blocker-card is-clear"><p class="eyebrow">Ready packet</p><p>Core confirmations are captured. Review the sheet, map, and timeline before departure.</p></section>`
+      }
+      ${
+        workspace?.google_sheet_url
+          ? googleSheetPanel(workspace, "Bookings and confirmations", "Best place to track real confirmation numbers, links, check-in details, and day-of notes.")
+          : `<div class="empty-state">Create the Google Sheet first so confirmations and logistics have one canonical home.</div>`
+      }
+      ${
+        items.length
+          ? `<section class="stage-card packet-summary-strip">
+              <div class="section-head compact-head">
+                <div>
+                  <p class="eyebrow">Selected now</p>
+                  <h3>Current chosen items</h3>
+                </div>
+              </div>
+              <div class="packet-mini-grid">${items.map(packetItemCard).join("")}</div>
+            </section>`
+          : ""
+      }
+      <div class="button-row step-forward-row">
+        <button type="button" class="secondary" data-next-stage="plan">Back to timeline + map</button>
+        <button type="button" id="refreshPacketWorkspace">Update Google Sheet</button>
+      </div>
+    </div>
+    ${feedbackBlock("review")}
+  `;
+}
+
+function packetItemCard(item) {
+  const time = [item.date, timeRange(item.start_time, item.end_time)].filter(Boolean).join(" · ");
+  return `<article class="packet-item-card compact ${escapeHtml(item.status)}">
+    <div>
+      <p class="eyebrow">${escapeHtml(item.category)}</p>
+      <h4>${escapeHtml(item.title)}</h4>
+      <p>${escapeHtml([item.provider, item.confirmation_code ? `Confirmation ${item.confirmation_code}` : ""].filter(Boolean).join(" · "))}</p>
+      <div class="metric-row">
+        <span class="metric ${item.status === "confirmed" ? "live" : item.status === "booked" ? "warn" : ""}">${escapeHtml(truthLabel({ row_status: item.status }))}</span>
+        ${time ? `<span class="metric">${escapeHtml(time)}</span>` : ""}
+      </div>
+      ${item.address ? `<small>${escapeHtml(item.address)}</small>` : ""}
+      ${item.notes ? `<small>${escapeHtml(item.notes)}</small>` : ""}
+      ${externalLink(item.booking_link || item.source_url, "Open booking")}
+    </div>
+  </article>`;
 }
 
 function workspaceStage() {
@@ -856,17 +1008,7 @@ function wireIntakeStage(root) {
   form.querySelector("[name=party_type]").addEventListener("change", () => adaptPartyFields(form, true));
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
-    await saveIntake(form, result);
-  });
-  root.querySelector("#draftFromIntake").addEventListener("click", async () => {
-    const response = await saveIntake(form, result);
-    if (response?.intake?.trip_id) {
-      const draft = await apiPost("/api/draft", { trip_id: response.intake.trip_id });
-      state.lastWorkflowByStage.draft = draft.workflow_id;
-      state.activeStage = "options";
-      await loadTrip(response.intake.trip_id);
-      render();
-    }
+    await saveIntake(form, result, { continuePlanning: true });
   });
   wireFeedbackForms(root, "intake");
 }
@@ -916,17 +1058,30 @@ function setFormValue(form, name, value) {
   }
 }
 
-async function saveIntake(form, result) {
+async function saveIntake(form, result, options = {}) {
   try {
-    setWorking(result, "Saving intake");
+    const continuePlanning = options.continuePlanning === true;
+    setWorking(result, continuePlanning ? "Saving intake..." : "Saving intake");
     const payload = formPayload(form);
     const response = await apiPost("/api/intake", payload);
     state.lastWorkflowByStage.intake = response.workflow_id;
     state.activeTripId = response.intake.trip_id;
     state.isCreatingTrip = false;
     state.suggestedIntake = null;
-    await loadTrip(response.intake.trip_id);
-    result.textContent = `Saved ${response.intake.trip_id}`;
+    if (continuePlanning) {
+      setWorking(result, "Saved. Building trip options...");
+      const draft = await apiPost("/api/draft", { trip_id: response.intake.trip_id });
+      state.lastWorkflowByStage.draft = draft.workflow_id;
+      state.guidedNotice = {
+        stage: "options",
+        title: "Intake saved. Next: choose the trip shape.",
+        message:
+          "Pick one option below; Trippy will then walk you into flights, lodging, activities, the timeline, and the trip packet.",
+      };
+      await loadTrip(response.intake.trip_id, { stage: "options" });
+    } else {
+      await loadTrip(response.intake.trip_id, { gotoNext: true });
+    }
     return response;
   } catch (error) {
     result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
@@ -934,19 +1089,42 @@ async function saveIntake(form, result) {
   }
 }
 
-function wireDraftStage(root) {
-  const button = root.querySelector("#draftButton");
-  if (button) {
-    button.addEventListener("click", async () => {
-      await runStage(root, "draft", "/api/draft", { trip_id: state.activeTripId });
-    });
+function stageNotice(stage) {
+  if (state.guidedNotice?.stage !== stage) {
+    return "";
   }
+  return `<div class="guided-notice">
+    <strong>${escapeHtml(state.guidedNotice.title || "Next step")}</strong>
+    <span>${escapeHtml(state.guidedNotice.message || guidedNextStep())}</span>
+  </div>`;
+}
+
+function wireDraftStage(root) {
+  ensureDraftOptions(root);
   root.querySelectorAll("[data-select-option]").forEach((selectButton) => {
     selectButton.addEventListener("click", async () => {
       await selectOptionAndStartResearch(root, selectButton.dataset.selectOption);
     });
   });
   wireFeedbackForms(root, "draft");
+}
+
+async function ensureDraftOptions(root) {
+  if (!state.activeTripId || state.trip?.draft?.options?.length || state.isAutoDrafting) {
+    return;
+  }
+  const result = root.querySelector(".inline-result");
+  try {
+    state.isAutoDrafting = true;
+    setWorking(result, "Building trip options...");
+    const response = await apiPost("/api/draft", { trip_id: state.activeTripId });
+    state.lastWorkflowByStage.draft = response.workflow_id;
+    await loadTrip(state.activeTripId, { stage: "options" });
+  } catch (error) {
+    result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+  } finally {
+    state.isAutoDrafting = false;
+  }
 }
 
 async function selectOptionAndStartResearch(root, optionId) {
@@ -1108,12 +1286,13 @@ function wireFlightsStage(root) {
       }
     });
   });
+  wireBookingForms(root);
   wireStageNavigation(root);
   wireFeedbackForms(root, "flights");
 }
 
 function wireLodgingStage(root) {
-  wireShortlistButtons(root, "lodging");
+  ensureLodgingOptions(root);
   const structureForm = root.querySelector("#stayStructureForm");
   if (structureForm) {
     structureForm.addEventListener("submit", async (event) => {
@@ -1129,6 +1308,27 @@ function wireLodgingStage(root) {
           notes: payload.notes || "",
         });
         state.lastWorkflowByStage.lodging = response.workflow_id;
+        state.pendingScrollTarget = "#lodgingComparison";
+        await loadTrip(state.activeTripId, { stage: "lodging" });
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  }
+  root.querySelectorAll("[data-use-stay-option]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const result = root.querySelector(".inline-result");
+      const option = stayStructureOptionById(button.dataset.useStayOption);
+      if (!option) return;
+      try {
+        setWorking(result, "Saving selected stay structure");
+        const response = await apiPost("/api/lodging-structure", {
+          trip_id: state.activeTripId,
+          strategy: option.strategy || "split_stay",
+          night_plan: option.night_plan || [],
+          notes: `Selected ${option.title || "stay structure"}: ${option.summary || ""}`,
+        });
+        state.lastWorkflowByStage.lodging = response.workflow_id;
         await loadTrip(state.activeTripId);
         state.activeStage = "lodging";
         render();
@@ -1136,7 +1336,21 @@ function wireLodgingStage(root) {
         result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
       }
     });
-  }
+  });
+  root.querySelectorAll("[data-edit-stay-option]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const option = stayStructureOptionById(button.dataset.editStayOption);
+      if (!option || !structureForm) return;
+      const strategy = structureForm.querySelector("[name=strategy]");
+      const nightPlan = structureForm.querySelector("[name=night_plan_text]");
+      const notes = structureForm.querySelector("[name=notes]");
+      if (strategy) strategy.value = option.strategy || "split_stay";
+      if (nightPlan) nightPlan.value = stayStructureText(option.night_plan || []);
+      if (notes) notes.value = `${option.title || "Stay option"}: ${option.summary || ""}`;
+      structureForm.scrollIntoView({ behavior: "smooth", block: "center" });
+      nightPlan?.focus();
+    });
+  });
   const candidate = root.querySelector("#lodgingCandidateForm");
   if (candidate) {
     candidate.addEventListener("submit", async (event) => {
@@ -1177,8 +1391,40 @@ function wireLodgingStage(root) {
       }
     });
   });
+  wireBookingForms(root);
   wireStageNavigation(root);
   wireFeedbackForms(root, "lodging");
+}
+
+async function ensureLodgingOptions(root) {
+  const shortlist = shortlistByCategory("lodging");
+  if (!state.activeTripId || shortlist?.lodging_options?.length || state.isAutoBuildingLodging) {
+    return;
+  }
+  const result = root.querySelector(".inline-result");
+  try {
+    state.isAutoBuildingLodging = true;
+    setWorking(result, "Building lodging options...");
+    const lodging = await apiPost("/api/shortlist", {
+      trip_id: state.activeTripId,
+      category: "lodging",
+      validate_live: true,
+      deep_research: true,
+      adapter: "auto",
+    });
+    state.lastWorkflowByStage.lodging = lodging.workflow_id;
+    setWorking(result, "Thinking through stay structure options...");
+    const structure = await apiPost("/api/lodging-structure-suggestions", {
+      trip_id: state.activeTripId,
+      use_llm: true,
+    });
+    state.lastWorkflowByStage.lodging = structure.workflow_id;
+    await loadTrip(state.activeTripId, { stage: "lodging" });
+  } catch (error) {
+    result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+  } finally {
+    state.isAutoBuildingLodging = false;
+  }
 }
 
 function wireActivitiesStage(root) {
@@ -1245,6 +1491,7 @@ function wireActivitiesStage(root) {
       }
     });
   });
+  wireBookingForms(root);
   wireStageNavigation(root);
   wireFeedbackForms(root, "activities");
 }
@@ -1274,6 +1521,21 @@ function wirePlanStage(root) {
   wireFeedbackForms(root, "plan");
 }
 
+function wirePacketStage(root) {
+  wireBookingForms(root);
+  root.querySelector("#refreshPacketWorkspace")?.addEventListener("click", async () => {
+    await runStage(root, "plan", "/api/workspace", {
+      trip_id: state.activeTripId,
+      validate_live: true,
+      create_google_sheet: true,
+    });
+    state.activeStage = "packet";
+    render();
+  });
+  wireStageNavigation(root);
+  wireFeedbackForms(root, "review");
+}
+
 function wireShortlistButtons(root, stage) {
   root.querySelectorAll("[data-shortlist]").forEach((button) => {
     button.addEventListener("click", async () => {
@@ -1298,6 +1560,27 @@ function wireStageNavigation(root) {
       state.activeStage = button.dataset.nextStage;
       render();
       document.getElementById("stageBody")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  });
+}
+
+function wireBookingForms(root) {
+  root.querySelectorAll("[data-booking-form]").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const result = form.querySelector(".inline-result");
+      try {
+        setWorking(result, "Saving booking details");
+        const payload = formPayload(form);
+        payload.trip_id = state.activeTripId;
+        const response = await apiPost("/api/trip-packet/item", payload);
+        state.lastWorkflowByStage.packet = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = state.activeStage === "packet" ? "packet" : state.activeStage;
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
     });
   });
 }
@@ -1838,17 +2121,14 @@ function renderShortlistPanel(shortlist) {
 
 function flightComparison(shortlist) {
   const rows = sortedFlights(shortlist.flight_options || []);
-  const recommended = (shortlist.flight_options || []).find((option) => option.option_id === shortlist.recommended_option_id) || rows[0];
-  const runner = rows.find((option) => option.option_id !== recommended?.option_id);
   return `<section class="comparison-panel">
-    <div class="comparison-head">
+    <div class="comparison-head compact-head compare-header-tight">
       <div>
         <p class="eyebrow">Flights</p>
-        <h3>Routing and timing comparison</h3>
-        <p>${escapeHtml(shortlist.recommendation_summary || "")}</p>
+        <h3>Exact compare</h3>
+        <p>Choose on airline, flight number, takeoff, landing, duration, and price. Everything else is secondary.</p>
       </div>
       <div class="compare-tools">
-        <span class="metric live">Recommended ${escapeHtml(shortlist.recommended_option_id || "TBD")}</span>
         <label>Sort
           <select id="flightSort">
             ${["best", "cheapest", "shortest", "lowest-friction"].map((value) => `<option value="${value}" ${state.flightSort === value ? "selected" : ""}>${escapeHtml(labelForSort(value))}</option>`).join("")}
@@ -1856,19 +2136,17 @@ function flightComparison(shortlist) {
         </label>
       </div>
     </div>
-    ${recommended ? flightRecommendationPanel(recommended, runner) : ""}
     <div class="comparison-table-wrap">
       <table class="comparison-table flight-table">
         <thead>
           <tr>
             <th>Pick</th>
-            <th>Airline / source</th>
-            <th>Timing</th>
-            <th>Route</th>
+            <th>Airline / flight #</th>
+            <th>Takeoff</th>
+            <th>Landing</th>
             <th>Duration</th>
             <th>Price</th>
-            <th>Friction</th>
-            <th></th>
+            <th>Link</th>
           </tr>
         </thead>
         <tbody>
@@ -1881,57 +2159,107 @@ function flightComparison(shortlist) {
 
 function flightRow(option) {
   const isRecommended = option.option_id === recommendedId("flights");
-  const layover = (option.layover_airports || []).length
-    ? `${option.layover_airports.join(", ")} · ${option.layover_duration || "duration TBD"}`
-    : "Nonstop";
+  const timingMissing = !specificFlightValue(option.departure_time) || !specificFlightValue(option.arrival_time);
+  const numberMissing = !(option.flight_numbers || []).length;
+  const truth = truthLabel(option);
   return `<tr class="${isRecommended ? "recommended-row" : ""}">
     <td>
       <span class="flight-label ${isRecommended ? "is-recommended" : ""}">${escapeHtml(option.recommendation_label || option.recommendation_grade || "")}</span>
       <button class="mini-button" type="button" data-select-flight="${escapeHtml(option.option_id)}">${isRecommended ? "Use" : "Choose"}</button>
+      ${(timingMissing || numberMissing) ? `<small>${escapeHtml([numberMissing ? "flight # pending" : "", timingMissing ? "times pending" : ""].filter(Boolean).join(" · "))}</small>` : `<small>${escapeHtml(truth)}</small>`}
     </td>
     <td>
       <strong>${escapeHtml(option.airline)}</strong>
-      <small>${escapeHtml(option.booking_source)} · ${statusSummary(option)}</small>
+      <small>${escapeHtml(formatFlightNumbers(option))} · ${escapeHtml(option.booking_source)}</small>
     </td>
     <td>
-      <strong>${escapeHtml(option.departure_time || "Live verify departure")}</strong>
-      <small>${escapeHtml(option.arrival_time || "Live verify arrival")}</small>
+      <strong>${escapeHtml(formatFlightTiming(option))}</strong>
+      <small>${escapeHtml(option.departure_airport || "")}</small>
     </td>
     <td>
-      <strong>${escapeHtml(option.departure_airport)} to ${escapeHtml(option.arrival_airport)}</strong>
-      <small>${escapeHtml(option.stops === 0 ? "Nonstop" : `${option.stops} stop(s)`)} · ${escapeHtml(layover)}</small>
+      <strong>${escapeHtml(formatFlightArrival(option))}</strong>
+      <small>${escapeHtml(option.arrival_airport || "")}</small>
     </td>
     <td>
       <strong>${escapeHtml(option.total_travel_duration)}</strong>
-      <small>${escapeHtml(option.timing_implication || option.timing_fit || option.traveler_fit || "")}</small>
+      <small>${escapeHtml(flightDurationNote(option))}</small>
     </td>
     <td>
-      <strong>${escapeHtml(option.price_band)}</strong>
-      <small>${escapeHtml(option.fare_estimate_cad || "")}</small>
+      <strong>${escapeHtml(option.validation?.extracted_fields?.price_signal || option.price_band)}</strong>
+      <small>${escapeHtml(option.fare_estimate_cad || option.validation?.price_status?.replaceAll("_", " ") || "")}</small>
     </td>
     <td>
-      <span class="score-pill">${escapeHtml(option.friction_score)} friction</span>
-      <small>${escapeHtml(option.recommendation_rationale || (option.friction_flags || [])[0] || option.recommendation_grade || "")}</small>
-      ${evidenceDetails(option)}
+      <div class="action-stack">
+        ${externalLink(option.deep_link, "Open search")}
+        ${bookingForm("flight", option)}
+      </div>
     </td>
-    <td>${externalLink(option.deep_link, "Open")}</td>
   </tr>`;
 }
 
-function flightRecommendationPanel(recommended, runner) {
-  return `<div class="recommendation-panel">
-    <div>
-      <p class="eyebrow">${escapeHtml(recommended.recommendation_label || "Recommended")}</p>
-      <h4>${escapeHtml(recommended.airline)}</h4>
-      <p>${escapeHtml(recommended.recommendation_rationale || recommended.timing_fit || "")}</p>
-      <p class="subtle">${escapeHtml(recommended.date_viability_signal || "")}</p>
-    </div>
-    ${runner ? `<div>
-      <p class="eyebrow">Runner-up</p>
-      <strong>${escapeHtml(runner.airline)}</strong>
-      <p>${escapeHtml(runner.recommendation_rationale || runner.timing_fit || "")}</p>
-    </div>` : ""}
-  </div>`;
+function formatFlightNumbers(option) {
+  const numbers = option.flight_numbers || [];
+  return numbers.length ? numbers.join(" + ") : "Flight # pending";
+}
+
+function formatFlightTiming(option) {
+  const date = option.departure_date || "";
+  const time = specificFlightValue(option.departure_time) || "";
+  if (date || time) {
+    return [date, time].filter(Boolean).join(" · ");
+  }
+  return "Takeoff pending";
+}
+
+function formatFlightArrival(option) {
+  const date = option.arrival_date || "";
+  const time = specificFlightValue(option.arrival_time) || "";
+  if (date || time) {
+    return [date, time].filter(Boolean).join(" · ");
+  }
+  return "Landing pending";
+}
+
+function flightDurationNote(option) {
+  const stops = Number(option.stops || 0);
+  if (!stops) {
+    return "Nonstop";
+  }
+  const layover = (option.layover_airports || []).length
+    ? `${option.layover_airports.join(", ")}${option.layover_duration ? ` · ${option.layover_duration}` : ""}`
+    : `${stops} stop(s)`;
+  return layover;
+}
+
+function flightExactness(option) {
+  const missing = new Set(option.validation?.missing_fields || []);
+  const hasNumbers = (option.flight_numbers || []).length > 0;
+  const hasSpecificTimes = Boolean(specificFlightValue(option.departure_time) && specificFlightValue(option.arrival_time));
+  const hasDates = Boolean(option.departure_date && option.arrival_date);
+  const hasPrice = option.validation?.price_status === "live_signal" || !String(option.price_band || "").toLowerCase().includes("live-verify");
+  if (hasNumbers && hasSpecificTimes && hasDates && hasPrice && missing.size <= 2) {
+    return "exact itinerary";
+  }
+  if (hasNumbers && hasSpecificTimes) {
+    return "partial itinerary";
+  }
+  return "needs exact itinerary";
+}
+
+function specificFlightValue(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  const lower = text.toLowerCase();
+  if (
+    lower.includes("target ") ||
+    lower.includes("variable") ||
+    lower.includes("live verify") ||
+    lower.includes("verify ") ||
+    lower.includes("not supplied")
+  ) {
+    return "";
+  }
+  return text;
 }
 
 function sortedFlights(rows) {
@@ -1964,10 +2292,46 @@ function labelForSort(value) {
 
 function truthLegend() {
   return `<div class="truth-legend" aria-label="Data confidence guide">
-    <span class="truth-chip verified">Verified from source</span>
-    <span class="truth-chip partial">Partial / approximate</span>
-    <span class="truth-chip review">Needs manual check</span>
+    <span class="truth-chip idea">Idea</span>
+    <span class="truth-chip partial">Estimate</span>
+    <span class="truth-chip verified">Checked</span>
+    <span class="truth-chip selected">Selected</span>
+    <span class="truth-chip booked">Booked</span>
+    <span class="truth-chip confirmed">Confirmed</span>
   </div>`;
+}
+
+function bookingForm(category, option, existing = null) {
+  const title = option.airline || option.name || option.vehicle_class || option.activity_name || option.title || "";
+  const provider = existing?.provider || option.booking_source || option.source || "";
+  const link = existing?.booking_link || existing?.source_url || option.deep_link || "";
+  const status = existing?.status || (option.row_status === "confirmed" ? "confirmed" : option.row_status === "booked" ? "booked" : "booked");
+  return `<details class="booking-details">
+    <summary>${existing?.confirmation_code ? "Edit confirmation" : "Book / confirm"}</summary>
+    <form data-booking-form class="booking-form">
+      <input type="hidden" name="category" value="${escapeHtml(category)}" />
+      <input type="hidden" name="option_id" value="${escapeHtml(option.option_id || existing?.option_id || "")}" />
+      <label>Status
+        <select name="status">
+          <option value="booked" ${status === "booked" ? "selected" : ""}>Booked</option>
+          <option value="confirmed" ${status === "confirmed" ? "selected" : ""}>Confirmed</option>
+        </select>
+      </label>
+      ${input("provider", "Provider", provider)}
+      ${input("confirmation_code", "Confirmation code", existing?.confirmation_code || "")}
+      ${input("booking_link", "Booking link", link, "url")}
+      ${input("date", "Date", existing?.date || "", "date")}
+      <div class="inline-two">
+        ${input("start_time", "Start", existing?.start_time || option.departure_time || option.scheduled_start_time || "", "text")}
+        ${input("end_time", "End", existing?.end_time || option.arrival_time || option.scheduled_end_time || "", "text")}
+      </div>
+      ${input("address", "Address", existing?.address || "")}
+      ${input("cost_cad", "Cost CAD", existing?.cost_cad || "", "number")}
+      ${textarea("notes", "Trip-day notes", existing?.notes || "", `${title} check-in, seats, access, baggage, pickup, or voucher notes.`)}
+      <button class="mini-button" type="submit">Save packet detail</button>
+      <small class="inline-result"></small>
+    </form>
+  </details>`;
 }
 
 function lodgingStructurePanel(shortlist) {
@@ -1976,6 +2340,7 @@ function lodgingStructurePanel(shortlist) {
     return `<div class="empty-state">Choose a trip shape to see one-stay vs split-stay guidance.</div>`;
   }
   const nightPlan = structure.night_plan || [];
+  const options = structure.options || [];
   const label = structure.strategy === "split_stay" ? "Split stays" : "One stay";
   const selectedLodging = structure.selected_lodging_option_id
     ? `Selected lodging: ${structure.selected_lodging_option_id}`
@@ -1984,7 +2349,7 @@ function lodgingStructurePanel(shortlist) {
     <div>
       <p class="eyebrow">Stay structure</p>
       <h3>${escapeHtml(label)} ${structure.confidence ? `<span>${escapeHtml(structure.confidence)}</span>` : ""}</h3>
-      <p>${escapeHtml(structure.summary || "")}</p>
+      <p>${escapeHtml(structure.summary || "Pick a stay approach, then edit the night split if needed.")}</p>
       <p class="subtle">${escapeHtml(selectedLodging)} · ${escapeHtml(structure.data_status || "plan-based")}</p>
     </div>
     <div class="night-plan">
@@ -1993,9 +2358,52 @@ function lodgingStructurePanel(shortlist) {
         <span>${escapeHtml(item.nights)} night(s)</span>
       </article>`).join("")}
     </div>
-    ${(structure.reasoning || []).length ? `<ul class="tight-list">${structure.reasoning.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : ""}
+    ${options.length ? stayStructureOptionsGrid(options, structure.recommended_structure_id) : ""}
     ${stayStructureForm(structure)}
   </section>`;
+}
+
+function stayStructureOptionsGrid(options, recommendedId) {
+  return `<div class="stay-option-grid">
+    ${options.slice(0, 3).map((option, index) => stayStructureOptionCard(option, index, recommendedId)).join("")}
+  </div>`;
+}
+
+function stayStructureOptionCard(option, index, recommendedId) {
+  const isRecommended = option.structure_id === recommendedId || (!recommendedId && index === 0);
+  const nightPlan = option.night_plan || [];
+  const reasons = (option.reasoning || []).slice(0, 2);
+  return `<article class="stay-option-card ${isRecommended ? "recommended-row" : ""}">
+    ${stayStructureMapThumb(option, index)}
+    <div class="stay-option-body">
+      <div class="option-head">
+        <h4>${escapeHtml(option.title || "Stay option")}</h4>
+        <span class="metric ${isRecommended ? "live" : ""}">${escapeHtml(option.recommendation_label || "option")}</span>
+      </div>
+      <p>${escapeHtml(option.summary || "")}</p>
+      <div class="night-plan mini">
+        ${nightPlan.map((item) => `<article><strong>${escapeHtml(item.region)}</strong><span>${escapeHtml(item.nights)}n</span></article>`).join("")}
+      </div>
+      ${reasons.length ? `<ul class="tight-list">${reasons.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : ""}
+      <div class="stay-option-actions">
+        <button type="button" data-use-stay-option="${escapeHtml(option.structure_id)}">Use</button>
+        <button type="button" class="secondary" data-edit-stay-option="${escapeHtml(option.structure_id)}">Edit</button>
+      </div>
+    </div>
+  </article>`;
+}
+
+function stayStructureMapThumb(option, index) {
+  const regions = option.map_regions?.length
+    ? option.map_regions
+    : (option.night_plan || []).map((item) => item.region);
+  const variant = Number(option.thumbnail_variant || index + 1);
+  return `<div class="option-map-thumb stay-map-thumb option-${Math.min(Math.max(variant, 1), 3)}">
+    <div class="map-route-line"></div>
+    <div class="map-pin-row">
+      ${regions.slice(0, 4).map((region, pinIndex) => `<span class="map-pin" style="--pin-index:${pinIndex}">${escapeHtml(region)}</span>`).join("")}
+    </div>
+  </div>`;
 }
 
 function stayStructureForm(structure) {
@@ -2010,7 +2418,7 @@ function stayStructureForm(structure) {
         </select>
       </label>
     </div>
-    <label>Move nights around
+    <label>Edit nights
       <textarea name="night_plan_text" rows="4" placeholder="Ponta Delgada | 4 | lodging-1 | central base&#10;Furnas | 3 | lodging-2 | hot springs side">${escapeHtml(text)}</textarea>
     </label>
     <label>Why this structure?
@@ -2022,6 +2430,11 @@ function stayStructureForm(structure) {
     </div>
     <p class="subtle">Format: region | nights | lodging option ID optional | notes optional. The workspace timeline will use this after you save and refresh the workspace.</p>
   </form>`;
+}
+
+function stayStructureOptionById(optionId) {
+  const structure = shortlistByCategory("lodging")?.artifacts?.lodging_structure;
+  return (structure?.options || []).find((option) => option.structure_id === optionId);
 }
 
 function stayStructureText(nightPlan) {
@@ -2097,15 +2510,13 @@ function durationHours(value) {
 
 function statusSummary(option) {
   const validation = option.validation || {};
-  const status = validation.verification_status || option.row_status || "researched";
-  const freshness = validation.freshness_status && validation.freshness_status !== "unknown" ? validation.freshness_status : "";
-  const confidence = validation.confidence ? `${Math.round(Number(validation.confidence) * 100)}%` : "";
-  const adapter = validation.adapter_used ? `${validation.adapter_used}` : "";
+  const truth = truthLabel(option);
+  const freshness = displayFreshnessStatus(validation.freshness_status);
+  const confidence = validation.confidence ? `${Math.round(Number(validation.confidence) * 100)}% confidence` : "";
   return `<span class="status-badges">
-    <span class="status-badge ${status === "live_verified" || option.row_status === "verified_live" ? "ok" : "partial"}">${escapeHtml(status)}</span>
+    <span class="status-badge ${truthClass(option)}">${escapeHtml(truth)}</span>
     ${freshness ? `<span class="status-badge">${escapeHtml(freshness)}</span>` : ""}
     ${confidence ? `<span class="status-badge">${escapeHtml(confidence)}</span>` : ""}
-    ${adapter ? `<span class="status-badge">${escapeHtml(adapter)}</span>` : ""}
   </span>`;
 }
 
@@ -2125,76 +2536,181 @@ function evidenceDetails(option) {
 
 function lodgingComparison(shortlist) {
   const rows = shortlist.lodging_options || [];
-  return `<section class="comparison-panel">
-    <div class="comparison-head">
+  const structure = shortlist.artifacts?.lodging_structure;
+  const stayPlan = lodgingStayPlan(structure);
+  const grouped = structure?.strategy === "split_stay" && stayPlan.length > 1;
+  return `<section id="lodgingComparison" class="comparison-panel" tabindex="-1">
+    <div class="comparison-head compact-head compare-header-tight">
       <div>
         <p class="eyebrow">Lodging</p>
-        <h3>Fit, location, beds, and value</h3>
-        <p>${escapeHtml(shortlist.recommendation_summary || "")}</p>
+        <h3>${grouped ? "Choose one place per stay base" : "Choose the best place to stay"}</h3>
+        <p>${escapeHtml(grouped ? "The saved stay split now drives the comparison. Each list below is tied to one stay window and one area." : "Focus on place, cost, dates, location, and the reason it earned its score.")}</p>
       </div>
-      <span class="metric live">Recommended ${escapeHtml(shortlist.recommended_option_id || "TBD")}</span>
+      <span class="metric live">${escapeHtml(shortlist.recommended_option_id ? `Top pick ${shortlist.recommended_option_id}` : "Compare")}</span>
     </div>
+    ${grouped ? lodgingGroupedLists(rows, stayPlan) : lodgingTable(rows, stayPlan[0] || defaultTripStay())}
+  </section>`;
+}
+
+function lodgingTable(rows, stay = null) {
+  return `
     <div class="comparison-table-wrap">
       <table class="comparison-table lodging-table">
         <thead>
           <tr>
-            <th>Property / source</th>
-            <th>Area</th>
-            <th>Beds / party fit</th>
-            <th>Cost / flexibility</th>
-            <th>Access</th>
-            <th>Score</th>
-            <th></th>
+            <th>Pick</th>
+            <th>Place</th>
+            <th>Dates</th>
+            <th>Location</th>
+            <th>Cost</th>
+            <th>Score / why</th>
+            <th>Link</th>
           </tr>
         </thead>
         <tbody>
-          ${rows.map(lodgingRow).join("")}
+          ${rows.map((option) => lodgingRow(option, stay)).join("")}
         </tbody>
       </table>
+    </div>`;
+}
+
+function lodgingGroupedLists(rows, stayPlan) {
+  const assigned = new Set();
+  const groups = stayPlan.map((stay) => {
+    const matches = rows.filter((option) => lodgingOptionMatchesStay(option, stay.region));
+    matches.forEach((option) => assigned.add(option.option_id));
+    return { stay, matches };
+  });
+  const otherRows = rows.filter((option) => !assigned.has(option.option_id));
+  return `<div class="lodging-group-stack">
+    ${groups.map(({ stay, matches }, index) => lodgingRegionGroup(stay, matches, index)).join("")}
+    ${otherRows.length ? lodgingRegionGroup({ region: "Other candidates", nights: "" }, otherRows, groups.length, true) : ""}
+  </div>`;
+}
+
+function lodgingRegionGroup(stay, rows, index, secondary = false) {
+  return `<section class="lodging-region-panel ${secondary ? "secondary-region" : ""}">
+    <div class="lodging-region-head">
+      <div>
+        <p class="eyebrow">${secondary ? "Also compare" : `Stay ${index + 1}`}</p>
+        <h4>${escapeHtml(stay.region || "Base")}</h4>
+        ${stay.nights ? `<span>${escapeHtml(stay.nights)} night(s)${stay.dateLabel ? ` · ${escapeHtml(stay.dateLabel)}` : ""}</span>` : ""}
+      </div>
+      ${stay.notes ? `<p>${escapeHtml(stay.notes)}</p>` : ""}
     </div>
+    ${rows.length ? lodgingTable(rows, stay) : `<div class="empty-state">No lodging options match this base yet. Add a candidate for ${escapeHtml(stay.region || "this location")}.</div>`}
   </section>`;
 }
 
-function lodgingRow(option) {
+function lodgingStayPlan(structure) {
+  let cursor = 1;
+  return (structure?.night_plan || [])
+    .filter((stay) => stay?.region && Number(stay.nights || 0) > 0)
+    .map((stay) => {
+      const nights = Number(stay.nights || 0);
+      const startDay = cursor;
+      const endDay = cursor + nights - 1;
+      cursor += nights;
+      return {
+        ...stay,
+        region: String(stay.region || ""),
+        startDay,
+        endDay,
+        dateLabel: stayDateLabel(startDay, endDay),
+        summaryLabel: `Day ${startDay}${endDay > startDay ? `-${endDay}` : ""}`,
+      };
+    });
+}
+
+function defaultTripStay() {
+  const draftOption = selectedPlanOption();
+  const duration = Number(state.trip?.intake?.duration_days || draftOption?.duration_days || 0);
+  return {
+    region: state.trip?.intake?.destination_seeds?.[0] || "",
+    nights: duration || "",
+    startDay: 1,
+    endDay: duration || 1,
+    dateLabel: duration ? stayDateLabel(1, duration) : "",
+  };
+}
+
+function lodgingOptionMatchesStay(option, region) {
+  const tokens = regionTokens(region);
+  if (!tokens.length) return false;
+  const haystack = [
+    option.name,
+    option.location_area,
+    option.island_or_region,
+    option.lodging_type,
+  ].join(" ").toLowerCase();
+  return tokens.some((token) => haystack.includes(token));
+}
+
+function regionTokens(region) {
+  const stopwords = new Set([
+    "the",
+    "and",
+    "base",
+    "side",
+    "coast",
+    "area",
+    "near",
+    "central",
+    "north",
+    "south",
+    "east",
+    "west",
+    "sao",
+    "são",
+    "miguel",
+  ]);
+  return String(region || "")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= 4 && !stopwords.has(token));
+}
+
+function lodgingRow(option, stay = null) {
   const needsThreeBeds = requiresThreeBeds();
   const isRecommended = option.option_id === recommendedId("lodging");
-  const bedFit = [
-    needsThreeBeds
-      ? option.min_three_beds_satisfied === true
-        ? "3+ beds"
-        : "3+ beds unproven"
-      : "party fit to verify",
-    option.king_bed_preference_satisfied === true ? "king" : "king unproven",
-    option.fit_category || "",
+  const cost = option.current_price_signal || option.price_band;
+  const reason = option.comfort_fit || evidenceSummary(option) || (option.friction_flags || [])[0] || option.occupancy_fit || "";
+  const scoreLabel = `${option.family_comfort_score} comfort`;
+  const stayDates = stay?.dateLabel || "";
+  const placeNotes = [
+    option.source,
+    option.king_bed_preference_satisfied === true ? "king confirmed" : needsThreeBeds ? "beds must be proven" : "",
+    displayFreshnessStatus(option.validation?.freshness_status),
   ].filter(Boolean).join(" · ");
   return `<tr class="${isRecommended ? "recommended-row" : ""}">
     <td>
+      <button class="mini-button" type="button" data-select-lodging="${escapeHtml(option.option_id)}">${isRecommended ? "Use" : "Choose"}</button>
+    </td>
+    <td>
       <strong>${escapeHtml(option.name)}</strong>
-      <small>${escapeHtml(option.source)} · ${escapeHtml(option.lodging_type)} · ${escapeHtml(validationSummary(option))}</small>
+      <small>${escapeHtml(placeNotes || option.lodging_type || "")}</small>
+    </td>
+    <td>
+      <strong>${escapeHtml(stayDates || tripDateRangeLabel())}</strong>
+      <small>${escapeHtml(stay?.summaryLabel || "whole-trip stay window")}</small>
     </td>
     <td>
       <strong>${escapeHtml(option.location_area)}</strong>
       <small>${escapeHtml(option.island_or_region || "")}</small>
     </td>
     <td>
-      <strong>${escapeHtml(bedFit)}</strong>
-      <small>${escapeHtml(option.occupancy_fit || option.adult_child_fit || "")}</small>
+      <strong>${escapeHtml(cost)}</strong>
+      <small>${escapeHtml(option.cancellation_notes || "flexibility check needed")}</small>
     </td>
     <td>
-      <strong>${escapeHtml(option.current_price_signal || option.price_band)}</strong>
-      <small>${escapeHtml(option.cancellation_notes || "")}</small>
+      <span class="score-pill">${escapeHtml(scoreLabel)}</span>
+      <small>${escapeHtml(reason)}</small>
     </td>
     <td>
-      <strong>${escapeHtml(option.parking_practicality)}</strong>
-      <small>${escapeHtml(option.walkability || option.driving_practicality || "")}</small>
-    </td>
-    <td>
-      <span class="score-pill">${escapeHtml(option.family_comfort_score)} comfort</span>
-      <small>${escapeHtml(evidenceSummary(option) || (option.friction_flags || [])[0] || option.comfort_fit || "")}</small>
-    </td>
-    <td>
-      <button class="mini-button" type="button" data-select-lodging="${escapeHtml(option.option_id)}">${isRecommended ? "Use" : "Choose"}</button>
-      ${externalLink(option.deep_link, "Open")}
+      <div class="action-stack">
+        ${externalLink(option.deep_link, "Open listing")}
+        ${bookingForm("lodging", option)}
+      </div>
     </td>
   </tr>`;
 }
@@ -2209,11 +2725,40 @@ function requiresThreeBeds() {
 function validationSummary(option) {
   const validation = option.validation || {};
   return [
-    validation.verification_status || "manual_required",
-    validation.freshness_status && validation.freshness_status !== "unknown" ? validation.freshness_status : "",
-    validation.adapter_used,
+    truthLabel(option),
+    displayFreshnessStatus(validation.freshness_status),
     validation.confidence ? `${Math.round(Number(validation.confidence) * 100)}%` : "",
   ].filter(Boolean).join(" · ");
+}
+
+function displayFreshnessStatus(value) {
+  const status = String(value || "");
+  if (!status || status === "unknown") return "";
+  if (status === "fresh") return "recent";
+  if (status === "stale") return "needs refresh";
+  if (status === "current") return "current";
+  return status.replaceAll("_", " ");
+}
+
+function truthLabel(option) {
+  const rowStatus = option?.row_status || option?.status || "";
+  const verification = option?.validation?.verification_status || "";
+  if (rowStatus === "confirmed") return "Confirmed";
+  if (rowStatus === "booked") return "Booked";
+  if (rowStatus === "approved" || rowStatus === "selected") return "Selected";
+  if (rowStatus === "verified_live" || verification === "live_verified" || verification === "link_validated") return "Checked";
+  if (rowStatus === "seeded") return "Idea";
+  return "Estimate";
+}
+
+function truthClass(option) {
+  const label = truthLabel(option).toLowerCase();
+  if (label === "confirmed") return "confirmed";
+  if (label === "booked") return "booked";
+  if (label === "selected") return "selected";
+  if (label === "checked") return "ok";
+  if (label === "idea") return "idea";
+  return "partial";
 }
 
 function evidenceSummary(option) {
@@ -2225,9 +2770,90 @@ function evidenceSummary(option) {
   return [extracted ? `extracted ${extracted}` : "", artifact ? `evidence ${artifact}` : ""].filter(Boolean).join(" · ");
 }
 
+function sortedActivityScheduleEntries(entries) {
+  return [...entries].sort((a, b) => {
+    const aDay = Number(a.scheduled_day || a.suggested_day || 999);
+    const bDay = Number(b.scheduled_day || b.suggested_day || 999);
+    if (aDay !== bDay) return aDay - bDay;
+    return timeSortKey(a.scheduled_start_time || a.suggested_start_time || "")
+      - timeSortKey(b.scheduled_start_time || b.suggested_start_time || "");
+  });
+}
+
+function sortedActivityOptions(rows) {
+  return [...rows].sort((a, b) => {
+    const aDay = Number(a.scheduled_day || a.suggested_day || 999);
+    const bDay = Number(b.scheduled_day || b.suggested_day || 999);
+    if (aDay !== bDay) return aDay - bDay;
+    return timeSortKey(a.scheduled_start_time || a.suggested_start_time || "")
+      - timeSortKey(b.scheduled_start_time || b.suggested_start_time || "");
+  });
+}
+
+function timeSortKey(value) {
+  const match = String(value || "").match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) {
+    return 24 * 60;
+  }
+  return Number(match[1]) * 60 + Number(match[2]);
+}
+
+function stayForDay(day) {
+  const plan = lodgingStayPlan(shortlistByCategory("lodging")?.artifacts?.lodging_structure);
+  return plan.find((stay) => day >= Number(stay.startDay || 0) && day <= Number(stay.endDay || 0)) || plan[0] || null;
+}
+
+function stayDateForDay(day) {
+  if (!day) {
+    return "";
+  }
+  return formatIsoShortDate(addDaysToIso(tripStartDate(), day - 1));
+}
+
+function activityRouteFit(option, stay) {
+  if (!stay?.region) {
+    return {
+      title: "Stay base TBD",
+      detail: "Pick a stay location before treating this timing as solid.",
+    };
+  }
+  const regionMatch = regionOverlap(stay.region, option.island_location);
+  return regionMatch
+    ? {
+        title: `From ${stay.region}`,
+        detail: "Fits the chosen stay area and should avoid unnecessary backtracking.",
+      }
+    : {
+        title: `From ${stay.region}`,
+        detail: "Outside this stay base; verify the route before approving.",
+      };
+}
+
+function regionOverlap(left, right) {
+  const leftTokens = regionTokens(left);
+  const rightTokens = regionTokens(right);
+  return leftTokens.some((token) => rightTokens.includes(token));
+}
+
+function activityCompareLinks(option, stay) {
+  const links = [];
+  if (option.deep_link) {
+    links.push(externalLink(option.deep_link, "Provider", "secondary-link"));
+  }
+  for (const [label, url] of Object.entries(option.validation_links || {})) {
+    if (url && !String(label).toLowerCase().includes("airbnb") && !String(url).includes("airbnb.")) {
+      links.push(externalLink(url, label, "secondary-link"));
+    }
+  }
+  if (stay?.region && option.island_location) {
+    links.push(externalLink(mapsDirectionsUrl(stay.region, option.island_location), "Route", "secondary-link"));
+  }
+  return links.join("");
+}
+
 function activitySchedulePanel(shortlist) {
   const schedule = shortlist.artifacts?.activity_schedule;
-  const entries = schedule?.entries || [];
+  const entries = sortedActivityScheduleEntries(schedule?.entries || []);
   const approved = entries.filter((entry) => ["approved", "booked"].includes(entry.status));
   return `<section class="structure-panel">
     <div>
@@ -2248,40 +2874,29 @@ function activitySchedulePanel(shortlist) {
 function activityScheduleChip(entry) {
   const day = entry.scheduled_day || entry.suggested_day || "TBD";
   const time = entry.scheduled_start_time || entry.suggested_start_time || "";
+  const stay = stayForDay(Number(day || 0));
   const status = entry.status || "researched";
   return `<article class="schedule-chip ${status === "approved" ? "is-approved" : ""}">
     <strong>Day ${escapeHtml(day)}</strong>
-    <span>${escapeHtml(time || "time TBD")}</span>
+    <span>${escapeHtml([entry.scheduled_date || entry.suggested_date || "", time || "time TBD"].filter(Boolean).join(" · "))}</span>
     <small>${escapeHtml(entry.activity_name || "")}</small>
+    ${stay?.region ? `<small>${escapeHtml(stay.region)}</small>` : ""}
   </article>`;
 }
 
 function activityComparison(shortlist) {
-  const rows = shortlist.activity_options || [];
+  const rows = sortedActivityOptions(shortlist.activity_options || []);
   return `<section class="comparison-panel">
-    <div class="comparison-head">
+    <div class="comparison-head compact-head compare-header-tight">
       <div>
         <p class="eyebrow">Activities</p>
-        <h3>Approve, schedule, and track</h3>
-        <p>${escapeHtml(shortlist.recommendation_summary || "")}</p>
+        <h3>Approve and place each activity</h3>
+        <p>Each option should make sense for the chosen stay location, day, cost, and route.</p>
       </div>
-      <span class="metric live">Recommended ${escapeHtml(shortlist.recommended_option_id || "TBD")}</span>
+      <span class="metric live">${escapeHtml(shortlist.recommended_option_id ? `Top pick ${shortlist.recommended_option_id}` : "Compare")}</span>
     </div>
-    <div class="comparison-table-wrap">
-      <table class="comparison-table activity-table">
-        <thead>
-          <tr>
-            <th>Activity / source</th>
-            <th>Suggested slot</th>
-            <th>Fit</th>
-            <th>Safety / crowd</th>
-            <th>Score</th>
-            <th>Schedule</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>${rows.map(activityRow).join("")}</tbody>
-      </table>
+    <div class="activity-card-stack">
+      ${rows.map(activityRow).join("")}
     </div>
   </section>`;
 }
@@ -2293,37 +2908,58 @@ function activityRow(option) {
   const scheduledDate = option.scheduled_date || option.suggested_date || "";
   const start = option.scheduled_start_time || option.suggested_start_time || "";
   const end = option.scheduled_end_time || option.suggested_end_time || "";
-  return `<tr class="${isApproved ? "recommended-row" : ""}">
-    <td>
-      <strong>${escapeHtml(option.activity_name)}</strong>
-      <small>${escapeHtml(option.source)} · ${escapeHtml(option.island_location)} · ${escapeHtml(validationSummary(option))}</small>
-    </td>
-    <td>
-      <strong>${scheduledDay ? `Day ${escapeHtml(scheduledDay)}` : "Day TBD"}</strong>
-      <small>${escapeHtml([scheduledDate, timeRange(start, end)].filter(Boolean).join(" · "))}</small>
-    </td>
-    <td>
-      <strong>${escapeHtml(option.duration)}</strong>
-      <small>${escapeHtml(option.age_family_fit || option.scheduling_rationale || "")}</small>
-    </td>
-    <td>
-      <strong>${escapeHtml(option.group_size_signal)}</strong>
-      <small>${escapeHtml(option.review_safety_signal)}</small>
-    </td>
-    <td>
-      <span class="score-pill">${escapeHtml(option.family_pace_fit_score)} pace</span>
-      <small>${escapeHtml((option.friction_flags || [])[0] || option.scheduling_rationale || "")}</small>
-    </td>
-    <td>${activityScheduleForm(option)}</td>
-    <td>
-      <button class="mini-button" type="button" data-select-activity="${escapeHtml(option.option_id)}">${isApproved ? "Approved" : "Approve"}</button>
-      ${externalLink(option.deep_link, "Open")}
-    </td>
-  </tr>`;
+  const stay = stayForDay(Number(scheduledDay || 0));
+  const routeFit = activityRouteFit(option, stay);
+  const compareLinks = activityCompareLinks(option, stay);
+  const reviewText = option.validation?.extracted_fields?.rating_summary || option.review_safety_signal || "Ratings pending deeper validation";
+  const cost = option.validation?.extracted_fields?.price_signal || option.price_band;
+  const availability = option.validation?.extracted_fields?.availability_signal || "source availability required";
+  const duration = option.validation?.extracted_fields?.duration_signal || option.duration || "source duration required";
+  return `<article class="activity-card ${isApproved ? "recommended-row" : ""}">
+    <div class="activity-card-image">${imageBlock(`${option.activity_name} ${option.island_location} activity`, option.activity_name)}</div>
+    <div class="activity-card-main">
+      <div class="activity-card-head">
+        <div>
+          <p class="eyebrow">${escapeHtml(option.source)}</p>
+          <h4>${escapeHtml(option.activity_name)}</h4>
+          <p>${escapeHtml(option.island_location)}</p>
+        </div>
+        <div class="metric-row">
+          <span class="score-pill">${escapeHtml(option.family_pace_fit_score)} pace</span>
+          <span class="metric ${isApproved ? "live" : ""}">${escapeHtml(isApproved ? "Approved" : truthLabel(option))}</span>
+        </div>
+      </div>
+      <div class="activity-data-grid">
+        <div>
+          <strong>${scheduledDay ? `Day ${escapeHtml(scheduledDay)}` : "Day TBD"}</strong>
+          <small>${escapeHtml([scheduledDate || stayDateForDay(Number(scheduledDay || 0)), timeRange(start, end)].filter(Boolean).join(" · "))}</small>
+        </div>
+        <div>
+          <strong>${escapeHtml(cost)}</strong>
+          <small>${escapeHtml([availability, duration].filter(Boolean).join(" · "))}</small>
+        </div>
+        <div>
+          <strong>${escapeHtml(routeFit.title)}</strong>
+          <small>${escapeHtml(routeFit.detail)}</small>
+        </div>
+        <div>
+          <strong>${escapeHtml(reviewText)}</strong>
+          <small>${escapeHtml(option.group_size_signal || "")}</small>
+        </div>
+      </div>
+      <div class="activity-link-row">
+        ${compareLinks}
+      </div>
+      <div class="activity-card-actions">
+        <button class="mini-button" type="button" data-select-activity="${escapeHtml(option.option_id)}">${isApproved ? "Approved" : "Approve"}</button>
+        ${activityScheduleForm(option)}
+      </div>
+    </div>
+  </article>`;
 }
 
 function activityScheduleForm(option) {
-  return `<form class="inline-schedule-form" data-activity-schedule-form>
+  return `<form class="inline-schedule-form compact" data-activity-schedule-form>
     <input type="hidden" name="option_id" value="${escapeHtml(option.option_id)}" />
     <label>Day<input name="day" type="number" min="1" value="${escapeHtml(option.scheduled_day || option.suggested_day || "")}" /></label>
     <label>Date<input name="date" type="date" value="${escapeHtml(option.scheduled_date || option.suggested_date || "")}" /></label>
@@ -2331,7 +2967,7 @@ function activityScheduleForm(option) {
     <label>End<input name="end_time" type="time" value="${escapeHtml(option.scheduled_end_time || option.suggested_end_time || "")}" /></label>
     <label class="checkbox-line"><input name="fixed" type="checkbox" ${option.scheduled_flexibility === "fixed" ? "checked" : ""} /> fixed</label>
     <input name="notes" type="text" placeholder="notes" value="${escapeHtml(option.scheduling_notes || "")}" />
-    <button class="mini-button secondary" type="submit">Save slot</button>
+    <button class="mini-button secondary" type="submit">Save</button>
   </form>`;
 }
 
@@ -2378,7 +3014,7 @@ function carRow(option) {
   return `<tr class="${isRecommended || isApproved ? "recommended-row" : ""}">
     <td>
       <strong>${escapeHtml(option.vehicle_class)}</strong>
-      <small>${escapeHtml(option.booking_source)} · ${escapeHtml(option.row_status || "researched")} · ${escapeHtml(validationSummary(option))}</small>
+      <small>${escapeHtml(option.booking_source)} · ${escapeHtml(validationSummary(option))}</small>
     </td>
     <td>
       <strong>${escapeHtml(option.pickup_location)}</strong>
@@ -2404,6 +3040,7 @@ function carRow(option) {
     </td>
     <td>
       <button class="mini-button" type="button" data-select-car="${escapeHtml(option.option_id)}">${isApproved ? "Selected" : "Choose"}</button>
+      ${bookingForm("car", option)}
     </td>
   </tr>`;
 }
@@ -2428,7 +3065,7 @@ function compactOptionCard(item) {
     <h4>${escapeHtml(item.title || "Untitled")}</h4>
     <p>${escapeHtml(item.subtitle || "")}</p>
     <div class="metric-row">
-      ${item.status ? `<span class="metric ${item.status === "verified_live" ? "live" : ""}">${escapeHtml(item.status)}</span>` : ""}
+      ${item.status ? `<span class="metric ${["Confirmed", "Booked", "Selected"].includes(item.status) ? "live" : ""}">${escapeHtml(item.status)}</span>` : ""}
       ${item.verification ? `<span class="metric">${escapeHtml(item.verification)}</span>` : ""}
     </div>
     ${item.notes ? `<small>${escapeHtml(String(item.notes))}</small>` : ""}
@@ -2486,9 +3123,46 @@ function mapsEmbedUrl(query) {
   return `https://www.google.com/maps?q=${encodeURIComponent(query || "travel planning")}&output=embed`;
 }
 
+function mapsDirectionsUrl(origin, destination) {
+  return `https://www.google.com/maps/dir/?api=1&origin=${encodeURIComponent(origin || "")}&destination=${encodeURIComponent(destination || "")}&travelmode=driving`;
+}
+
 function mapFileUrl(kind) {
   if (!state.activeTripId) return "";
   return `/api/map-file?trip_id=${encodeURIComponent(state.activeTripId)}&kind=${encodeURIComponent(kind)}`;
+}
+
+function googleSheetPanel(workspace, title, subtitle = "") {
+  const embedUrl = googleSheetEmbedUrl(workspace?.google_sheet_url);
+  return `<section class="stage-card sheet-frame-panel">
+    <div class="section-head compact-head">
+      <div>
+        <p class="eyebrow">Google Sheet</p>
+        <h3>${escapeHtml(title)}</h3>
+        ${subtitle ? `<p>${escapeHtml(subtitle)}</p>` : ""}
+      </div>
+      ${workspace?.google_sheet_url ? externalLink(workspace.google_sheet_url, "Open in Google Sheets", "primary-link") : ""}
+    </div>
+    ${
+      embedUrl
+        ? `<div class="sheet-frame-wrap"><iframe title="${escapeHtml(title)}" loading="lazy" src="${escapeHtml(embedUrl)}"></iframe></div>`
+        : `<div class="empty-state">Google Sheet link unavailable.</div>`
+    }
+  </section>`;
+}
+
+function googleSheetEmbedUrl(url) {
+  const text = String(url || "");
+  if (!text.includes("docs.google.com/spreadsheets")) {
+    return "";
+  }
+  const idMatch = text.match(/\/spreadsheets\/d\/([^/]+)/);
+  if (!idMatch) {
+    return text;
+  }
+  const gidMatch = text.match(/[?&#]gid=([0-9]+)/);
+  const gid = gidMatch?.[1] || "0";
+  return `https://docs.google.com/spreadsheets/d/${idMatch[1]}/edit?gid=${gid}&rm=minimal&widget=true&headers=false`;
 }
 
 function workspaceSummary(workspace) {
@@ -2589,8 +3263,10 @@ function optionForPick(option, category) {
   const title = option.airline || option.name || option.vehicle_class || option.activity_name || option.option_id;
   const subtitle = option.location_area || option.island_location || option.departure_airport || option.pickup_location || category;
   const link = option.deep_link;
-  const status = option.row_status || "researched";
-  const verification = option.validation?.verification_status || "";
+  const status = truthLabel(option);
+  const verification = option.validation?.confidence
+    ? `${Math.round(Number(option.validation.confidence) * 100)}% confidence`
+    : "";
   const notes = option.recommendation_grade || option.traveler_fit || option.traveler_roster_supported || "";
   return {
     title,
@@ -2609,7 +3285,7 @@ function pickCard(item) {
       <h3>${escapeHtml(item.title || "Untitled")}</h3>
       <p>${escapeHtml(item.subtitle || "")}</p>
       <div class="metric-row">
-        ${item.status ? `<span class="metric ${item.status === "verified_live" ? "live" : ""}">${escapeHtml(item.status)}</span>` : ""}
+        ${item.status ? `<span class="metric ${["Confirmed", "Booked", "Selected"].includes(item.status) ? "live" : ""}">${escapeHtml(item.status)}</span>` : ""}
         ${item.verification ? `<span class="metric">${escapeHtml(item.verification)}</span>` : ""}
       </div>
       ${item.notes ? `<p>${escapeHtml(String(item.notes))}</p>` : ""}
@@ -2653,6 +3329,10 @@ function collectTrips() {
 function shortlistReadyCount() {
   const count = state.trip?.shortlists?.length || 0;
   return `${count}/4`;
+}
+
+function tripPacketReadiness() {
+  return Number(state.trip?.trip_packet?.readiness_percent || 0);
 }
 
 function latestWorkflowId() {
@@ -2702,6 +3382,59 @@ function formatTime(value) {
     hour: "numeric",
     minute: "2-digit",
   });
+}
+
+function tripStartDate() {
+  return state.trip?.intake?.travel_window?.start_date || state.suggestedIntake?.travel_window?.start_date || "";
+}
+
+function addDaysToIso(isoDate, days) {
+  if (!isoDate) {
+    return "";
+  }
+  const base = new Date(`${isoDate}T12:00:00`);
+  if (Number.isNaN(base.getTime())) {
+    return "";
+  }
+  base.setDate(base.getDate() + Number(days || 0));
+  return base.toISOString().slice(0, 10);
+}
+
+function formatIsoShortDate(isoDate) {
+  if (!isoDate) {
+    return "";
+  }
+  const date = new Date(`${isoDate}T12:00:00`);
+  if (Number.isNaN(date.getTime())) {
+    return isoDate;
+  }
+  return date.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function stayDateLabel(startDay, endDay) {
+  const tripStart = tripStartDate();
+  if (!tripStart) {
+    return `Day ${startDay}${endDay > startDay ? `-${endDay}` : ""}`;
+  }
+  const start = addDaysToIso(tripStart, startDay - 1);
+  const end = addDaysToIso(tripStart, endDay - 1);
+  return `${formatIsoShortDate(start)}${end && end !== start ? ` - ${formatIsoShortDate(end)}` : ""}`;
+}
+
+function tripDateRangeLabel() {
+  const intake = state.trip?.intake || state.suggestedIntake;
+  if (!intake) {
+    return "Dates TBD";
+  }
+  if (intake.travel_window?.start_date) {
+    const duration = Number(intake.duration_days || intake.duration_min_days || 0);
+    const end = duration ? addDaysToIso(intake.travel_window.start_date, duration - 1) : intake.travel_window?.end_date;
+    return `${formatIsoShortDate(intake.travel_window.start_date)}${end ? ` - ${formatIsoShortDate(end)}` : ""}`;
+  }
+  return intake.duration_label || "Dates TBD";
 }
 
 function formPayload(form) {

--- a/trippy/ui/static/app.js
+++ b/trippy/ui/static/app.js
@@ -2,24 +2,28 @@ const state = {
   app: null,
   trip: null,
   activeTripId: null,
-  activeStage: "intake",
+  activeStage: "start",
   lastWorkflowByStage: {},
   isCreatingTrip: false,
   suggestedIntake: null,
   ideaComparison: null,
   ideaRequest: null,
+  ideaWorkflowId: null,
+  ideaFeedback: {},
   showSuggestForm: false,
   openTripMenuId: null,
   flightSort: "best",
 };
 
 const stages = [
+  { id: "start", label: "Start" },
   { id: "intake", label: "Intake" },
-  { id: "draft", label: "Options" },
-  { id: "research", label: "Research" },
-  { id: "workspace", label: "Workspace" },
-  { id: "maps", label: "Map" },
-  { id: "feedback", label: "Learning" },
+  { id: "options", label: "Options" },
+  { id: "flights", label: "Flights" },
+  { id: "lodging", label: "Lodging" },
+  { id: "activities", label: "Activities" },
+  { id: "plan", label: "Plan" },
+  { id: "review", label: "Review" },
 ];
 
 const partyOptions = [
@@ -33,6 +37,7 @@ const partyOptions = [
 
 document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("refreshButton").addEventListener("click", refresh);
+  document.getElementById("generateTripButton").addEventListener("click", () => startGenerateIdeas());
   document.getElementById("newTripButton").addEventListener("click", () => startNewTrip());
   document.addEventListener("click", (event) => {
     const target = event.target;
@@ -52,6 +57,9 @@ async function refresh() {
   if (state.activeTripId) {
     await loadTrip(state.activeTripId, { refreshApp: false });
   }
+  if (state.activeTripId && state.activeStage === "start" && !state.showSuggestForm) {
+    state.activeStage = nextUnlockedStage();
+  }
   render();
 }
 
@@ -64,6 +72,9 @@ async function loadTrip(tripId, options = {}) {
   state.openTripMenuId = null;
   state.activeTripId = tripId;
   state.trip = await apiGet(`/api/trip?trip_id=${encodeURIComponent(tripId)}`);
+  if (options.gotoNext) {
+    state.activeStage = nextUnlockedStage();
+  }
   render();
 }
 
@@ -76,6 +87,19 @@ function startNewTrip(prefill = null) {
   state.openTripMenuId = null;
   render();
   document.getElementById("stageBody")?.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function startGenerateIdeas() {
+  state.activeTripId = null;
+  state.trip = null;
+  state.isCreatingTrip = false;
+  state.suggestedIntake = null;
+  state.ideaFeedback = {};
+  state.activeStage = "start";
+  state.showSuggestForm = true;
+  state.openTripMenuId = null;
+  render();
+  document.querySelector(".wizard-panel")?.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
 async function apiGet(path) {
@@ -101,41 +125,181 @@ async function handleResponse(response) {
 }
 
 function render() {
+  normalizeActiveStage();
   renderHeader();
   renderTripList();
   renderStageTabs();
   renderStage();
   renderPicks();
   renderRunLog();
-  renderIdeas();
+  wireProgressBar();
 }
 
 function renderHeader() {
   const intake = state.trip?.intake || state.suggestedIntake;
-  const title = intake?.trip_name || "Plan the next great trip";
+  document.querySelector(".command-band")?.classList.toggle("no-active-trip", !intake);
+  const title = intake?.trip_name || "";
   const subhead = intake
     ? `${(intake.destination_seeds || []).join(", ")} · ${partyLabel(intake.party?.party_type)} · ${intake.party?.total_travelers || intake.travelers} traveler(s) · ${intake.duration_label || `${intake.duration_days || "?"} days`}`
-    : "Use the wizard to create a trip, compare options, and give feedback as Trippy learns.";
+    : "";
   document.getElementById("activeTripTitle").textContent = title;
   document.getElementById("activeTripSubhead").textContent = subhead;
-  document.getElementById("nextStep").textContent = state.trip?.next_step || "Create a trip intake.";
   document.getElementById("logsJsonLink").href = state.activeTripId
     ? `/api/logs?trip_id=${encodeURIComponent(state.activeTripId)}`
     : "/api/logs";
+  document.getElementById("planningProgress").innerHTML = planningProgressBar();
+}
 
-  const dashboardTrip = currentDashboardTrip();
-  const statuses = [
-    ["Fit", dashboardTrip?.family_fit_score || "TBD"],
-    ["Comfort", dashboardTrip?.comfort_score || "TBD"],
-    ["Planned", dashboardTrip ? `${dashboardTrip.planning_completeness}%` : "0%"],
-    ["Shortlists", shortlistReadyCount()],
+function normalizeActiveStage() {
+  const legacyStageMap = {
+    draft: "options",
+    research: "flights",
+    workspace: "plan",
+    maps: "plan",
+    feedback: "review",
+  };
+  state.activeStage = legacyStageMap[state.activeStage] || state.activeStage;
+  if (!stages.some((stage) => stage.id === state.activeStage)) {
+    state.activeStage = "start";
+  }
+  if (!isStageUnlocked(state.activeStage)) {
+    state.activeStage = nextUnlockedStage();
+  }
+}
+
+function isStageUnlocked(stageId) {
+  const hasTrip = Boolean(state.activeTripId || state.trip?.intake);
+  const hasIntake = Boolean(state.trip?.intake);
+  const hasSelectedPlan = Boolean(state.trip?.draft?.selected_option_id);
+  if (stageId === "start") return true;
+  if (stageId === "intake") return state.isCreatingTrip || hasTrip;
+  if (stageId === "options") return hasIntake;
+  if (["flights", "lodging", "activities", "plan"].includes(stageId)) return hasSelectedPlan;
+  if (stageId === "review") return hasTrip || Boolean(state.trip?.recent_workflows?.length);
+  return false;
+}
+
+function isStageComplete(stageId) {
+  if (stageId === "start") return Boolean(state.activeTripId || state.isCreatingTrip || state.suggestedIntake);
+  if (stageId === "intake") return Boolean(state.trip?.intake);
+  if (stageId === "options") return Boolean(state.trip?.draft?.selected_option_id);
+  if (stageId === "flights") return Boolean(shortlistByCategory("flights")?.flight_options?.length);
+  if (stageId === "lodging") return Boolean(shortlistByCategory("lodging")?.lodging_options?.length);
+  if (stageId === "activities") {
+    return Boolean(
+      shortlistByCategory("activities")?.activity_options?.length ||
+        shortlistByCategory("cars")?.car_options?.length,
+    );
+  }
+  if (stageId === "plan") return Boolean(state.trip?.workspace || state.trip?.map_artifact);
+  return Boolean(state.trip?.recent_workflows?.length);
+}
+
+function nextUnlockedStage() {
+  if (state.isCreatingTrip || state.suggestedIntake) return "intake";
+  if (!state.activeTripId && !state.trip?.intake) return "start";
+  if (!state.trip?.intake) return "intake";
+  if (!state.trip?.draft?.selected_option_id) return "options";
+  if (!shortlistByCategory("flights")?.flight_options?.length) return "flights";
+  if (!shortlistByCategory("lodging")?.lodging_options?.length) return "lodging";
+  if (!shortlistByCategory("activities")?.activity_options?.length) return "activities";
+  return "plan";
+}
+
+function guidedNextStep() {
+  const stage = nextUnlockedStage();
+  const messages = {
+    start: "Choose Generate for ideas or New when you already know the trip.",
+    intake: "Confirm who is going, timing, priorities, and comfort constraints.",
+    options: "Build and choose the trip shape before exact recommendations.",
+    flights: "Compare flight timing, friction, price bands, and source confidence.",
+    lodging: "Decide one stay vs split stays, then compare places that fit the party.",
+    activities: "Pick activities and car logic that fit the chosen trip shape.",
+    plan: "Build the timeline, map, risks, and planning workspace.",
+    review: "Send feedback only when a workflow should teach Trippy.",
+  };
+  return state.trip?.next_step || messages[stage] || messages.start;
+}
+
+function planningProgressBar() {
+  if (!state.trip?.intake && !state.suggestedIntake) {
+    return "";
+  }
+  const items = planningMilestones();
+  return `<div class="progress-track" aria-label="Trip planning progress">
+    ${items.map(progressStep).join("")}
+  </div>`;
+}
+
+function planningMilestones() {
+  const trip = state.trip || {};
+  const draft = trip.draft;
+  const workspace = trip.workspace;
+  const hasIntake = Boolean(trip.intake || state.suggestedIntake);
+  return [
+    {
+      key: "intake",
+      icon: "I",
+      label: "Intake",
+      state: hasIntake ? "done" : "todo",
+      detail: hasIntake ? "saved" : "needed",
+    },
+    {
+      key: "shape",
+      icon: "O",
+      label: "Shape",
+      state: draft?.selected_option_id ? "done" : draft?.options?.length ? "active" : "todo",
+      detail: draft?.selected_option_id ? "selected" : draft?.options?.length ? "choose" : "draft",
+    },
+    shortlistMilestone("flights", "F", "Flights"),
+    shortlistMilestone("lodging", "L", "Lodging"),
+    shortlistMilestone("cars", "C", "Cars"),
+    shortlistMilestone("activities", "A", "Activities"),
+    {
+      key: "workspace",
+      icon: "S",
+      label: "Sheet",
+      state: workspace?.google_sheet_url ? "done" : workspace ? "active" : "todo",
+      detail: workspace?.google_sheet_url ? "created" : workspace ? "local" : "build",
+    },
+    {
+      key: "booked",
+      icon: "B",
+      label: "Booked",
+      state: bookingMilestoneState(),
+      detail: bookingMilestoneDetail(),
+    },
   ];
-  document.getElementById("statusStrip").innerHTML = statuses
-    .map(
-      ([label, value]) =>
-        `<div class="status-chip"><strong>${escapeHtml(value)}</strong><span>${escapeHtml(label)}</span></div>`,
-    )
-    .join("");
+}
+
+function shortlistMilestone(category, icon, label) {
+  const shortlist = shortlistByCategory(category);
+  if (!shortlist) {
+    return { key: category, icon, label, state: "todo", detail: "needed" };
+  }
+  const options = shortlistOptions(shortlist);
+  const approved = options.some((option) => option.row_status === "approved" || option.row_status === "booked");
+  const booked = options.some((option) => option.row_status === "booked");
+  return {
+    key: category,
+    icon,
+    label,
+    state: booked || approved ? "done" : options.length ? "active" : "todo",
+    detail: booked ? "booked" : approved ? "approved" : `${options.length} found`,
+  };
+}
+
+function bookingMilestoneState() {
+  const options = (state.trip?.shortlists || []).flatMap(shortlistOptions);
+  const flightBooked = options.some((option) => option.row_status === "booked" && option.airline);
+  const lodgingBooked = options.some((option) => option.row_status === "booked" && option.name);
+  const workspaceRows = state.trip?.workspace?.tabs || [];
+  const hasConfirmation = JSON.stringify(workspaceRows).toLowerCase().includes("confirmation");
+  return flightBooked && lodgingBooked && hasConfirmation ? "done" : "todo";
+}
+
+function bookingMilestoneDetail() {
+  return bookingMilestoneState() === "done" ? "confirmed" : "confirmations needed";
 }
 
 function renderTripList() {
@@ -166,7 +330,7 @@ function renderTripList() {
     })
     .join("");
   list.querySelectorAll("button[data-trip-id]").forEach((button) => {
-    button.addEventListener("click", () => loadTrip(button.dataset.tripId));
+    button.addEventListener("click", () => loadTrip(button.dataset.tripId, { gotoNext: true }));
   });
   list.querySelectorAll("button[data-trip-menu]").forEach((button) => {
     button.addEventListener("click", (event) => {
@@ -202,42 +366,124 @@ async function deleteTrip(tripId) {
 
 function renderStageTabs() {
   const tabs = document.getElementById("stageTabs");
-  tabs.innerHTML = stages
-    .map((stage) => {
-      const active = stage.id === state.activeStage ? " active" : "";
-      return `<button type="button" class="${active}" data-stage="${stage.id}">${stage.label}</button>`;
-    })
-    .join("");
-  tabs.querySelectorAll("button").forEach((button) => {
+  if (!tabs) {
+    return;
+  }
+  tabs.innerHTML = "";
+}
+
+function wireProgressBar() {
+  document.querySelectorAll("[data-progress-stage]").forEach((button) => {
     button.addEventListener("click", () => {
-      state.activeStage = button.dataset.stage;
-      renderStage();
-      renderStageTabs();
+      const stage = button.dataset.progressStage;
+      if (stage && isStageUnlocked(stage)) {
+        state.activeStage = stage;
+        render();
+        document.querySelector(".wizard-panel")?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      }
     });
   });
 }
 
+function progressStep(item) {
+  const title = `${item.label}: ${item.detail}`;
+  return `<button type="button" class="progress-step ${escapeHtml(item.state)}" data-progress-stage="${escapeHtml(progressStageForMilestone(item.key))}" title="${escapeHtml(title)}" aria-label="${escapeHtml(title)}" data-tooltip="${escapeHtml(title)}">
+    <span class="progress-icon" aria-hidden="true">${progressIcon(item.key)}</span>
+    <span class="sr-only">${escapeHtml(title)}</span>
+  </button>`;
+}
+
+function progressIcon(key) {
+  const icons = {
+    intake: `<svg viewBox="0 0 24 24" role="img"><path d="M8 4h8l1 2h3v15H4V6h3l1-2Z"/><path d="M8 10h8M8 14h8M8 18h5"/></svg>`,
+    shape: `<svg viewBox="0 0 24 24" role="img"><path d="M5 19V5l5 3 5-3 4 3v14l-4-3-5 3-5-3Z"/><path d="M10 8v14M15 5v14"/></svg>`,
+    flights: `<svg viewBox="0 0 24 24" role="img"><path d="M3 13 21 5l-5 16-4-7-6 4 3-6-6 1Z"/></svg>`,
+    lodging: `<svg viewBox="0 0 24 24" role="img"><path d="M4 11h16v8M4 19V6M20 19v-5H8"/><path d="M8 11V8h5v3"/></svg>`,
+    cars: `<svg viewBox="0 0 24 24" role="img"><path d="M5 16h14l-1-5-2-3H8l-2 3-1 5Z"/><path d="M7 16v2M17 16v2M7 12h10"/></svg>`,
+    activities: `<svg viewBox="0 0 24 24" role="img"><path d="m12 3 2.4 5 5.6.8-4 3.9.9 5.5L12 15.6 7.1 18.2l.9-5.5-4-3.9 5.6-.8L12 3Z"/></svg>`,
+    workspace: `<svg viewBox="0 0 24 24" role="img"><path d="M6 3h9l3 3v15H6V3Z"/><path d="M14 3v4h4M9 11h6M9 15h6M9 19h4"/></svg>`,
+    booked: `<svg viewBox="0 0 24 24" role="img"><path d="M20 7 10 17l-5-5"/></svg>`,
+  };
+  return icons[key] || icons.intake;
+}
+
+function progressStageForMilestone(key) {
+  const map = {
+    intake: "intake",
+    shape: "options",
+    flights: "flights",
+    lodging: "lodging",
+    cars: "activities",
+    activities: "activities",
+    workspace: "plan",
+    booked: "plan",
+  };
+  return map[key] || "start";
+}
+
 function renderStage() {
   const body = document.getElementById("stageBody");
-  if (state.activeStage === "intake") {
+  if (state.activeStage === "start") {
+    body.innerHTML = startStage();
+    wireStartStage(body);
+  } else if (state.activeStage === "intake") {
     body.innerHTML = intakeStage();
     wireIntakeStage(body);
-  } else if (state.activeStage === "draft") {
+  } else if (state.activeStage === "options") {
     body.innerHTML = draftStage();
     wireDraftStage(body);
-  } else if (state.activeStage === "research") {
-    body.innerHTML = researchStage();
-    wireResearchStage(body);
-  } else if (state.activeStage === "workspace") {
-    body.innerHTML = workspaceStage();
-    wireWorkspaceStage(body);
-  } else if (state.activeStage === "maps") {
-    body.innerHTML = mapsStage();
-    wireMapsStage(body);
+  } else if (state.activeStage === "flights") {
+    body.innerHTML = flightsStage();
+    wireFlightsStage(body);
+  } else if (state.activeStage === "lodging") {
+    body.innerHTML = lodgingStage();
+    wireLodgingStage(body);
+  } else if (state.activeStage === "activities") {
+    body.innerHTML = activitiesStage();
+    wireActivitiesStage(body);
+  } else if (state.activeStage === "plan") {
+    body.innerHTML = planStage();
+    wirePlanStage(body);
   } else {
     body.innerHTML = learningStage();
-    wireFeedbackForms(body, "feedback");
+    wireFeedbackForms(body, "review");
   }
+}
+
+function startStage() {
+  const concepts = state.ideaComparison?.concepts || [];
+  return `
+    <section class="start-screen">
+      <div class="start-hero">
+        <p class="eyebrow">Start here</p>
+        <h3>Choose how Trippy should begin.</h3>
+        <p>Generate is for inspiration. New is for a trip you already have in mind. Nothing is saved until you approve the detailed intake.</p>
+      </div>
+      <div class="idea-action-grid">
+        <article class="idea-action-card suggest">
+          <p class="eyebrow">Path A</p>
+          <h3>Generate ideas</h3>
+          <p>Answer a few lightweight questions and Trippy will suggest a few trip concepts to choose from.</p>
+          <button id="ideaSuggestToggle" type="button">${state.showSuggestForm ? "Hide generator" : "Generate"}</button>
+        </article>
+        <article class="idea-action-card">
+          <p class="eyebrow">Path B</p>
+          <h3>New trip</h3>
+          <p>Open the full intake when you already know the destination, dates, or constraints.</p>
+          <button id="ideaNewTrip" type="button">New</button>
+        </article>
+      </div>
+      ${state.showSuggestForm ? suggestIdeaForm() : ""}
+      ${
+        concepts.length
+          ? `<div class="suggestion-grid">${concepts.map(suggestionCard).join("")}</div>`
+          : `<div class="empty-state">No generated ideas yet. Use Generate for lightweight ideation, or New for direct planning.</div>`
+      }
+    </section>
+  `;
 }
 
 function intakeStage() {
@@ -334,7 +580,7 @@ function draftStage() {
     <div class="stage-card action-card">
       <div>
         <h3>${options.length ? "Planning shapes are deterministic from the saved intake" : "Build planning shapes"}</h3>
-        <p>${options.length ? "Use refresh only after changing constraints. Selecting an option now starts deeper source research." : "Trippy will build a small set of planning shapes from the saved intake."}</p>
+        <p>${options.length ? "Refresh only after changing constraints. Choosing one shape moves directly into flights." : "Trippy will build a small set of planning shapes from the saved intake."}</p>
       </div>
       <button id="draftButton" type="button">${buttonLabel}</button>
       <p class="inline-result"></p>
@@ -355,19 +601,10 @@ function researchStage() {
       <div>
         <h3>Exact research</h3>
         <p>Refresh source-backed shortlists, then compare timing, cost bands, roster fit, and friction.</p>
-        <label class="check-row"><input id="validateLive" type="checkbox"> Validate source links live</label>
-        <label>Research adapter<select id="researchAdapter">
-          <option value="auto">auto</option>
-          <option value="link">link only</option>
-          <option value="playwright">playwright</option>
-          <option value="openclaw">openclaw</option>
-        </select></label>
       </div>
       <div class="button-row compact-buttons">
-        <button data-shortlist="flights" type="button">Flights</button>
-        <button data-shortlist="flights" data-deep-research="true" type="button">Deep verify flights</button>
-        <button data-shortlist="lodging" type="button">Lodging</button>
-        <button data-shortlist="lodging" data-deep-research="true" type="button">Deep verify lodging</button>
+        <button data-shortlist="flights" data-auto-research="true" type="button">Flights</button>
+        <button data-shortlist="lodging" data-auto-research="true" type="button">Lodging</button>
         <button data-shortlist="cars" type="button">Cars</button>
         <button data-shortlist="activities" type="button">Activities</button>
       </div>
@@ -385,16 +622,13 @@ function flightCandidateForm() {
     <div>
       <p class="eyebrow">Bring your own flight</p>
       <h3>Add flight candidate</h3>
-      <p>Paste a Google Flights, Kayak, Expedia, Flighthub link, or itinerary text. Trippy will score timing, layovers, fare confidence, and friction in the same flight model.</p>
+      <p>Paste a Google Flights, Kayak, Expedia, Flighthub link, or itinerary text. Trippy will choose the best available research path and score timing, layovers, fare confidence, and friction.</p>
     </div>
     <div class="form-grid">
       ${input("name", "Airline / label", "", "text")}
       ${input("link", "Link", "", "url")}
       ${textarea("notes", "Flight notes", "", "Example: Air Canada AC123 + TAP TP1861, depart 9:15 PM, arrive 2:20 PM, duration 10h 35m, 1 stop via LIS, layover 2h 20m, CAD 1180 pp, checked bag included.")}
     </div>
-    <label class="check-row"><input type="checkbox" name="validate_live"> Validate link reachability</label>
-    <label class="check-row"><input type="checkbox" name="deep_research"> Deep verify with source adapters</label>
-    ${select("adapter", "Adapter", "auto", ["auto", "link", "playwright", "openclaw"])}
     <div class="button-row">
       <button type="submit">Evaluate flight</button>
     </div>
@@ -407,21 +641,154 @@ function lodgingCandidateForm() {
     <div>
       <p class="eyebrow">Bring your own option</p>
       <h3>Add lodging candidate</h3>
-      <p>Paste a Booking.com, Airbnb, VRBO, hotel, or notes-only candidate and Trippy will score it in the same lodging model.</p>
+      <p>Paste a Booking.com, Airbnb, VRBO, hotel, or notes-only candidate. Trippy will choose the best available research path and score it in the same lodging model.</p>
     </div>
     <div class="form-grid">
       ${input("name", "Name", "", "text")}
       ${input("link", "Link", "", "url")}
       ${textarea("notes", "Notes", "", "Paste bed layout, area, nightly/total cost, parking, cancellation, or why you like it.")}
     </div>
-    <label class="check-row"><input type="checkbox" name="validate_live"> Validate link reachability</label>
-    <label class="check-row"><input type="checkbox" name="deep_research"> Deep verify with source adapters</label>
-    ${select("adapter", "Adapter", "auto", ["auto", "link", "playwright", "openclaw"])}
     <div class="button-row">
       <button type="submit">Evaluate lodging</button>
     </div>
     <p class="inline-result"></p>
   </form>`;
+}
+
+function flightsStage() {
+  if (!state.activeTripId) {
+    return `<div class="empty-state">Create or select a trip first.</div>`;
+  }
+  const shortlist = shortlistByCategory("flights");
+  return `
+    <div class="guided-step-layout">
+      <section class="stage-card action-card">
+        <div>
+          <p class="eyebrow">Step 4</p>
+          <h3>Find the best flight fit</h3>
+          <p>Compare timing, route pain, price bands, and source confidence. Trippy recommends the lowest-friction option from current evidence.</p>
+          ${truthLegend()}
+        </div>
+        <div class="button-row compact-buttons">
+          <button data-shortlist="flights" data-auto-research="true" type="button">${shortlist ? "Refresh flights" : "Find flights"}</button>
+        </div>
+        <p class="inline-result"></p>
+      </section>
+      ${shortlist ? flightComparison(shortlist) : `<div class="empty-state">Flight suggestions appear here after you choose a trip shape.</div>`}
+      <details class="stage-card quiet-details">
+        <summary>Add a flight you found</summary>
+        ${flightCandidateForm()}
+      </details>
+      <div class="button-row step-forward-row">
+        <button type="button" class="secondary" data-next-stage="options">Back to options</button>
+        <button type="button" data-next-stage="lodging">Next: lodging</button>
+      </div>
+    </div>
+    ${feedbackBlock("flights")}
+  `;
+}
+
+function lodgingStage() {
+  if (!state.activeTripId) {
+    return `<div class="empty-state">Create or select a trip first.</div>`;
+  }
+  const shortlist = shortlistByCategory("lodging");
+  return `
+    <div class="guided-step-layout">
+      <section class="stage-card action-card">
+        <div>
+          <p class="eyebrow">Step 5</p>
+          <h3>Choose the stay structure</h3>
+          <p>Trippy checks whether one base or split stays better matches the chosen trip shape, then compares properties against party fit.</p>
+          ${truthLegend()}
+        </div>
+        <div class="button-row compact-buttons">
+          <button data-shortlist="lodging" data-auto-research="true" type="button">${shortlist ? "Refresh lodging" : "Find lodging"}</button>
+        </div>
+        <p class="inline-result"></p>
+      </section>
+      ${lodgingStructurePanel(shortlist)}
+      ${shortlist ? lodgingComparison(shortlist) : `<div class="empty-state">Lodging suggestions appear here after the selected shape is known.</div>`}
+      <details class="stage-card quiet-details">
+        <summary>Add a hotel, Airbnb, or VRBO you found</summary>
+        ${lodgingCandidateForm()}
+      </details>
+      <div class="button-row step-forward-row">
+        <button type="button" class="secondary" data-next-stage="flights">Back to flights</button>
+        <button type="button" data-next-stage="activities">Next: activities</button>
+      </div>
+    </div>
+    ${feedbackBlock("lodging")}
+  `;
+}
+
+function activitiesStage() {
+  if (!state.activeTripId) {
+    return `<div class="empty-state">Create or select a trip first.</div>`;
+  }
+  const activities = shortlistByCategory("activities");
+  const cars = shortlistByCategory("cars");
+  return `
+    <div class="guided-step-layout">
+      <section class="stage-card action-card">
+        <div>
+          <p class="eyebrow">Step 6</p>
+          <h3>Activities and local movement</h3>
+          <p>Keep the days balanced: safe, well-reviewed activities, practical driving, and enough downtime.</p>
+        </div>
+        <div class="button-row compact-buttons">
+          <button data-shortlist="activities" type="button">${activities ? "Refresh activities" : "Find activities"}</button>
+          <button data-shortlist="cars" type="button">${cars ? "Refresh cars" : "Find cars"}</button>
+        </div>
+        <p class="inline-result"></p>
+      </section>
+      <div class="research-stack">
+        ${activities ? activitySchedulePanel(activities) : ""}
+        ${activities ? activityComparison(activities) : `<div class="empty-state">Activity suggestions are not built yet.</div>`}
+        ${cars ? carComparison(cars) : `<div class="empty-state">Car suggestions are not built yet.</div>`}
+      </div>
+      <div class="button-row step-forward-row">
+        <button type="button" class="secondary" data-next-stage="lodging">Back to lodging</button>
+        <button type="button" data-next-stage="plan">Next: timeline + map</button>
+      </div>
+    </div>
+    ${feedbackBlock("activities")}
+  `;
+}
+
+function planStage() {
+  if (!state.activeTripId) {
+    return `<div class="empty-state">Create or select a trip first.</div>`;
+  }
+  const workspace = state.trip?.workspace;
+  const artifact = state.trip?.map_artifact;
+  const mapRows = (workspace?.tabs || []).find((tab) => tab.name === "Maps")?.rows || [];
+  const hasGoogleSheet = Boolean(workspace?.google_sheet_id || workspace?.google_sheet_url);
+  const sheetButtonLabel = hasGoogleSheet ? "Update Google Sheet" : "Create Google Sheet";
+  return `
+    <div class="guided-step-layout">
+      ${structureGuidancePanel()}
+      <section class="stage-card action-card">
+        <div>
+          <p class="eyebrow">Step 7</p>
+          <h3>Google Sheet and custom map</h3>
+          <p>Keep the planning sheet, timeline, map anchors, risks, and next actions current.</p>
+        </div>
+        <div class="button-row compact-buttons">
+          <button id="googleWorkspaceButton" type="button">${sheetButtonLabel}</button>
+          <button id="mapButton" type="button" class="secondary">${artifact ? "Update custom map" : "Create custom map"}</button>
+        </div>
+        <p class="inline-result"></p>
+      </section>
+      ${workspace ? workspaceSummary(workspace) : `<div class="empty-state">Create the Google Sheet to build the Master Timeline, map anchors, and risks.</div>`}
+      ${artifact ? embeddedMapPanel(artifact) : fallbackMapPanel(mapRows)}
+      <div class="button-row step-forward-row">
+        <button type="button" class="secondary" data-next-stage="activities">Back to activities</button>
+        <button type="button" data-next-stage="review">Next: feedback</button>
+      </div>
+    </div>
+    ${feedbackBlock("plan")}
+  `;
 }
 
 function workspaceStage() {
@@ -431,8 +798,6 @@ function workspaceStage() {
       <div>
         <h3>Workspace</h3>
         <p>Hydrate Overview, Master Timeline, Flights, Lodging, Cars, Activities, Maps, and Risks from the selected plan and shortlists.</p>
-        <label class="check-row"><input id="workspaceLive" type="checkbox"> Validate source links before hydration</label>
-        <label class="check-row"><input id="workspaceGoogle" type="checkbox"> Create Google Sheet</label>
       </div>
       <button id="workspaceButton" type="button">Prepare workspace</button>
       <p class="inline-result"></p>
@@ -460,6 +825,10 @@ function mapsStage() {
   `;
 }
 
+function wireStartStage(root) {
+  wireIdeaControls(root);
+}
+
 function learningStage() {
   const workflows = state.trip?.recent_workflows || [];
   const logs = currentRunLog();
@@ -476,7 +845,7 @@ function learningStage() {
       </div>
     </div>
     <div class="run-log compact">${logs.slice(-8).reverse().map(logRow).join("") || `<div class="empty-state">No learning events yet.</div>`}</div>
-    ${feedbackBlock("feedback")}
+    ${feedbackBlock("review")}
   `;
 }
 
@@ -494,7 +863,7 @@ function wireIntakeStage(root) {
     if (response?.intake?.trip_id) {
       const draft = await apiPost("/api/draft", { trip_id: response.intake.trip_id });
       state.lastWorkflowByStage.draft = draft.workflow_id;
-      state.activeStage = "draft";
+      state.activeStage = "options";
       await loadTrip(response.intake.trip_id);
       render();
     }
@@ -583,22 +952,22 @@ function wireDraftStage(root) {
 async function selectOptionAndStartResearch(root, optionId) {
   const result = root.querySelector(".inline-result");
   try {
-    setWorking(result, "Selecting option and starting source research");
+    setWorking(result, "Selecting option and finding first recommendations");
     const selection = await apiPost("/api/select", {
       trip_id: state.activeTripId,
       option_id: optionId,
     });
     state.lastWorkflowByStage.draft = selection.workflow_id;
     for (const category of ["flights", "lodging", "cars", "activities"]) {
-      result.textContent = `Researching ${category}...`;
+      result.textContent = `Building ${category} suggestions...`;
       const response = await apiPost("/api/shortlist", {
         trip_id: state.activeTripId,
         category,
         validate_live: false,
       });
-      state.lastWorkflowByStage.research = response.workflow_id;
+      state.lastWorkflowByStage[category] = response.workflow_id;
     }
-    state.activeStage = "research";
+    state.activeStage = "flights";
     await loadTrip(state.activeTripId);
     render();
   } catch (error) {
@@ -619,9 +988,9 @@ function wireResearchStage(root) {
       await runStage(root, "research", "/api/shortlist", {
         trip_id: state.activeTripId,
         category: button.dataset.shortlist,
-        validate_live: root.querySelector("#validateLive").checked,
-        deep_research: button.dataset.deepResearch === "true",
-        adapter: root.querySelector("#researchAdapter").value,
+        validate_live: button.dataset.autoResearch === "true",
+        deep_research: button.dataset.autoResearch === "true" || button.dataset.deepResearch === "true",
+        adapter: "auto",
       });
     });
   });
@@ -634,6 +1003,9 @@ function wireResearchStage(root) {
         setWorking(result, "Evaluating lodging candidate");
         const payload = formPayload(candidate);
         payload.trip_id = state.activeTripId;
+        payload.validate_live = true;
+        payload.deep_research = true;
+        payload.adapter = "auto";
         const response = await apiPost("/api/lodging-candidate", payload);
         state.lastWorkflowByStage.research = response.workflow_id;
         await loadTrip(state.activeTripId);
@@ -653,6 +1025,9 @@ function wireResearchStage(root) {
         setWorking(result, "Evaluating flight candidate");
         const payload = formPayload(flightCandidate);
         payload.trip_id = state.activeTripId;
+        payload.validate_live = true;
+        payload.deep_research = true;
+        payload.adapter = "auto";
         const response = await apiPost("/api/flight-candidate", payload);
         state.lastWorkflowByStage.research = response.workflow_id;
         await loadTrip(state.activeTripId);
@@ -684,14 +1059,257 @@ function wireResearchStage(root) {
   wireFeedbackForms(root, "research");
 }
 
+function wireFlightsStage(root) {
+  wireShortlistButtons(root, "flights");
+  const flightSort = root.querySelector("#flightSort");
+  if (flightSort) {
+    flightSort.addEventListener("change", () => {
+      state.flightSort = flightSort.value;
+      render();
+    });
+  }
+  const flightCandidate = root.querySelector("#flightCandidateForm");
+  if (flightCandidate) {
+    flightCandidate.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const result = flightCandidate.querySelector(".inline-result");
+      try {
+        setWorking(result, "Evaluating flight candidate");
+        const payload = formPayload(flightCandidate);
+        payload.trip_id = state.activeTripId;
+        payload.validate_live = true;
+        payload.deep_research = true;
+        payload.adapter = "auto";
+        const response = await apiPost("/api/flight-candidate", payload);
+        state.lastWorkflowByStage.flights = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = "flights";
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  }
+  root.querySelectorAll("[data-select-flight]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const result = root.querySelector(".inline-result");
+      try {
+        setWorking(result, "Selecting flight and updating timing guidance");
+        const response = await apiPost("/api/select-flight", {
+          trip_id: state.activeTripId,
+          option_id: button.dataset.selectFlight,
+        });
+        state.lastWorkflowByStage.flights = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = "lodging";
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  });
+  wireStageNavigation(root);
+  wireFeedbackForms(root, "flights");
+}
+
+function wireLodgingStage(root) {
+  wireShortlistButtons(root, "lodging");
+  const structureForm = root.querySelector("#stayStructureForm");
+  if (structureForm) {
+    structureForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const result = structureForm.querySelector(".inline-result");
+      try {
+        setWorking(result, "Saving stay structure");
+        const payload = formPayload(structureForm);
+        const response = await apiPost("/api/lodging-structure", {
+          trip_id: state.activeTripId,
+          strategy: payload.strategy,
+          night_plan: parseNightPlanText(payload.night_plan_text),
+          notes: payload.notes || "",
+        });
+        state.lastWorkflowByStage.lodging = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = "lodging";
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  }
+  const candidate = root.querySelector("#lodgingCandidateForm");
+  if (candidate) {
+    candidate.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const result = candidate.querySelector(".inline-result");
+      try {
+        setWorking(result, "Evaluating lodging candidate");
+        const payload = formPayload(candidate);
+        payload.trip_id = state.activeTripId;
+        payload.validate_live = true;
+        payload.deep_research = true;
+        payload.adapter = "auto";
+        const response = await apiPost("/api/lodging-candidate", payload);
+        state.lastWorkflowByStage.lodging = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = "lodging";
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  }
+  root.querySelectorAll("[data-select-lodging]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const result = root.querySelector(".inline-result");
+      try {
+        setWorking(result, "Selecting lodging");
+        const response = await apiPost("/api/select-lodging", {
+          trip_id: state.activeTripId,
+          option_id: button.dataset.selectLodging,
+        });
+        state.lastWorkflowByStage.lodging = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = "lodging";
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  });
+  wireStageNavigation(root);
+  wireFeedbackForms(root, "lodging");
+}
+
+function wireActivitiesStage(root) {
+  wireShortlistButtons(root, "activities");
+  root.querySelectorAll("[data-select-car]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const result = root.querySelector(".inline-result");
+      try {
+        setWorking(result, "Selecting car and updating local movement plan");
+        const response = await apiPost("/api/select-car", {
+          trip_id: state.activeTripId,
+          option_id: button.dataset.selectCar,
+        });
+        state.lastWorkflowByStage.activities = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = "activities";
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  });
+  root.querySelectorAll("[data-select-activity]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const result = root.querySelector(".inline-result");
+      try {
+        setWorking(result, "Approving activity and adding it to the timeline");
+        const response = await apiPost("/api/select-activity", {
+          trip_id: state.activeTripId,
+          option_id: button.dataset.selectActivity,
+        });
+        state.lastWorkflowByStage.activities = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = "activities";
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  });
+  root.querySelectorAll("[data-activity-schedule-form]").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const result = root.querySelector(".inline-result");
+      const payload = formPayload(form);
+      try {
+        setWorking(result, "Saving activity schedule");
+        const response = await apiPost("/api/schedule-activity", {
+          trip_id: state.activeTripId,
+          option_id: payload.option_id,
+          day: Number(payload.day || 0) || null,
+          date: payload.date || "",
+          start_time: payload.start_time || "",
+          end_time: payload.end_time || "",
+          fixed: payload.fixed === "on",
+          notes: payload.notes || "",
+        });
+        state.lastWorkflowByStage.activities = response.workflow_id;
+        await loadTrip(state.activeTripId);
+        state.activeStage = "activities";
+        render();
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
+      }
+    });
+  });
+  wireStageNavigation(root);
+  wireFeedbackForms(root, "activities");
+}
+
+function wirePlanStage(root) {
+  const googleWorkspaceButton = root.querySelector("#googleWorkspaceButton");
+  if (googleWorkspaceButton) {
+    googleWorkspaceButton.addEventListener("click", async () => {
+      await runStage(root, "plan", "/api/workspace", {
+        trip_id: state.activeTripId,
+        validate_live: true,
+        create_google_sheet: true,
+      });
+      state.activeStage = "plan";
+      render();
+    });
+  }
+  const mapButton = root.querySelector("#mapButton");
+  if (mapButton) {
+    mapButton.addEventListener("click", async () => {
+      await runStage(root, "plan", "/api/map", { trip_id: state.activeTripId });
+      state.activeStage = "plan";
+      render();
+    });
+  }
+  wireStageNavigation(root);
+  wireFeedbackForms(root, "plan");
+}
+
+function wireShortlistButtons(root, stage) {
+  root.querySelectorAll("[data-shortlist]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const category = button.dataset.shortlist;
+      const autoResearch = button.dataset.autoResearch === "true";
+      await runStage(root, stage, "/api/shortlist", {
+        trip_id: state.activeTripId,
+        category,
+        validate_live: autoResearch,
+        deep_research: autoResearch || button.dataset.deepResearch === "true",
+        adapter: "auto",
+      });
+      state.activeStage = stage;
+      render();
+    });
+  });
+}
+
+function wireStageNavigation(root) {
+  root.querySelectorAll("[data-next-stage]").forEach((button) => {
+    button.addEventListener("click", () => {
+      state.activeStage = button.dataset.nextStage;
+      render();
+      document.getElementById("stageBody")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  });
+}
+
 function wireWorkspaceStage(root) {
   const button = root.querySelector("#workspaceButton");
   if (button) {
     button.addEventListener("click", async () => {
       await runStage(root, "workspace", "/api/workspace", {
         trip_id: state.activeTripId,
-        validate_live: root.querySelector("#workspaceLive").checked,
-        create_google_sheet: root.querySelector("#workspaceGoogle").checked,
+        validate_live: true,
+        create_google_sheet: false,
       });
     });
   }
@@ -774,6 +1392,9 @@ function renderRunLog() {
 }
 
 function renderIdeas() {
+  if (!document.getElementById("ideaGrid")) {
+    return;
+  }
   const concepts = state.ideaComparison?.concepts || [];
   document.getElementById("ideaCount").textContent = concepts.length
     ? `${concepts.length} suggestion(s)`
@@ -811,7 +1432,7 @@ function suggestIdeaForm() {
     <div>
       <p class="eyebrow">Fast suggest</p>
       <h3>Who, when, and what kind of trip?</h3>
-      <p>Trippy will rank a few concept options, then your choice will become an editable intake draft.</p>
+      <p>Trippy will rank concept options from priors and constraints. These are not live-priced until the later flight and lodging steps.</p>
     </div>
     <div class="form-grid">
       ${select("party_type", "Who is going", partyType, partyOptions)}
@@ -839,7 +1460,7 @@ function wireIdeaControls(root) {
   root.querySelector("#ideaNewTrip")?.addEventListener("click", () => startNewTrip());
   root.querySelector("#ideaSuggestToggle")?.addEventListener("click", () => {
     state.showSuggestForm = !state.showSuggestForm;
-    renderIdeas();
+    render();
   });
   const form = root.querySelector("#ideaSuggestForm");
   if (form) {
@@ -852,8 +1473,9 @@ function wireIdeaControls(root) {
         setWorking(result, "Building suggestions");
         const payload = formPayload(form);
         const response = await apiPost("/api/suggest-ideas", payload);
-        state.ideaRequest = payload;
+        state.ideaRequest = response.comparison?.request || payload;
         state.ideaComparison = response.comparison;
+        state.ideaWorkflowId = response.workflow_id;
         state.lastWorkflowByStage.intake = response.workflow_id;
         state.app = await apiGet("/api/state");
         render();
@@ -869,6 +1491,32 @@ function wireIdeaControls(root) {
       );
       if (concept) {
         startNewTrip(prefillIntakeFromIdea(concept, state.ideaRequest || state.ideaComparison?.request || {}));
+      }
+    });
+  });
+  root.querySelectorAll("[data-idea-feedback]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const concept = (state.ideaComparison?.concepts || []).find(
+        (item) => item.concept_id === button.dataset.ideaConcept,
+      );
+      const feedbackRoot = button.closest(".idea-feedback");
+      const result = feedbackRoot?.querySelector(".idea-feedback-result");
+      if (!concept || !feedbackRoot || !result) {
+        return;
+      }
+      const notes = feedbackRoot.querySelector("textarea")?.value || "";
+      try {
+        setWorking(result, "Saving feedback");
+        const payload = ideaFeedbackPayload(concept, button.dataset.ideaFeedback, notes);
+        const response = await apiPost("/api/feedback", payload);
+        state.ideaFeedback[concept.concept_id] = response.feedback;
+        result.textContent =
+          response.learning_proposals.length > 0
+            ? "Feedback saved for review-gated learning."
+            : "Feedback saved.";
+        state.app = await apiGet("/api/state");
+      } catch (error) {
+        result.innerHTML = `<span class="error">${escapeHtml(error.message)}</span>`;
       }
     });
   });
@@ -905,6 +1553,8 @@ function adaptSuggestPartyFields(form, resetValues) {
 function suggestionCard(concept) {
   const destinations = concept.destinations || [];
   const risks = concept.why_it_may_not_fit || concept.major_risks || [];
+  const requestedDuration = Number(state.ideaComparison?.request?.duration_days || state.ideaRequest?.duration_days || 0);
+  const durationOff = requestedDuration && concept.recommended_duration_days > requestedDuration;
   return `<article class="suggestion-card">
     ${imageBlock(`${destinations.join(" ")} ${concept.title}`, concept.title)}
     <div class="suggestion-body">
@@ -914,7 +1564,7 @@ function suggestionCard(concept) {
       </div>
       <p>${escapeHtml(destinations.join(", "))}</p>
       <div class="metric-row">
-        <span class="metric">${escapeHtml(concept.recommended_duration_days)} days</span>
+        <span class="metric ${durationOff ? "warn" : "live"}">${escapeHtml(concept.recommended_duration_days)} days${requestedDuration ? ` for ${escapeHtml(requestedDuration)} requested` : ""}</span>
         <span class="metric">${escapeHtml(concept.best_season)}</span>
         <span class="metric">${escapeHtml(concept.estimated_travel_burden)} travel</span>
       </div>
@@ -923,8 +1573,57 @@ function suggestionCard(concept) {
         ${risks.slice(0, 1).map((item) => `<li class="risk">${escapeHtml(item)}</li>`).join("")}
       </ul>
       <button type="button" data-use-suggestion="${escapeHtml(concept.concept_id)}">Use this idea</button>
+      ${ideaFeedbackControls(concept)}
     </div>
   </article>`;
+}
+
+function ideaFeedbackControls(concept) {
+  const saved = state.ideaFeedback[concept.concept_id];
+  return `<div class="idea-feedback">
+    <label>Feedback on this idea
+      <textarea rows="2" placeholder="Example: too long for 6 days, too city-heavy, not enough beach, too expensive">${escapeHtml(saved?.notes || "")}</textarea>
+    </label>
+    <div class="button-row compact-buttons">
+      <button class="mini-button secondary" type="button" data-idea-feedback="too_long" data-idea-concept="${escapeHtml(concept.concept_id)}">Too long</button>
+      <button class="mini-button secondary" type="button" data-idea-feedback="not_fit" data-idea-concept="${escapeHtml(concept.concept_id)}">Not a fit</button>
+      <button class="mini-button secondary" type="button" data-idea-feedback="helpful" data-idea-concept="${escapeHtml(concept.concept_id)}">Looks good</button>
+    </div>
+    <small class="idea-feedback-result">${saved ? "Feedback saved." : ""}</small>
+  </div>`;
+}
+
+function ideaFeedbackPayload(concept, action, notes) {
+  const request = state.ideaComparison?.request || state.ideaRequest || {};
+  const requestedDuration = request.duration_days || "";
+  const workflowId = state.ideaWorkflowId || state.lastWorkflowByStage.intake || latestWorkflowId();
+  const base = `Idea "${concept.title}" (${concept.recommended_duration_days} days) from request${requestedDuration ? ` for ${requestedDuration} days` : ""}.`;
+  if (action === "helpful") {
+    return {
+      workflow_id: workflowId,
+      rating: "helpful",
+      notes: [base, notes || "This idea looks directionally useful."].filter(Boolean).join(" "),
+      future_learning: false,
+    };
+  }
+  if (action === "too_long") {
+    return {
+      workflow_id: workflowId,
+      rating: "needs-work",
+      notes: [base, notes || "The suggested duration is too long for the requested trip length."].filter(Boolean).join(" "),
+      correction: requestedDuration
+        ? `Respect the requested ${requestedDuration}-day constraint before ranking ideas. Do not return ${concept.recommended_duration_days}-day concepts unless clearly labeled as outside scope.`
+        : "Respect the user's stated duration before ranking ideas.",
+      future_learning: true,
+    };
+  }
+  return {
+    workflow_id: workflowId,
+    rating: "needs-work",
+    notes: [base, notes || "This concept is not a good fit."].filter(Boolean).join(" "),
+    correction: notes || "Use this rejection to adjust future idea ranking and rationale.",
+    future_learning: true,
+  };
 }
 
 function prefillIntakeFromIdea(concept, request) {
@@ -968,9 +1667,40 @@ function prefillIntakeFromIdea(concept, request) {
       "Prefilled from a Trippy suggestion; edit before saving.",
       rationale ? `Why it fits: ${rationale}` : "",
       risks ? `Watchouts: ${risks}` : "",
-      concept.estimated_cost_band_cad ? `Cost signal: ${concept.estimated_cost_band_cad}` : "",
+      concept.estimated_cost_band_cad
+        ? `Cost signal is a template estimate, not live or party-adjusted: ${concept.estimated_cost_band_cad}`
+        : "",
     ].filter(Boolean).join("\n"),
   };
+}
+
+function parseNightPlanText(text) {
+  return String(text || "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => {
+      const parts = line.includes("|")
+        ? line.split("|").map((part) => part.trim())
+        : line.split(",").map((part) => part.trim());
+      let region = parts[0] || "";
+      let nights = parts[1] || "";
+      if (!nights && line.includes(":")) {
+        const colonParts = line.split(":");
+        region = colonParts[0].trim();
+        nights = colonParts.slice(1).join(":").trim();
+      }
+      const nightMatch = String(nights || line).match(/\b(\d+)\b/);
+      if (!region || !nightMatch) {
+        throw new Error(`Stay plan line ${index + 1} needs a region and number of nights.`);
+      }
+      return {
+        region,
+        nights: Number(nightMatch[1]),
+        lodging_option_id: parts[2] || "",
+        notes: parts.slice(3).join(" | "),
+      };
+    });
 }
 
 function partyFromIdeaRequest(request) {
@@ -1052,7 +1782,7 @@ function numberOrDefault(value, fallback) {
 function planOptionCard(option) {
   const selected = state.trip?.draft?.selected_option_id === option.option_id;
   return `<article class="option-card ${selected ? "selected" : ""}">
-    ${imageBlock(`${option.option_id} ${option.title} ${option.regions.join(" ")}`, option.title)}
+    ${optionVisual(option)}
     <div class="option-card-body">
       <div class="option-head">
         <h3>${escapeHtml(option.title)}</h3>
@@ -1071,6 +1801,21 @@ function planOptionCard(option) {
       <button type="button" data-select-option="${escapeHtml(option.option_id)}">${selected ? "Selected" : "Select and research"}</button>
     </div>
   </article>`;
+}
+
+function optionVisual(option) {
+  const regions = option.regions || [];
+  const nightEntries = Object.entries(option.nights_by_region || {});
+  const stayCount = nightEntries.filter(([, nights]) => Number(nights) > 0).length || regions.length || 1;
+  return `<div class="option-map-thumb option-${Math.min(stayCount, 3)}">
+    <div class="map-route-line"></div>
+    <div class="map-pin-row">
+      ${regions.slice(0, 4).map((region, index) => `<span class="map-pin" style="--pin-index:${index}">${escapeHtml(region)}</span>`).join("")}
+    </div>
+    <div class="night-plan mini">
+      ${nightEntries.map(([region, nights]) => `<article><strong>${escapeHtml(region)}</strong><span>${escapeHtml(nights)} night(s)</span></article>`).join("") || `<article><strong>${escapeHtml(regions.join(" + ") || "Base")}</strong><span>nights TBD</span></article>`}
+    </div>
+  </div>`;
 }
 
 function shortlistCards() {
@@ -1169,7 +1914,7 @@ function flightRow(option) {
       <small>${escapeHtml(option.recommendation_rationale || (option.friction_flags || [])[0] || option.recommendation_grade || "")}</small>
       ${evidenceDetails(option)}
     </td>
-    <td><a href="${escapeHtml(option.deep_link)}">Open</a></td>
+    <td>${externalLink(option.deep_link, "Open")}</td>
   </tr>`;
 }
 
@@ -1215,6 +1960,128 @@ function labelForSort(value) {
     shortest: "Shortest",
     "lowest-friction": "Lowest friction",
   }[value] || value;
+}
+
+function truthLegend() {
+  return `<div class="truth-legend" aria-label="Data confidence guide">
+    <span class="truth-chip verified">Verified from source</span>
+    <span class="truth-chip partial">Partial / approximate</span>
+    <span class="truth-chip review">Needs manual check</span>
+  </div>`;
+}
+
+function lodgingStructurePanel(shortlist) {
+  const structure = shortlist?.artifacts?.lodging_structure || inferredLodgingStructure();
+  if (!structure) {
+    return `<div class="empty-state">Choose a trip shape to see one-stay vs split-stay guidance.</div>`;
+  }
+  const nightPlan = structure.night_plan || [];
+  const label = structure.strategy === "split_stay" ? "Split stays" : "One stay";
+  const selectedLodging = structure.selected_lodging_option_id
+    ? `Selected lodging: ${structure.selected_lodging_option_id}`
+    : "No lodging selected yet";
+  return `<section class="structure-panel">
+    <div>
+      <p class="eyebrow">Stay structure</p>
+      <h3>${escapeHtml(label)} ${structure.confidence ? `<span>${escapeHtml(structure.confidence)}</span>` : ""}</h3>
+      <p>${escapeHtml(structure.summary || "")}</p>
+      <p class="subtle">${escapeHtml(selectedLodging)} · ${escapeHtml(structure.data_status || "plan-based")}</p>
+    </div>
+    <div class="night-plan">
+      ${nightPlan.map((item) => `<article>
+        <strong>${escapeHtml(item.region)}</strong>
+        <span>${escapeHtml(item.nights)} night(s)</span>
+      </article>`).join("")}
+    </div>
+    ${(structure.reasoning || []).length ? `<ul class="tight-list">${structure.reasoning.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>` : ""}
+    ${stayStructureForm(structure)}
+  </section>`;
+}
+
+function stayStructureForm(structure) {
+  const strategy = structure.strategy || "single_stay";
+  const text = stayStructureText(structure.night_plan || []);
+  return `<form id="stayStructureForm" class="stay-structure-form">
+    <div>
+      <label>Stay approach
+        <select name="strategy">
+          <option value="single_stay" ${strategy === "single_stay" ? "selected" : ""}>One base</option>
+          <option value="split_stay" ${strategy === "split_stay" ? "selected" : ""}>Split stays</option>
+        </select>
+      </label>
+    </div>
+    <label>Move nights around
+      <textarea name="night_plan_text" rows="4" placeholder="Ponta Delgada | 4 | lodging-1 | central base&#10;Furnas | 3 | lodging-2 | hot springs side">${escapeHtml(text)}</textarea>
+    </label>
+    <label>Why this structure?
+      <textarea name="notes" rows="2" placeholder="What tradeoff are we testing?">${escapeHtml(structure.manual_notes || "")}</textarea>
+    </label>
+    <div class="button-row">
+      <button type="submit">Save stay plan</button>
+      <span class="inline-result"></span>
+    </div>
+    <p class="subtle">Format: region | nights | lodging option ID optional | notes optional. The workspace timeline will use this after you save and refresh the workspace.</p>
+  </form>`;
+}
+
+function stayStructureText(nightPlan) {
+  return nightPlan
+    .map((item) =>
+      [
+        item.region,
+        item.nights,
+        item.lodging_option_id || "",
+        item.notes || "",
+      ].filter((value, index) => index < 2 || value).join(" | "),
+    )
+    .join("\n");
+}
+
+function inferredLodgingStructure() {
+  const option = selectedPlanOption();
+  if (!option) {
+    return null;
+  }
+  const nightEntries = Object.entries(option.nights_by_region || {});
+  const stayCount = nightEntries.filter(([, nights]) => Number(nights) > 0).length || option.regions.length;
+  const strategy = stayCount > 1 ? "split_stay" : "single_stay";
+  return {
+    strategy,
+    confidence: "plan-based",
+    summary:
+      strategy === "split_stay"
+        ? "The selected shape likely needs multiple stays; verify each move earns its friction cost."
+        : "The selected shape is best treated as one base unless exact lodging or flight timing proves otherwise.",
+    reasoning: [
+      option.lodging_strategy,
+      option.island_region_movement_friction,
+    ].filter(Boolean),
+    night_plan: nightEntries.length
+      ? nightEntries.map(([region, nights]) => ({ region, nights }))
+      : (option.regions || []).map((region) => ({ region, nights: "TBD" })),
+  };
+}
+
+function structureGuidancePanel() {
+  const flight = recommendedFlight();
+  const lodging = shortlistByCategory("lodging");
+  const structure = lodging?.artifacts?.lodging_structure || inferredLodgingStructure();
+  const bullets = [
+    flight?.date_viability_signal,
+    flight?.timing_implication,
+    structure?.summary,
+  ].filter(Boolean);
+  if (!bullets.length) {
+    return "";
+  }
+  return `<section class="structure-panel trip-fit-panel">
+    <div>
+      <p class="eyebrow">Trip-fit guidance</p>
+      <h3>Dates, stays, and timing</h3>
+      <p>These are planning signals from current evidence, not final inventory truth.</p>
+    </div>
+    <ul class="tight-list">${bullets.slice(0, 4).map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
+  </section>`;
 }
 
 function numericPrice(value) {
@@ -1289,12 +2156,18 @@ function lodgingComparison(shortlist) {
 }
 
 function lodgingRow(option) {
+  const needsThreeBeds = requiresThreeBeds();
+  const isRecommended = option.option_id === recommendedId("lodging");
   const bedFit = [
-    option.min_three_beds_satisfied === true ? "3+ beds" : "3+ beds unproven",
+    needsThreeBeds
+      ? option.min_three_beds_satisfied === true
+        ? "3+ beds"
+        : "3+ beds unproven"
+      : "party fit to verify",
     option.king_bed_preference_satisfied === true ? "king" : "king unproven",
     option.fit_category || "",
   ].filter(Boolean).join(" · ");
-  return `<tr class="${option.option_id === recommendedId("lodging") ? "recommended-row" : ""}">
+  return `<tr class="${isRecommended ? "recommended-row" : ""}">
     <td>
       <strong>${escapeHtml(option.name)}</strong>
       <small>${escapeHtml(option.source)} · ${escapeHtml(option.lodging_type)} · ${escapeHtml(validationSummary(option))}</small>
@@ -1319,8 +2192,18 @@ function lodgingRow(option) {
       <span class="score-pill">${escapeHtml(option.family_comfort_score)} comfort</span>
       <small>${escapeHtml(evidenceSummary(option) || (option.friction_flags || [])[0] || option.comfort_fit || "")}</small>
     </td>
-    <td><a href="${escapeHtml(option.deep_link)}">Open</a></td>
+    <td>
+      <button class="mini-button" type="button" data-select-lodging="${escapeHtml(option.option_id)}">${isRecommended ? "Use" : "Choose"}</button>
+      ${externalLink(option.deep_link, "Open")}
+    </td>
   </tr>`;
+}
+
+function requiresThreeBeds() {
+  const party = state.trip?.intake?.party || state.suggestedIntake?.party || {};
+  const total = Number(party.total_travelers || state.trip?.intake?.travelers || 0);
+  const children = Number(party.children || 0);
+  return total >= 5 || children >= 2;
 }
 
 function validationSummary(option) {
@@ -1340,6 +2223,189 @@ function evidenceSummary(option) {
   const extracted = Object.keys(fields).slice(0, 3).join(", ");
   const artifact = artifacts[0]?.path || artifacts[0]?.url || "";
   return [extracted ? `extracted ${extracted}` : "", artifact ? `evidence ${artifact}` : ""].filter(Boolean).join(" · ");
+}
+
+function activitySchedulePanel(shortlist) {
+  const schedule = shortlist.artifacts?.activity_schedule;
+  const entries = schedule?.entries || [];
+  const approved = entries.filter((entry) => ["approved", "booked"].includes(entry.status));
+  return `<section class="structure-panel">
+    <div>
+      <p class="eyebrow">Activity timing</p>
+      <h3>Suggested day-by-day fit</h3>
+      <p>${escapeHtml(schedule?.summary || "Activities are placed against the current stay plan so you can approve and track them on the timeline.")}</p>
+    </div>
+    <div class="schedule-strip">
+      ${entries.slice(0, 6).map(activityScheduleChip).join("") || `<span class="empty-state">Find activities to see suggested days.</span>`}
+    </div>
+    <div class="metric-row">
+      <span class="metric live">${approved.length} approved</span>
+      <span class="metric">${entries.length} suggested</span>
+    </div>
+  </section>`;
+}
+
+function activityScheduleChip(entry) {
+  const day = entry.scheduled_day || entry.suggested_day || "TBD";
+  const time = entry.scheduled_start_time || entry.suggested_start_time || "";
+  const status = entry.status || "researched";
+  return `<article class="schedule-chip ${status === "approved" ? "is-approved" : ""}">
+    <strong>Day ${escapeHtml(day)}</strong>
+    <span>${escapeHtml(time || "time TBD")}</span>
+    <small>${escapeHtml(entry.activity_name || "")}</small>
+  </article>`;
+}
+
+function activityComparison(shortlist) {
+  const rows = shortlist.activity_options || [];
+  return `<section class="comparison-panel">
+    <div class="comparison-head">
+      <div>
+        <p class="eyebrow">Activities</p>
+        <h3>Approve, schedule, and track</h3>
+        <p>${escapeHtml(shortlist.recommendation_summary || "")}</p>
+      </div>
+      <span class="metric live">Recommended ${escapeHtml(shortlist.recommended_option_id || "TBD")}</span>
+    </div>
+    <div class="comparison-table-wrap">
+      <table class="comparison-table activity-table">
+        <thead>
+          <tr>
+            <th>Activity / source</th>
+            <th>Suggested slot</th>
+            <th>Fit</th>
+            <th>Safety / crowd</th>
+            <th>Score</th>
+            <th>Schedule</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>${rows.map(activityRow).join("")}</tbody>
+      </table>
+    </div>
+  </section>`;
+}
+
+function activityRow(option) {
+  const status = option.row_status || "researched";
+  const isApproved = status === "approved" || status === "booked";
+  const scheduledDay = option.scheduled_day || option.suggested_day || "";
+  const scheduledDate = option.scheduled_date || option.suggested_date || "";
+  const start = option.scheduled_start_time || option.suggested_start_time || "";
+  const end = option.scheduled_end_time || option.suggested_end_time || "";
+  return `<tr class="${isApproved ? "recommended-row" : ""}">
+    <td>
+      <strong>${escapeHtml(option.activity_name)}</strong>
+      <small>${escapeHtml(option.source)} · ${escapeHtml(option.island_location)} · ${escapeHtml(validationSummary(option))}</small>
+    </td>
+    <td>
+      <strong>${scheduledDay ? `Day ${escapeHtml(scheduledDay)}` : "Day TBD"}</strong>
+      <small>${escapeHtml([scheduledDate, timeRange(start, end)].filter(Boolean).join(" · "))}</small>
+    </td>
+    <td>
+      <strong>${escapeHtml(option.duration)}</strong>
+      <small>${escapeHtml(option.age_family_fit || option.scheduling_rationale || "")}</small>
+    </td>
+    <td>
+      <strong>${escapeHtml(option.group_size_signal)}</strong>
+      <small>${escapeHtml(option.review_safety_signal)}</small>
+    </td>
+    <td>
+      <span class="score-pill">${escapeHtml(option.family_pace_fit_score)} pace</span>
+      <small>${escapeHtml((option.friction_flags || [])[0] || option.scheduling_rationale || "")}</small>
+    </td>
+    <td>${activityScheduleForm(option)}</td>
+    <td>
+      <button class="mini-button" type="button" data-select-activity="${escapeHtml(option.option_id)}">${isApproved ? "Approved" : "Approve"}</button>
+      ${externalLink(option.deep_link, "Open")}
+    </td>
+  </tr>`;
+}
+
+function activityScheduleForm(option) {
+  return `<form class="inline-schedule-form" data-activity-schedule-form>
+    <input type="hidden" name="option_id" value="${escapeHtml(option.option_id)}" />
+    <label>Day<input name="day" type="number" min="1" value="${escapeHtml(option.scheduled_day || option.suggested_day || "")}" /></label>
+    <label>Date<input name="date" type="date" value="${escapeHtml(option.scheduled_date || option.suggested_date || "")}" /></label>
+    <label>Start<input name="start_time" type="time" value="${escapeHtml(option.scheduled_start_time || option.suggested_start_time || "")}" /></label>
+    <label>End<input name="end_time" type="time" value="${escapeHtml(option.scheduled_end_time || option.suggested_end_time || "")}" /></label>
+    <label class="checkbox-line"><input name="fixed" type="checkbox" ${option.scheduled_flexibility === "fixed" ? "checked" : ""} /> fixed</label>
+    <input name="notes" type="text" placeholder="notes" value="${escapeHtml(option.scheduling_notes || "")}" />
+    <button class="mini-button secondary" type="submit">Save slot</button>
+  </form>`;
+}
+
+function timeRange(start, end) {
+  if (start && end) return `${start}-${end}`;
+  return start || end || "";
+}
+
+function carComparison(shortlist) {
+  const rows = shortlist.car_options || [];
+  return `<section class="comparison-panel">
+    <div class="comparison-head">
+      <div>
+        <p class="eyebrow">Cars</p>
+        <h3>Rental price, fit, pickup, and terms</h3>
+        <p>${escapeHtml(shortlist.recommendation_summary || "")}</p>
+      </div>
+      <span class="metric live">Recommended ${escapeHtml(shortlist.recommended_option_id || "TBD")}</span>
+    </div>
+    <div class="comparison-table-wrap">
+      <table class="comparison-table car-table">
+        <thead>
+          <tr>
+            <th>Provider / vehicle</th>
+            <th>Pickup / dropoff</th>
+            <th>Passenger + luggage fit</th>
+            <th>Price + terms</th>
+            <th>Friction</th>
+            <th>Compare</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>${rows.map(carRow).join("")}</tbody>
+      </table>
+    </div>
+  </section>`;
+}
+
+function carRow(option) {
+  const isRecommended = option.option_id === recommendedId("cars");
+  const isApproved = option.row_status === "approved" || option.row_status === "booked";
+  const priceSignal = option.validation?.extracted_fields?.price || option.price_band || "live price needed";
+  const compareLinks = Object.entries(option.comparison_links || {});
+  return `<tr class="${isRecommended || isApproved ? "recommended-row" : ""}">
+    <td>
+      <strong>${escapeHtml(option.vehicle_class)}</strong>
+      <small>${escapeHtml(option.booking_source)} · ${escapeHtml(option.row_status || "researched")} · ${escapeHtml(validationSummary(option))}</small>
+    </td>
+    <td>
+      <strong>${escapeHtml(option.pickup_location)}</strong>
+      <small>Dropoff: ${escapeHtml(option.dropoff_location)}</small>
+    </td>
+    <td>
+      <strong>${escapeHtml((option.seating_capacity || "verify") + " seats")}</strong>
+      <small>${escapeHtml(option.passenger_fit)} · ${escapeHtml(option.luggage_fit)}</small>
+    </td>
+    <td>
+      <strong>${escapeHtml(priceSignal)}</strong>
+      <small>${escapeHtml(option.cancellation_notes)} · ${escapeHtml(option.fees_caution)}</small>
+    </td>
+    <td>
+      <span class="score-pill">${escapeHtml(option.total_friction_score)} friction</span>
+      <small>${escapeHtml((option.friction_flags || [])[0] || option.tradeoffs?.[0] || "")}</small>
+    </td>
+    <td>
+      <div class="source-link-list">
+        ${externalLink(option.deep_link, option.booking_source || "Open")}
+        ${compareLinks.map(([source, link]) => externalLink(link, source)).join("")}
+      </div>
+    </td>
+    <td>
+      <button class="mini-button" type="button" data-select-car="${escapeHtml(option.option_id)}">${isApproved ? "Selected" : "Choose"}</button>
+    </td>
+  </tr>`;
 }
 
 function compactShortlist(shortlist) {
@@ -1366,33 +2432,35 @@ function compactOptionCard(item) {
       ${item.verification ? `<span class="metric">${escapeHtml(item.verification)}</span>` : ""}
     </div>
     ${item.notes ? `<small>${escapeHtml(String(item.notes))}</small>` : ""}
-    ${item.link ? `<a href="${escapeHtml(item.link)}">Open link</a>` : ""}
+    ${externalLink(item.link, "Open link")}
   </article>`;
 }
 
 function embeddedMapPanel(artifact) {
   const pins = artifact.pins || [];
-  const routes = artifact.routes || [];
-  const focus = pins.find((pin) => pin.category === "lodging") || pins[0];
+  const primaryMapUrl = artifact.primary_google_maps_url || artifact.exports?.google_maps_route || "";
+  const kmlUrl = mapFileUrl("kml");
+  const csvUrl = mapFileUrl("csv");
   return `<section class="map-panel">
-    <iframe title="Trip planning map" loading="lazy" src="${mapsEmbedUrl(focus?.query || artifact.title)}"></iframe>
+    <iframe title="Trip planning map" loading="lazy" src="${mapEmbedUrl(primaryMapUrl, pins[0]?.query || artifact.title)}"></iframe>
     <div class="map-side">
-      <p class="eyebrow">Sequence-aware map</p>
-      <h3>${escapeHtml(artifact.title)}</h3>
-      <ol class="map-sequence">
-        ${pins.slice(0, 12).map((pin) => `<li><a href="${escapeHtml(pin.google_maps_url)}">${escapeHtml(pin.label)}</a><small>${escapeHtml(pin.category)} · ${escapeHtml(pin.notes || "")}</small></li>`).join("")}
-      </ol>
-      <h4>Routes to sanity-check</h4>
-      <div class="route-list">
-        ${routes.map((route) => `<a href="${escapeHtml(route.google_maps_url)}">${escapeHtml(route.label)}</a>`).join("") || `<span class="empty-state">No route links yet.</span>`}
+      <p class="eyebrow">Custom Google map</p>
+      <h3>One ordered trip map</h3>
+      <div class="map-actions">
+        ${externalLink(primaryMapUrl, "Open Google Map", "primary-link")}
+        ${externalLink(kmlUrl, "Google My Maps KML", "secondary-link")}
+        ${externalLink(csvUrl, "CSV import", "secondary-link")}
       </div>
+      <ol class="map-sequence">
+        ${pins.map((pin) => `<li>${externalLink(pin.google_maps_url, pin.label)}<small>${escapeHtml(pin.category)} · ${escapeHtml(pin.notes || "")}</small></li>`).join("")}
+      </ol>
     </div>
   </section>`;
 }
 
 function fallbackMapPanel(rows) {
   if (!rows.length) {
-    return `<div class="empty-state">Build map artifacts or workspace rows first.</div>`;
+    return `<div class="empty-state">Build the custom trip map to see all points in order.</div>`;
   }
   const focus = rows[0]?.[0] || "trip map";
   return `<section class="map-panel">
@@ -1401,14 +2469,26 @@ function fallbackMapPanel(rows) {
       <p class="eyebrow">Workspace map seeds</p>
       <h3>Suggested order</h3>
       <ol class="map-sequence">
-        ${rows.slice(0, 12).map((row) => `<li><a href="${escapeHtml(row[4] || "")}">${escapeHtml(row[0])}</a><small>${escapeHtml(row[1] || "")}</small></li>`).join("")}
+        ${rows.slice(0, 12).map((row) => `<li>${externalLink(row[4], row[0])}<small>${escapeHtml(row[1] || "")}</small></li>`).join("")}
       </ol>
     </div>
   </section>`;
 }
 
+function mapEmbedUrl(url, fallbackQuery) {
+  if (url && url.includes("google.com/maps/dir/")) {
+    return `${url}${url.includes("?") ? "&" : "?"}output=embed`;
+  }
+  return mapsEmbedUrl(fallbackQuery);
+}
+
 function mapsEmbedUrl(query) {
   return `https://www.google.com/maps?q=${encodeURIComponent(query || "travel planning")}&output=embed`;
+}
+
+function mapFileUrl(kind) {
+  if (!state.activeTripId) return "";
+  return `/api/map-file?trip_id=${encodeURIComponent(state.activeTripId)}&kind=${encodeURIComponent(kind)}`;
 }
 
 function workspaceSummary(workspace) {
@@ -1420,7 +2500,7 @@ function workspaceSummary(workspace) {
     <div class="metric-row">
       ${tabs.map((tab) => `<span class="metric">${escapeHtml(tab.name)} · ${tab.rows.length}</span>`).join("")}
     </div>
-    ${workspace.google_sheet_url ? `<p><a href="${escapeHtml(workspace.google_sheet_url)}">Open Google Sheet</a></p>` : ""}
+    ${workspace.google_sheet_url ? `<p>${externalLink(workspace.google_sheet_url, "Open Google Sheet")}</p>` : ""}
     ${(workspace.next_actions || []).map((item) => `<p>${escapeHtml(item)}</p>`).join("")}
     ${timelinePreview(timeline)}
     ${riskPreview(risks)}
@@ -1440,7 +2520,7 @@ function timelinePreview(tab) {
     <div class="timeline-preview-list">
       ${rows.slice(0, 6).map((row) => `<article>
         <strong>${escapeHtml(row[5] || "Event")} · ${escapeHtml(row[6] || "Untitled")}</strong>
-        <small>${escapeHtml([row[0], row[2], row[7]].filter(Boolean).join(" · "))}</small>
+        <small>${escapeHtml([`Day ${row[0]}`, row[1], row[2], row[7]].filter(Boolean).join(" · "))}</small>
         ${row[16] ? `<span class="metric warn">${escapeHtml(row[16])}</span>` : ""}
       </article>`).join("")}
     </div>
@@ -1478,8 +2558,30 @@ function recommendedOptions() {
   return picks;
 }
 
+function shortlistByCategory(category) {
+  return (state.trip?.shortlists || []).find((item) => item.category === category);
+}
+
+function selectedPlanOption() {
+  const draft = state.trip?.draft;
+  const selectedId = draft?.selected_option_id || draft?.recommended_option_id;
+  return (draft?.options || []).find((option) => option.option_id === selectedId) || null;
+}
+
+function recommendedFlight() {
+  const shortlist = shortlistByCategory("flights");
+  if (!shortlist) {
+    return null;
+  }
+  return (
+    (shortlist.flight_options || []).find((option) => option.option_id === shortlist.recommended_option_id) ||
+    (shortlist.flight_options || [])[0] ||
+    null
+  );
+}
+
 function recommendedId(category) {
-  const shortlist = (state.trip?.shortlists || []).find((item) => item.category === category);
+  const shortlist = shortlistByCategory(category);
   return shortlist?.recommended_option_id || "";
 }
 
@@ -1503,7 +2605,6 @@ function optionForPick(option, category) {
 
 function pickCard(item) {
   return `<article class="pick-card">
-    ${imageBlock(item.query || item.title, item.title || "Travel")}
     <div class="pick-card-body">
       <h3>${escapeHtml(item.title || "Untitled")}</h3>
       <p>${escapeHtml(item.subtitle || "")}</p>
@@ -1512,7 +2613,7 @@ function pickCard(item) {
         ${item.verification ? `<span class="metric">${escapeHtml(item.verification)}</span>` : ""}
       </div>
       ${item.notes ? `<p>${escapeHtml(String(item.notes))}</p>` : ""}
-      ${item.link ? `<a href="${escapeHtml(item.link)}">Open link</a>` : ""}
+      ${externalLink(item.link, "Open link")}
     </div>
   </article>`;
 }
@@ -1729,6 +2830,14 @@ function setWorking(element, text) {
   if (element) {
     element.textContent = `${text}...`;
   }
+}
+
+function externalLink(url, label, className = "") {
+  if (!url) {
+    return "";
+  }
+  const classAttr = className ? ` class="${escapeHtml(className)}"` : "";
+  return `<a${classAttr} href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label || "Open")}</a>`;
 }
 
 function escapeHtml(value) {

--- a/trippy/ui/templates/index.html
+++ b/trippy/ui/templates/index.html
@@ -23,6 +23,16 @@
           <a id="dashboardJsonLink" href="/api/state" title="Open backend state">Data</a>
           <a id="logsJsonLink" href="/api/logs" title="Open workflow logs">Logs</a>
         </nav>
+        <aside class="trip-rail" aria-label="Trips">
+          <div class="rail-head">
+            <div class="rail-actions">
+              <button id="generateTripButton" type="button" class="secondary">Generate</button>
+              <button id="newTripButton" type="button">New</button>
+            </div>
+          </div>
+          <div id="tripList" class="trip-list"></div>
+        </aside>
+        <div id="railResizeHandle" class="rail-resize-handle" aria-hidden="true"></div>
       </header>
 
       <main>
@@ -38,16 +48,6 @@
         </section>
 
         <section class="layout">
-          <aside class="trip-rail" aria-label="Trips">
-            <div class="rail-head">
-              <div class="rail-actions">
-                <button id="generateTripButton" type="button" class="secondary">Generate</button>
-                <button id="newTripButton" type="button">New</button>
-              </div>
-            </div>
-            <div id="tripList" class="trip-list"></div>
-          </aside>
-
           <section class="wizard-panel" aria-label="Planning wizard">
             <div id="stageBody"></div>
           </section>

--- a/trippy/ui/templates/index.html
+++ b/trippy/ui/templates/index.html
@@ -8,79 +8,74 @@
     <link rel="stylesheet" href="/static/app.css">
   </head>
   <body>
-    <header class="app-header">
-      <div class="brand-lockup">
-        <img src="/static/trippy-logo.png" alt="Trippy logo" class="brand-logo">
-        <div>
-          <p class="eyebrow">Chapman family travel</p>
-          <h1>Trippy</h1>
-        </div>
-      </div>
-      <nav class="top-actions" aria-label="Primary">
-        <button id="refreshButton" type="button">Refresh</button>
-        <a id="dashboardJsonLink" href="/api/state">Data</a>
-        <a id="logsJsonLink" href="/api/logs">Logs</a>
-      </nav>
-    </header>
-
-    <main>
-      <section class="command-band">
-        <div>
-          <p class="eyebrow">Active trip</p>
-          <h2 id="activeTripTitle">Loading trips</h2>
-          <p id="activeTripSubhead" class="subhead"></p>
-        </div>
-        <div class="status-strip" id="statusStrip"></div>
-      </section>
-
-      <section class="layout">
-        <aside class="trip-rail" aria-label="Trips">
-          <div class="rail-head">
-            <h2>Trips</h2>
-            <button id="newTripButton" type="button">New</button>
+    <div class="app-shell">
+      <header class="app-header" aria-label="Trippy navigation">
+        <div class="brand-lockup">
+          <img src="/static/trippy-logo.png" alt="Trippy logo" class="brand-logo">
+          <div class="brand-copy">
+            <p class="eyebrow">Chapman family</p>
+            <h1>Trippy</h1>
+            <span>Travel planner</span>
           </div>
-          <div id="tripList" class="trip-list"></div>
-        </aside>
+        </div>
+        <nav class="top-actions" aria-label="Primary">
+          <button id="refreshButton" type="button" title="Refresh planner state">Refresh</button>
+          <a id="dashboardJsonLink" href="/api/state" title="Open backend state">Data</a>
+          <a id="logsJsonLink" href="/api/logs" title="Open workflow logs">Logs</a>
+        </nav>
+      </header>
 
-        <section class="wizard-panel" aria-label="Planning wizard">
-          <div class="wizard-head">
-            <div>
-              <p class="eyebrow">Planner</p>
-              <h2>Trip Wizard</h2>
-            </div>
-            <p id="nextStep" class="next-step">Create or select a trip.</p>
+      <main>
+        <section class="command-band hero-shell">
+          <div class="hero-logo-start" aria-hidden="true">
+            <img src="/static/trippy-logo.png" alt="">
           </div>
-
-          <div class="stage-tabs" id="stageTabs"></div>
-          <div id="stageBody"></div>
+          <div class="hero-copy">
+            <h2 id="activeTripTitle">Loading trips</h2>
+            <p id="activeTripSubhead" class="subhead"></p>
+          </div>
+          <div class="planning-progress" id="planningProgress"></div>
         </section>
-      </section>
 
-      <section class="visual-section">
-        <div class="section-head">
-          <h2>Current Picks</h2>
-          <span id="pickCount">0 ready</span>
-        </div>
-        <div id="pickGrid" class="pick-grid"></div>
-      </section>
+        <section class="layout">
+          <aside class="trip-rail" aria-label="Trips">
+            <div class="rail-head">
+              <div class="rail-actions">
+                <button id="generateTripButton" type="button" class="secondary">Generate</button>
+                <button id="newTripButton" type="button">New</button>
+              </div>
+            </div>
+            <div id="tripList" class="trip-list"></div>
+          </aside>
 
-      <section class="visual-section">
-        <div class="section-head">
-          <h2>Run Log</h2>
-          <span id="logCount">0 events</span>
-        </div>
-        <p id="backendLogPath" class="log-path"></p>
-        <div id="runLog" class="run-log"></div>
-      </section>
+          <section class="wizard-panel" aria-label="Planning wizard">
+            <div id="stageBody"></div>
+          </section>
+        </section>
 
-      <section class="visual-section">
-        <div class="section-head">
-          <h2>Ideas Bucket</h2>
-          <span id="ideaCount">0 ideas</span>
-        </div>
-        <div id="ideaGrid" class="pick-grid"></div>
-      </section>
-    </main>
+        <section class="visual-section">
+          <div class="section-head">
+            <div>
+              <p class="eyebrow">Snapshot</p>
+              <h2>Current picks</h2>
+            </div>
+            <span id="pickCount">0 ready</span>
+          </div>
+          <div id="pickGrid" class="pick-grid"></div>
+        </section>
+
+        <details class="visual-section log-disclosure">
+          <summary>
+            <span>Run Log</span>
+            <span id="logCount">0 events</span>
+          </summary>
+          <div>
+            <p id="backendLogPath" class="log-path"></p>
+            <div id="runLog" class="run-log"></div>
+          </div>
+        </details>
+      </main>
+    </div>
 
     <template id="feedbackTemplate">
       <form class="feedback-form">


### PR DESCRIPTION
## Summary
- Reworks the local Trippy UI into a more guided planner flow with Generate/New entry points, compact progress, cleaner trip rail controls, and richer feedback hooks.
- Expands exact planning surfaces for flights, lodging, cars, activities, timeline/workspace hydration, and dashboard/agent status.
- Adds a single ordered custom map artifact per trip with numbered pins, a primary Google Maps route link, and Google My Maps-compatible KML/CSV exports.
- Makes Google Sheet workspace handling create on first use and update an existing stored sheet on later runs instead of duplicating sheets.

## Trust Boundary
- Keeps planning logic in services rather than duplicating it in the UI.
- Preserves review-gated learning and source confidence/freshness labels.
- Does not add autonomous booking or payment behavior.

## Validation
- `node --check trippy/ui/static/app.js`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy trippy/`
- `uv run pytest` -> `269 passed, 5 skipped`