### PR TITLE
Add Firecrawl as first-class travel web intelligence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ TRIPPY_LIVE_VALIDATION_TIMEOUT_SECONDS=4
 TRIPPY_SOURCE_RESEARCH_TIMEOUT_SECONDS=12
 TRIPPY_SOURCE_RESEARCH_PLAYWRIGHT_ENABLED=false
 TRIPPY_SOURCE_RESEARCH_OPENCLAW_ENABLED=false
+FIRECRAWL_API_KEY=
+FIRECRAWL_BASE_URL=https://api.firecrawl.dev
+FIRECRAWL_ENABLED=true
+FIRECRAWL_CACHE_TTL_SECONDS=900
+FIRECRAWL_MAX_RESULTS=5
 TRIPPY_OPENCLAW_GATEWAY_URL=http://127.0.0.1:18789
 TRIPPY_OPENCLAW_COMMAND=openclaw
 GMAIL_CREDENTIALS_PATH=~/.trippy/gmail_credentials.json
@@ -214,6 +219,38 @@ deterministic anti-friction post-processor flags risky candidates (late arrivals
 vs. lodging check-in, tight layovers, multi-airline tickets, undersized cars,
 missing total price or cancellation terms) and downgrades their recommendation
 grade and live-data status accordingly.
+
+### Firecrawl web intelligence layer (optional, read-only)
+
+Firecrawl is now a first-class **public web intelligence** provider across flights,
+lodging, cars, and activities. It is used to extract source-backed policy and fit
+context (baggage rules, cancellation windows, check-in/out, child-seat policies,
+hours/restrictions, weather dependency, amenities), while official APIs stay the
+source of truth for transactional inventory and booking-ready details.
+
+```bash
+uv run trippy trip-plan flights    --trip-id <id> --deep-research --adapter firecrawl
+uv run trippy trip-plan lodging    --trip-id <id> --deep-research --adapter firecrawl
+uv run trippy trip-plan cars       --trip-id <id> --deep-research --adapter firecrawl
+uv run trippy trip-plan activities --trip-id <id> --deep-research --adapter firecrawl
+```
+
+Safety model:
+- Firecrawl evidence is read-only and advisory.
+- Booking/payment/account actions remain explicitly human-gated.
+- Scraped prices are not treated as guaranteed live availability.
+- Low-confidence/stale extraction remains flagged with warnings and missing fields.
+
+Developer probe:
+
+```bash
+python scripts/firecrawl_travel_probe.py \
+  --domain lodging \
+  --destination "Puerto Vallarta" \
+  --dates "2026-03-10 to 2026-03-17" \
+  --travelers "2 adults, 3 kids" \
+  --query "family friendly beachfront resorts Puerto Vallarta cancellation policy"
+```
 
 ---
 

--- a/scripts/firecrawl_travel_probe.py
+++ b/scripts/firecrawl_travel_probe.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Cloud-safe Firecrawl probe for travel web intelligence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from trippy.services.firecrawl import FirecrawlService
+from trippy.services.web_intelligence import TravelWebIntelligenceService
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Probe Firecrawl travel extraction")
+    parser.add_argument(
+        "--domain", choices=["flights", "lodging", "cars", "activities"], required=True
+    )
+    parser.add_argument("--destination", default="")
+    parser.add_argument("--dates", default="")
+    parser.add_argument("--travelers", default="")
+    parser.add_argument("--query", required=True)
+    args = parser.parse_args()
+
+    firecrawl = FirecrawlService()
+    availability = firecrawl.availability()
+    web = TravelWebIntelligenceService(firecrawl=firecrawl)
+
+    print(
+        json.dumps({"firecrawl_available": availability.available, "reason": availability.reason})
+    )
+
+    if args.domain == "lodging":
+        rows = web.research_lodging_web(args.query)
+    elif args.domain == "activities":
+        rows = web.research_activities_web(args.query)
+    elif args.domain == "cars":
+        rows = web.enrich_car_rental_with_web_context(args.query)
+    else:
+        rows = [web.enrich_flight_with_web_context(args.query)]
+
+    print(json.dumps([row.model_dump(mode="json") for row in rows], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_firecrawl.py
+++ b/tests/unit/test_firecrawl.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from trippy.models.shortlists import ResearchShortlistState, ShortlistCategory
+from trippy.models.source_research import (
+    SourceAdapterCapability,
+    SourceResearchMode,
+    SourceResearchRequest,
+)
+from trippy.models.trip_planning import (
+    TravelerAgeBand,
+    TravelWindow,
+    TripIntake,
+    TripIntakeMode,
+    TripParty,
+    TripPartyType,
+    TripTraveler,
+)
+from trippy.services.firecrawl import FirecrawlService
+from trippy.services.flight_shortlist import FlightShortlistService
+from trippy.services.source_research import FirecrawlResearchAdapter, SourceResearchService
+from trippy.services.trip_intake import TripIntakeService
+from trippy.services.trip_planner import TripPlannerService
+from trippy.services.web_intelligence import TravelWebIntelligenceService
+
+
+def test_firecrawl_missing_key_returns_unavailable_result() -> None:
+    service = FirecrawlService(api_key="", enabled=True)
+    result = service.search("family resorts porto", limit=1)[0]
+
+    assert result.extraction_type == "unavailable"
+    assert "missing" in result.warnings[0].lower()
+
+
+def test_firecrawl_research_uses_mocked_endpoints() -> None:
+    service = FirecrawlService(api_key="test-key", enabled=True)
+
+    def fake_request(path: str, payload: dict[str, object]) -> dict[str, object]:
+        if "search" in path:
+            return {"data": [{"url": "https://example.com/hotel", "title": "Hotel Example"}]}
+        return {"data": {"markdown": "Family suite, free parking, cancellation until 24h."}}
+
+    service._request = fake_request  # type: ignore[method-assign]
+    rows = service.research("porto family hotel", limit=1)
+
+    assert rows
+    assert rows[0].source_url == "https://example.com/hotel"
+    assert "Family suite" in rows[0].raw_markdown_excerpt
+
+
+def test_web_intelligence_models_are_normalized() -> None:
+    service = FirecrawlService(api_key="test-key", enabled=True)
+
+    def fake_request(path: str, payload: dict[str, object]) -> dict[str, object]:
+        if "search" in path:
+            return {
+                "data": [
+                    {
+                        "url": "https://example.com/activity",
+                        "title": "Whale Tour",
+                        "description": "Family tour",
+                    }
+                ]
+            }
+        return {"data": {"markdown": "Open daily. 3 hour tour. Minimum age 6. Cancel 48h."}}
+
+    service._request = fake_request  # type: ignore[method-assign]
+    web = TravelWebIntelligenceService(firecrawl=service)
+
+    activities = web.research_activities_web("whale tour azores")
+
+    assert activities
+    assert activities[0].name == "Whale Tour"
+    assert activities[0].source_urls == ["https://example.com/activity"]
+    assert activities[0].age_restrictions
+
+
+def test_firecrawl_adapter_returns_observations() -> None:
+    service = FirecrawlService(api_key="test-key", enabled=True)
+
+    def fake_request(path: str, payload: dict[str, object]) -> dict[str, object]:
+        if "search" in path:
+            return {"data": [{"url": "https://example.com/airline", "title": "Fare Rules"}]}
+        return {
+            "data": {"markdown": "Carry-on 1 bag. Checked baggage 23kg. Changes allowed with fee."}
+        }
+
+    service._request = fake_request  # type: ignore[method-assign]
+    adapter = FirecrawlResearchAdapter(service=service)
+    request = SourceResearchRequest(
+        trip_id="trip-1",
+        category=ShortlistCategory.FLIGHTS.value,
+        option_id="flight-1",
+        source_name="Google Flights",
+        source_url="https://example.com/airline",
+        candidate_name="AC123",
+        adapter_mode=SourceResearchMode.FIRECRAWL,
+    )
+
+    result = adapter.research(request, artifact_dir=Path("/tmp/firecrawl-test"))
+
+    assert result.adapter_used == SourceAdapterCapability.FIRECRAWL
+    assert result.observations
+    assert any(ob.field in {"baggage_signal", "fare_rules"} for ob in result.observations)
+
+
+def test_firecrawl_merges_into_shortlist_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from trippy import config
+
+    monkeypatch.setattr(config, "INTAKES_PATH", tmp_path / "intakes")
+    monkeypatch.setattr(config, "PLANS_PATH", tmp_path / "plans")
+    monkeypatch.setattr(config, "SHORTLISTS_PATH", tmp_path / "shortlists")
+    monkeypatch.setattr(config, "RESEARCH_PATH", tmp_path / "research")
+    monkeypatch.setattr(config, "LEARNING_PATH", tmp_path / "learning")
+    monkeypatch.setattr(config, "MEMORY_PATH", tmp_path / "memory.json")
+    monkeypatch.setattr(config, "TRIPS_PATH", tmp_path / "trips")
+
+    intake = TripIntake(
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Azores Firecrawl 2027",
+        destination_seeds=["Azores"],
+        travel_window=TravelWindow(label="summer 2027"),
+        duration_days=9,
+        travelers=5,
+        party=TripParty(
+            party_type=TripPartyType.WHOLE_FAMILY,
+            adults=2,
+            children=3,
+            roster=[
+                TripTraveler(name="Ken", age_band=TravelerAgeBand.ADULT),
+                TripTraveler(name="Sue", age_band=TravelerAgeBand.ADULT),
+                TripTraveler(name="Kid 1", age=14),
+                TripTraveler(name="Kid 2", age=11),
+                TripTraveler(name="Kid 3", age=8),
+            ],
+        ),
+        departure_airports=["YYZ"],
+    )
+    intake_service = TripIntakeService()
+    created = intake_service.create(intake)
+    planner = TripPlannerService(intake_service)
+    planner.draft(created.trip_id)
+    planner.select_option(created.trip_id, "azores-two-island-balanced")
+    state: ResearchShortlistState = FlightShortlistService(intake_service, planner).build(
+        created.trip_id
+    )
+
+    firecrawl = FirecrawlService(api_key="test-key", enabled=True)
+
+    def fake_request(path: str, payload: dict[str, object]) -> dict[str, object]:
+        if "search" in path:
+            return {"data": [{"url": "https://example.com/airline-policy", "title": "Policy"}]}
+        return {
+            "data": {"markdown": "Carry-on 1 bag. Checked baggage 23kg. Changes allowed with fee."}
+        }
+
+    firecrawl._request = fake_request  # type: ignore[method-assign]
+
+    researched = SourceResearchService(
+        adapters=[FirecrawlResearchAdapter(service=firecrawl)]
+    ).research_state(state, adapter_mode="firecrawl")
+    option = researched.flight_options[0]
+
+    assert option.validation.adapter_used == SourceAdapterCapability.FIRECRAWL.value
+    assert option.validation.evidence_url
+    assert option.validation.extracted_fields

--- a/trippy/agent.py
+++ b/trippy/agent.py
@@ -306,10 +306,55 @@ def _skill_tools() -> list[dict[str, Any]]:
                     },
                     "adapter": {
                         "type": "string",
-                        "enum": ["auto", "link", "playwright", "openclaw"],
+                        "enum": ["auto", "link", "playwright", "firecrawl", "openclaw"],
                         "default": "auto",
                     },
                 },
+            },
+        },
+        {
+            "name": "research_lodging_web",
+            "description": "Research lodging pages with Firecrawl and return normalized web evidence.",
+            "input_schema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {"query": {"type": "string"}},
+            },
+        },
+        {
+            "name": "research_activities_web",
+            "description": "Research activity pages with Firecrawl and return normalized web evidence.",
+            "input_schema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {"query": {"type": "string"}},
+            },
+        },
+        {
+            "name": "enrich_flight_with_web_context",
+            "description": "Enrich flight recommendations with baggage/fare/change policy context.",
+            "input_schema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {"query": {"type": "string"}},
+            },
+        },
+        {
+            "name": "enrich_car_rental_with_web_context",
+            "description": "Enrich car rental recommendations with policy/logistics context.",
+            "input_schema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {"query": {"type": "string"}},
+            },
+        },
+        {
+            "name": "extract_travel_page_context",
+            "description": "Extract normalized context from a single travel page URL.",
+            "input_schema": {
+                "type": "object",
+                "required": ["url"],
+                "properties": {"url": {"type": "string"}, "query": {"type": "string"}},
             },
         },
     ]
@@ -379,8 +424,44 @@ def _execute_tool(
 
     if name == "run_planning_service":
         return _run_planning_service(inputs)
+    if name in {
+        "research_lodging_web",
+        "research_activities_web",
+        "enrich_flight_with_web_context",
+        "enrich_car_rental_with_web_context",
+        "extract_travel_page_context",
+    }:
+        return _run_web_intelligence_tool(name, inputs)
 
     return json.dumps({"error": f"Unknown tool: {name}"})
+
+
+def _run_web_intelligence_tool(name: str, inputs: dict[str, Any]) -> str:
+    from trippy.services.web_intelligence import TravelWebIntelligenceService
+
+    service = TravelWebIntelligenceService()
+    query = str(inputs.get("query") or "")
+    if name == "research_lodging_web":
+        return json.dumps(
+            [row.model_dump(mode="json") for row in service.research_lodging_web(query)]
+        )
+    if name == "research_activities_web":
+        return json.dumps(
+            [row.model_dump(mode="json") for row in service.research_activities_web(query)]
+        )
+    if name == "enrich_flight_with_web_context":
+        return service.enrich_flight_with_web_context(query).model_dump_json()
+    if name == "enrich_car_rental_with_web_context":
+        return json.dumps(
+            [
+                row.model_dump(mode="json")
+                for row in service.enrich_car_rental_with_web_context(query)
+            ]
+        )
+    return service.extract_travel_page_context(
+        str(inputs.get("url") or ""),
+        query=query,
+    ).model_dump_json()
 
 
 def _run_planning_service(inputs: dict[str, Any]) -> str:

--- a/trippy/cli.py
+++ b/trippy/cli.py
@@ -597,7 +597,7 @@ def trip_plan_flights(
     adapter: str = typer.Option(
         "auto",
         "--adapter",
-        help="Source adapter mode: auto, link, playwright, or openclaw",
+        help="Source adapter mode: auto, link, firecrawl, playwright, or openclaw",
     ),
     propose_learning: bool = typer.Option(
         False,
@@ -660,7 +660,7 @@ def trip_plan_lodging(
     adapter: str = typer.Option(
         "auto",
         "--adapter",
-        help="Source adapter mode: auto, link, playwright, or openclaw",
+        help="Source adapter mode: auto, link, firecrawl, playwright, or openclaw",
     ),
     propose_learning: bool = typer.Option(
         False,
@@ -703,7 +703,7 @@ def trip_plan_cars(
     adapter: str = typer.Option(
         "auto",
         "--adapter",
-        help="Source adapter mode: auto, link, playwright, or openclaw",
+        help="Source adapter mode: auto, link, firecrawl, playwright, or openclaw",
     ),
     propose_learning: bool = typer.Option(
         False,
@@ -746,7 +746,7 @@ def trip_plan_activities(
     adapter: str = typer.Option(
         "auto",
         "--adapter",
-        help="Source adapter mode: auto, link, playwright, or openclaw",
+        help="Source adapter mode: auto, link, firecrawl, playwright, or openclaw",
     ),
     propose_learning: bool = typer.Option(
         False,

--- a/trippy/config.py
+++ b/trippy/config.py
@@ -47,6 +47,11 @@ PLANNING_LLM_ENABLED: bool = _bool("TRIPPY_PLANNING_LLM_ENABLED", bool(ANTHROPIC
 GOOGLE_SHEETS_API_KEY: str = os.environ.get("GOOGLE_SHEETS_API_KEY", "")
 SHERPA_API_KEY: str = os.environ.get("SHERPA_API_KEY", "")
 DUFFEL_ACCESS_TOKEN: str = os.environ.get("DUFFEL_ACCESS_TOKEN", "")
+FIRECRAWL_API_KEY: str = os.environ.get("FIRECRAWL_API_KEY", "")
+FIRECRAWL_BASE_URL: str = os.environ.get("FIRECRAWL_BASE_URL", "https://api.firecrawl.dev")
+FIRECRAWL_ENABLED: bool = _bool("FIRECRAWL_ENABLED", True)
+FIRECRAWL_CACHE_TTL_SECONDS: int = int(os.environ.get("FIRECRAWL_CACHE_TTL_SECONDS", "900"))
+FIRECRAWL_MAX_RESULTS: int = int(os.environ.get("FIRECRAWL_MAX_RESULTS", "5"))
 
 # Google Sheet template
 SHEET_TEMPLATE_ID: str = os.environ.get("TRIPPY_SHEET_TEMPLATE_ID", "")

--- a/trippy/models/__init__.py
+++ b/trippy/models/__init__.py
@@ -94,13 +94,22 @@ from trippy.models.trip_planning import (
     WorkspaceStatus,
     WorkspaceTab,
 )
+from trippy.models.web_research import (
+    ActivityWebOption,
+    CarRentalWebOption,
+    FlightWebContext,
+    LodgingWebOption,
+    WebResearchResult,
+)
 
 __all__ = [
     "ActivityOption",
+    "ActivityWebOption",
     "AvailabilityStatus",
     "Budget",
     "CarRentalExpectation",
     "CarOption",
+    "CarRentalWebOption",
     "ChecklistItem",
     "Confirmation",
     "CountryFitSignal",
@@ -117,6 +126,7 @@ __all__ = [
     "FamilyProfile",
     "FamilyTravelPreferences",
     "FlightOption",
+    "FlightWebContext",
     "FlightPreferenceInput",
     "FoodPriority",
     "FreshnessStatus",
@@ -126,6 +136,7 @@ __all__ = [
     "LodgingFitCategory",
     "LodgingPreferenceInput",
     "LodgingOption",
+    "LodgingWebOption",
     "MapPin",
     "MapPinCategory",
     "MapRoute",
@@ -184,4 +195,5 @@ __all__ = [
     "VerificationStatus",
     "WorkspaceStatus",
     "WorkspaceTab",
+    "WebResearchResult",
 ]

--- a/trippy/models/source_research.py
+++ b/trippy/models/source_research.py
@@ -13,6 +13,7 @@ class SourceAdapterCapability(StrEnum):
     LINK = "link"
     HTTP = "http"
     PLAYWRIGHT = "playwright"
+    FIRECRAWL = "firecrawl"
     OPENCLAW = "openclaw"
 
 
@@ -20,6 +21,7 @@ class SourceResearchMode(StrEnum):
     AUTO = "auto"
     LINK = "link"
     PLAYWRIGHT = "playwright"
+    FIRECRAWL = "firecrawl"
     OPENCLAW = "openclaw"
 
 

--- a/trippy/models/web_research.py
+++ b/trippy/models/web_research.py
@@ -1,0 +1,100 @@
+"""Normalized source-backed web intelligence models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class WebResearchResult(BaseModel):
+    id: str
+    query: str
+    source_url: str
+    source_title: str = ""
+    source_domain: str = ""
+    fetched_at: datetime = Field(default_factory=datetime.utcnow)
+    extraction_type: str = "search"
+    raw_markdown_excerpt: str = ""
+    structured_data: dict[str, Any] = Field(default_factory=dict)
+    confidence: float = 0.0
+    warnings: list[str] = Field(default_factory=list)
+    provider: str = "firecrawl"
+
+    @field_validator("confidence")
+    @classmethod
+    def _confidence_range(cls, value: float) -> float:
+        return max(0.0, min(1.0, value))
+
+
+class FlightWebContext(BaseModel):
+    airline: str = ""
+    route: str = ""
+    baggage_policy: str = ""
+    carry_on_policy: str = ""
+    checked_bag_policy: str = ""
+    fare_rules: str = ""
+    change_cancel_policy: str = ""
+    seat_selection_notes: str = ""
+    family_travel_notes: str = ""
+    airport_transfer_notes: str = ""
+    source_urls: list[str] = Field(default_factory=list)
+    confidence: float = 0.0
+    warnings: list[str] = Field(default_factory=list)
+
+
+class LodgingWebOption(BaseModel):
+    name: str = ""
+    address_or_area: str = ""
+    url: str = ""
+    property_type: str = ""
+    nightly_price_text: str = ""
+    fees_text: str = ""
+    cancellation_policy: str = ""
+    check_in_time: str = ""
+    check_out_time: str = ""
+    amenities: list[str] = Field(default_factory=list)
+    family_fit_notes: str = ""
+    parking_notes: str = ""
+    pet_policy: str = ""
+    accessibility_notes: str = ""
+    proximity_notes: str = ""
+    source_urls: list[str] = Field(default_factory=list)
+    confidence: float = 0.0
+    warnings: list[str] = Field(default_factory=list)
+
+
+class CarRentalWebOption(BaseModel):
+    vendor: str = ""
+    pickup_location: str = ""
+    dropoff_location: str = ""
+    vehicle_class: str = ""
+    price_text: str = ""
+    mileage_policy: str = ""
+    insurance_notes: str = ""
+    deposit_notes: str = ""
+    child_seat_notes: str = ""
+    cancellation_policy: str = ""
+    source_urls: list[str] = Field(default_factory=list)
+    confidence: float = 0.0
+    warnings: list[str] = Field(default_factory=list)
+
+
+class ActivityWebOption(BaseModel):
+    name: str = ""
+    location: str = ""
+    url: str = ""
+    category: str = ""
+    duration: str = ""
+    schedule_or_hours: str = ""
+    price_text: str = ""
+    age_restrictions: str = ""
+    booking_required: str = ""
+    cancellation_policy: str = ""
+    weather_dependency: str = ""
+    family_fit_notes: str = ""
+    accessibility_notes: str = ""
+    source_urls: list[str] = Field(default_factory=list)
+    confidence: float = 0.0
+    warnings: list[str] = Field(default_factory=list)

--- a/trippy/services/firecrawl.py
+++ b/trippy/services/firecrawl.py
@@ -1,0 +1,195 @@
+"""Firecrawl client wrapper with safe disabled-mode behavior."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+from trippy import config
+from trippy.models.web_research import WebResearchResult
+
+
+@dataclass
+class FirecrawlAvailability:
+    available: bool
+    reason: str = ""
+
+
+class FirecrawlService:
+    """Small Firecrawl REST wrapper for search/scrape/extract/research."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        enabled: bool | None = None,
+        timeout_seconds: float = 10.0,
+        retries: int = 2,
+    ) -> None:
+        self._api_key = api_key if api_key is not None else config.FIRECRAWL_API_KEY
+        self._base_url = (
+            base_url or config.FIRECRAWL_BASE_URL or "https://api.firecrawl.dev"
+        ).rstrip("/")
+        self._enabled = config.FIRECRAWL_ENABLED if enabled is None else enabled
+        self._timeout = timeout_seconds
+        self._retries = max(0, retries)
+        self._cache_ttl = max(0, config.FIRECRAWL_CACHE_TTL_SECONDS)
+        self._max_results = max(1, config.FIRECRAWL_MAX_RESULTS)
+        self._cache: dict[str, tuple[float, list[WebResearchResult]]] = {}
+
+    def availability(self) -> FirecrawlAvailability:
+        if not self._enabled:
+            return FirecrawlAvailability(available=False, reason="FIRECRAWL_ENABLED is false")
+        if not self._api_key:
+            return FirecrawlAvailability(available=False, reason="FIRECRAWL_API_KEY is missing")
+        return FirecrawlAvailability(available=True)
+
+    def search(self, query: str, *, limit: int | None = None) -> list[WebResearchResult]:
+        availability = self.availability()
+        if not availability.available:
+            return [self._unavailable_result(query, availability.reason)]
+        payload = {"query": query, "limit": min(limit or self._max_results, self._max_results)}
+        response = self._request("/v1/search", payload)
+        entries = response.get("data", []) if isinstance(response, dict) else []
+        return [
+            self._result_from_entry(query, entry, extraction_type="search") for entry in entries
+        ] or [self._unavailable_result(query, "Firecrawl search returned no results")]
+
+    def scrape_url(self, url: str) -> WebResearchResult:
+        availability = self.availability()
+        if not availability.available:
+            return self._unavailable_result(url, availability.reason, source_url=url)
+        payload = {"url": url, "formats": ["markdown"]}
+        response = self._request("/v1/scrape", payload)
+        data = response.get("data", {}) if isinstance(response, dict) else {}
+        markdown = str(data.get("markdown") or "")
+        return WebResearchResult(
+            id=f"firecrawl-{uuid.uuid4().hex[:12]}",
+            query=url,
+            source_url=url,
+            source_title=str(data.get("metadata", {}).get("title") or ""),
+            source_domain=urlparse(url).netloc,
+            extraction_type="scrape",
+            raw_markdown_excerpt=markdown[:1500],
+            structured_data={"markdown_length": len(markdown)},
+            confidence=0.7 if markdown else 0.3,
+            warnings=[] if markdown else ["No markdown returned by Firecrawl scrape"],
+        )
+
+    def extract_from_url(
+        self,
+        url: str,
+        *,
+        schema: dict[str, Any],
+        prompt: str,
+    ) -> WebResearchResult:
+        availability = self.availability()
+        if not availability.available:
+            return self._unavailable_result(prompt, availability.reason, source_url=url)
+        payload = {"urls": [url], "prompt": prompt, "schema": schema}
+        response = self._request("/v1/extract", payload)
+        data = response.get("data", {}) if isinstance(response, dict) else {}
+        return WebResearchResult(
+            id=f"firecrawl-{uuid.uuid4().hex[:12]}",
+            query=prompt,
+            source_url=url,
+            source_title=str(data.get("title") or ""),
+            source_domain=urlparse(url).netloc,
+            extraction_type="extract",
+            structured_data=cast_dict(data),
+            confidence=0.72 if data else 0.3,
+            warnings=[] if data else ["No structured payload returned by Firecrawl extract"],
+        )
+
+    def research(self, query: str, *, limit: int | None = None) -> list[WebResearchResult]:
+        cache_key = f"{query}:{limit or self._max_results}"
+        now = time.time()
+        if self._cache_ttl > 0 and cache_key in self._cache:
+            created_at, results = self._cache[cache_key]
+            if now - created_at <= self._cache_ttl:
+                return results
+        results = self.search(query, limit=limit)
+        enriched: list[WebResearchResult] = []
+        for item in results[: min(limit or self._max_results, self._max_results)]:
+            if not item.source_url:
+                enriched.append(item)
+                continue
+            scraped = self.scrape_url(item.source_url)
+            merged = item.model_copy(deep=True)
+            if scraped.raw_markdown_excerpt:
+                merged.raw_markdown_excerpt = scraped.raw_markdown_excerpt
+                merged.confidence = min(1.0, max(merged.confidence, scraped.confidence))
+                merged.warnings = sorted({*merged.warnings, *scraped.warnings})
+            enriched.append(merged)
+        if self._cache_ttl > 0:
+            self._cache[cache_key] = (now, enriched)
+        return enriched
+
+    def _request(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = urljoin(self._base_url + "/", path.lstrip("/"))
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "Trippy/0.2 Firecrawl",
+        }
+        last_error = ""
+        for attempt in range(self._retries + 1):
+            try:
+                request = Request(url, data=body, headers=headers, method="POST")
+                with urlopen(request, timeout=self._timeout) as response:  # noqa: S310
+                    raw = response.read().decode("utf-8")
+                    return cast_dict(json.loads(raw))
+            except (HTTPError, URLError, TimeoutError, ValueError) as exc:
+                last_error = str(exc)
+                if attempt >= self._retries:
+                    break
+                time.sleep(min(1.6, 0.3 * (2**attempt)))
+        return {"warning": f"Firecrawl request failed: {last_error}"}
+
+    def _unavailable_result(
+        self, query: str, reason: str, *, source_url: str = ""
+    ) -> WebResearchResult:
+        return WebResearchResult(
+            id=f"firecrawl-unavailable-{uuid.uuid4().hex[:8]}",
+            query=query,
+            source_url=source_url,
+            source_domain=urlparse(source_url).netloc if source_url else "",
+            extraction_type="unavailable",
+            confidence=0.0,
+            warnings=[reason],
+            structured_data={"status": "disabled"},
+        )
+
+    def _result_from_entry(
+        self, query: str, entry: Any, *, extraction_type: str
+    ) -> WebResearchResult:
+        obj = cast_dict(entry)
+        source_url = str(obj.get("url") or obj.get("sourceURL") or "")
+        return WebResearchResult(
+            id=f"firecrawl-{uuid.uuid4().hex[:12]}",
+            query=query,
+            source_url=source_url,
+            source_title=str(obj.get("title") or ""),
+            source_domain=urlparse(source_url).netloc,
+            extraction_type=extraction_type,
+            raw_markdown_excerpt=str(obj.get("markdown") or "")[:1500],
+            structured_data={
+                "description": obj.get("description") or "",
+                "score": obj.get("score") or 0,
+            },
+            confidence=0.65,
+        )
+
+
+def cast_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return {str(k): v for k, v in value.items()}
+    return {}

--- a/trippy/services/source_research.py
+++ b/trippy/services/source_research.py
@@ -38,6 +38,7 @@ from trippy.models.source_research import (
     SourceResearchResult,
     SourceResearchStatus,
 )
+from trippy.services.firecrawl import FirecrawlService
 from trippy.services.learning import LearningEventStore
 
 HtmlFetchResult = tuple[str, str, list[str]]
@@ -77,6 +78,7 @@ class SourceResearchService:
         self._learning = learning_store or LearningEventStore()
         self._adapters = adapters or [
             LinkResearchAdapter(),
+            FirecrawlResearchAdapter(),
             PlaywrightFlightAdapter(),
             PlaywrightLodgingAdapter(),
             PlaywrightActivityAdapter(),
@@ -162,9 +164,7 @@ class SourceResearchService:
                 ),
             }
         )
-        complementary_states, party_size = _load_friction_context(
-            state.trip_id, state.category
-        )
+        complementary_states, party_size = _load_friction_context(state.trip_id, state.category)
         from trippy.services.shortlist_friction import apply_shortlist_friction
 
         apply_shortlist_friction(
@@ -188,9 +188,7 @@ class SourceResearchService:
                 "transmission, deposit, insurance, or cancellation terms as ready-to-click."
             )
         else:
-            review_note = (
-                "Review deep-research evidence for lodging rows before treating any option as ready-to-click."
-            )
+            review_note = "Review deep-research evidence for lodging rows before treating any option as ready-to-click."
         state.next_actions.insert(0, review_note)
         self._record_run_event(state, run_id, run_results)
         return state
@@ -246,6 +244,12 @@ class SourceResearchService:
                 for adapter in self._adapters
                 if adapter.capability == SourceAdapterCapability.PLAYWRIGHT
             ]
+        if mode == SourceResearchMode.FIRECRAWL:
+            return [
+                adapter
+                for adapter in self._adapters
+                if adapter.capability == SourceAdapterCapability.FIRECRAWL
+            ]
         if mode == SourceResearchMode.OPENCLAW:
             return [
                 adapter
@@ -253,6 +257,7 @@ class SourceResearchService:
                 if adapter.capability == SourceAdapterCapability.OPENCLAW
             ]
         priority = [
+            SourceAdapterCapability.FIRECRAWL,
             SourceAdapterCapability.PLAYWRIGHT,
             SourceAdapterCapability.OPENCLAW,
             SourceAdapterCapability.LINK,
@@ -310,6 +315,112 @@ class LinkResearchAdapter:
                 "Link adapter preserved handoff evidence without claiming extracted live details."
             ],
             missing_fields=_missing_fields_for_category(request.category),
+        )
+
+
+class FirecrawlResearchAdapter:
+    """Firecrawl-backed public web intelligence adapter (read-only evidence)."""
+
+    capability = SourceAdapterCapability.FIRECRAWL
+
+    def __init__(self, *, service: FirecrawlService | None = None) -> None:
+        self._firecrawl = service or FirecrawlService()
+
+    def can_handle(self, request: SourceResearchRequest) -> bool:
+        return request.category in {
+            ShortlistCategory.LODGING.value,
+            ShortlistCategory.FLIGHTS.value,
+            ShortlistCategory.CARS.value,
+            ShortlistCategory.ACTIVITIES.value,
+        } and bool(request.source_url or request.query)
+
+    def research(
+        self,
+        request: SourceResearchRequest,
+        *,
+        artifact_dir: Path,
+    ) -> SourceResearchResult:
+        availability = self._firecrawl.availability()
+        if not availability.available:
+            return _result(
+                request,
+                adapter=self.capability,
+                status=SourceResearchStatus.SKIPPED,
+                confidence=0.0,
+                notes=[
+                    "Firecrawl is unavailable; request safely skipped without pipeline failure.",
+                    availability.reason,
+                ],
+                missing_fields=_missing_fields_for_category(request.category),
+            )
+
+        query = (
+            request.query or f"{request.candidate_name} {request.source_name} travel policy details"
+        )
+        research_results = self._firecrawl.research(query)
+        first = research_results[0] if research_results else None
+        if first is None:
+            return _result(
+                request,
+                adapter=self.capability,
+                status=SourceResearchStatus.BLOCKED,
+                confidence=0.15,
+                notes=["Firecrawl returned no usable research rows."],
+                missing_fields=_missing_fields_for_category(request.category),
+            )
+        text = first.raw_markdown_excerpt
+        evidence_url = first.source_url or request.source_url
+        evidence_refs = [evidence_url] if evidence_url else []
+        observations: list[SourceObservation]
+        if request.category == ShortlistCategory.FLIGHTS.value:
+            observations = _extract_flight_observations(
+                text, request=request, evidence_refs=evidence_refs
+            )
+        elif request.category == ShortlistCategory.LODGING.value:
+            observations = _extract_lodging_observations(
+                text, request=request, evidence_refs=evidence_refs
+            )
+        elif request.category == ShortlistCategory.CARS.value:
+            observations = _extract_car_observations(
+                text, request=request, evidence_refs=evidence_refs
+            )
+        else:
+            observations = _extract_activity_observations(
+                text, request=request, evidence_refs=evidence_refs
+            )
+        if not observations:
+            observations = [
+                SourceObservation(field="raw_markdown_excerpt", value=text[:400], confidence=0.4)
+            ]
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        markdown_path = artifact_dir / "firecrawl.md"
+        markdown_path.write_text(text, encoding="utf-8")
+        missing_fields = _remaining_fields_for_category(request.category, observations)
+        confidence = max(0.25, _observation_confidence(observations))
+        status = (
+            SourceResearchStatus.SUCCESS
+            if confidence >= 0.68 and len(missing_fields) <= 2
+            else SourceResearchStatus.PARTIAL
+        )
+        return _result(
+            request,
+            adapter=self.capability,
+            status=status,
+            confidence=confidence,
+            observations=observations,
+            evidence_artifacts=[
+                EvidenceArtifact(
+                    artifact_type="firecrawl-markdown",
+                    label="Firecrawl markdown excerpt",
+                    path=str(markdown_path),
+                    url=evidence_url,
+                )
+            ],
+            notes=[
+                "Firecrawl provided public-web enrichment only; live inventory and booking truth remain official APIs.",
+                *first.warnings,
+            ],
+            missing_fields=missing_fields,
         )
 
 
@@ -831,9 +942,7 @@ class OpenClawResearchAdapter:
                 "OpenClaw was used as an optional read-only browser-agent fallback.",
                 *notes,
             ],
-            missing_fields=_remaining_fields_for_category(
-                request.category, observations
-            ),
+            missing_fields=_remaining_fields_for_category(request.category, observations),
         )
 
     def _gateway_is_live(self) -> bool:
@@ -1608,7 +1717,9 @@ def _extract_activity_observations(
     price = _extract_price(cleaned)
     if price:
         observations.append(
-            _observation("price_signal", price, 0.64, request, evidence_refs, "Visible activity price text")
+            _observation(
+                "price_signal", price, 0.64, request, evidence_refs, "Visible activity price text"
+            )
         )
     availability = _activity_availability_signal(lower)
     if availability:
@@ -1663,7 +1774,9 @@ def _extract_car_observations(
     price = _extract_price(cleaned)
     if price:
         observations.append(
-            _observation("total_price", price, 0.64, request, evidence_refs, "Visible car rental price text")
+            _observation(
+                "total_price", price, 0.64, request, evidence_refs, "Visible car rental price text"
+            )
         )
     availability = _car_availability_signal(lower)
     if availability:
@@ -1690,7 +1803,9 @@ def _extract_car_observations(
         observations.append(_observation("luggage_capacity", luggage, 0.50, request, evidence_refs))
     model = _vehicle_model_signal(cleaned, request)
     if model:
-        observations.append(_observation("vehicle_model_example", model, 0.56, request, evidence_refs))
+        observations.append(
+            _observation("vehicle_model_example", model, 0.56, request, evidence_refs)
+        )
     cancellation = _cancellation_signal(lower)
     if cancellation:
         observations.append(
@@ -1698,7 +1813,9 @@ def _extract_car_observations(
         )
     insurance = _insurance_signal(lower)
     if insurance:
-        observations.append(_observation("insurance_signal", insurance, 0.45, request, evidence_refs))
+        observations.append(
+            _observation("insurance_signal", insurance, 0.45, request, evidence_refs)
+        )
     fees = _car_fees_signal(lower)
     if fees:
         observations.append(_observation("fees_signal", fees, 0.48, request, evidence_refs))
@@ -1947,7 +2064,11 @@ def _luggage_capacity_signal(text: str) -> str:
     )
     if match:
         return f"{match.group(0).strip()} capacity signal visible; verify exact boot/trunk space"
-    if re.search(r"\b(?:large\s+suitcase|full\s+size\s+luggage|luggage\s+capacity)\b", text, flags=re.IGNORECASE):
+    if re.search(
+        r"\b(?:large\s+suitcase|full\s+size\s+luggage|luggage\s+capacity)\b",
+        text,
+        flags=re.IGNORECASE,
+    ):
         return "luggage capacity language visible; verify exact number of bags"
     return ""
 
@@ -2390,7 +2511,9 @@ def _missing_high_value_fields(result: SourceResearchResult) -> bool:
             & set(result.missing_fields)
         )
     if result.request.category == ShortlistCategory.ACTIVITIES.value:
-        return bool({"current_price", "exact_availability", "bookable_time"} & set(result.missing_fields))
+        return bool(
+            {"current_price", "exact_availability", "bookable_time"} & set(result.missing_fields)
+        )
     if result.request.category == ShortlistCategory.CARS.value:
         return bool(
             {"total_price", "exact_seats", "transmission", "cancellation_terms"}
@@ -2646,9 +2769,7 @@ def _raw_notes(value: object) -> list[str]:
     return []
 
 
-_MARKDOWN_FENCE_RE = re.compile(
-    r"```(?:json|JSON)?\s*\n(.*?)\n\s*```", re.DOTALL
-)
+_MARKDOWN_FENCE_RE = re.compile(r"```(?:json|JSON)?\s*\n(.*?)\n\s*```", re.DOTALL)
 
 
 def _strip_markdown_fences(text: str) -> str:

--- a/trippy/services/web_intelligence.py
+++ b/trippy/services/web_intelligence.py
@@ -1,0 +1,149 @@
+"""Firecrawl-backed web intelligence normalization for travel domains."""
+
+from __future__ import annotations
+
+from trippy.models.web_research import (
+    ActivityWebOption,
+    CarRentalWebOption,
+    FlightWebContext,
+    LodgingWebOption,
+    WebResearchResult,
+)
+from trippy.services.firecrawl import FirecrawlService
+
+
+class TravelWebIntelligenceService:
+    def __init__(self, *, firecrawl: FirecrawlService | None = None) -> None:
+        self._firecrawl = firecrawl or FirecrawlService()
+
+    def extract_travel_page_context(self, url: str, query: str = "") -> WebResearchResult:
+        if query:
+            rows = self._firecrawl.research(query, limit=1)
+            if rows:
+                return rows[0]
+        return self._firecrawl.scrape_url(url)
+
+    def research_lodging_web(self, query: str) -> list[LodgingWebOption]:
+        rows = self._firecrawl.research(query)
+        return [
+            LodgingWebOption(
+                name=(row.source_title or row.source_domain),
+                address_or_area=row.structured_data.get("description", ""),
+                url=row.source_url,
+                amenities=_sniff_list(
+                    row.raw_markdown_excerpt, ["pool", "wifi", "parking", "breakfast"]
+                ),
+                family_fit_notes=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["family", "kids", "suite", "queen"]
+                ),
+                cancellation_policy=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["cancellation", "refundable"]
+                ),
+                check_in_time=_sniff_sentence(row.raw_markdown_excerpt, ["check-in", "check in"]),
+                check_out_time=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["check-out", "check out"]
+                ),
+                parking_notes=_sniff_sentence(row.raw_markdown_excerpt, ["parking"]),
+                pet_policy=_sniff_sentence(row.raw_markdown_excerpt, ["pet"]),
+                accessibility_notes=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["accessible", "wheelchair"]
+                ),
+                proximity_notes=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["minutes", "walk", "airport"]
+                ),
+                source_urls=[row.source_url],
+                confidence=row.confidence,
+                warnings=row.warnings,
+            )
+            for row in rows
+        ]
+
+    def research_activities_web(self, query: str) -> list[ActivityWebOption]:
+        rows = self._firecrawl.research(query)
+        return [
+            ActivityWebOption(
+                name=row.source_title or "Activity option",
+                location=row.source_domain,
+                url=row.source_url,
+                duration=_sniff_sentence(row.raw_markdown_excerpt, ["hour", "duration"]),
+                schedule_or_hours=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["open", "hours", "daily"]
+                ),
+                price_text=_sniff_sentence(row.raw_markdown_excerpt, ["$", "CAD", "USD", "price"]),
+                age_restrictions=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["age", "years", "minimum"]
+                ),
+                cancellation_policy=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["cancellation", "refund"]
+                ),
+                weather_dependency=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["weather", "rain", "wind"]
+                ),
+                family_fit_notes=_sniff_sentence(row.raw_markdown_excerpt, ["family", "kids"]),
+                accessibility_notes=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["accessible", "mobility"]
+                ),
+                source_urls=[row.source_url],
+                confidence=row.confidence,
+                warnings=row.warnings,
+            )
+            for row in rows
+        ]
+
+    def enrich_flight_with_web_context(self, query: str) -> FlightWebContext:
+        rows = self._firecrawl.research(query, limit=2)
+        text = "\n".join(row.raw_markdown_excerpt for row in rows)
+        return FlightWebContext(
+            route=query,
+            baggage_policy=_sniff_sentence(text, ["baggage", "bag", "carry-on", "checked"]),
+            carry_on_policy=_sniff_sentence(text, ["carry-on", "carry on"]),
+            checked_bag_policy=_sniff_sentence(text, ["checked bag", "checked baggage"]),
+            fare_rules=_sniff_sentence(text, ["fare", "basic", "economy", "rules"]),
+            change_cancel_policy=_sniff_sentence(text, ["change", "cancel", "refund"]),
+            seat_selection_notes=_sniff_sentence(text, ["seat selection", "seats"]),
+            family_travel_notes=_sniff_sentence(text, ["family", "child", "infant"]),
+            airport_transfer_notes=_sniff_sentence(text, ["airport transfer", "shuttle", "train"]),
+            source_urls=[row.source_url for row in rows if row.source_url],
+            confidence=max((row.confidence for row in rows), default=0.0),
+            warnings=sorted({warning for row in rows for warning in row.warnings}),
+        )
+
+    def enrich_car_rental_with_web_context(self, query: str) -> list[CarRentalWebOption]:
+        rows = self._firecrawl.research(query)
+        return [
+            CarRentalWebOption(
+                vendor=row.source_title or row.source_domain,
+                price_text=_sniff_sentence(row.raw_markdown_excerpt, ["CAD", "$", "per day"]),
+                mileage_policy=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["mileage", "kilometer", "km"]
+                ),
+                insurance_notes=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["insurance", "coverage"]
+                ),
+                deposit_notes=_sniff_sentence(row.raw_markdown_excerpt, ["deposit", "hold"]),
+                child_seat_notes=_sniff_sentence(
+                    row.raw_markdown_excerpt, ["child seat", "booster"]
+                ),
+                cancellation_policy=_sniff_sentence(row.raw_markdown_excerpt, ["cancel", "refund"]),
+                source_urls=[row.source_url],
+                confidence=row.confidence,
+                warnings=row.warnings,
+            )
+            for row in rows
+        ]
+
+
+def _sniff_sentence(text: str, tokens: list[str]) -> str:
+    lowered = text.lower()
+    for token in tokens:
+        index = lowered.find(token.lower())
+        if index >= 0:
+            start = max(0, index - 40)
+            end = min(len(text), index + 140)
+            return " ".join(text[start:end].split())
+    return ""
+
+
+def _sniff_list(text: str, tokens: list[str]) -> list[str]:
+    lowered = text.lower()
+    return [token for token in tokens if token in lowered]


### PR DESCRIPTION
### Motivation
- Provide a resilient public-web intelligence layer (Firecrawl) to enrich and fallback research for flights, lodging, cars, and activities while preserving API-first transactional truth.  

### Description
- Added a Firecrawl client/service with disabled-mode behavior, retries/backoff, timeout handling, optional in-memory TTL caching, and methods `search`, `scrape_url`, `extract_from_url`, and `research` (`trippy/services/firecrawl.py`).  
- Introduced normalized web intelligence models (`WebResearchResult`, `FlightWebContext`, `LodgingWebOption`, `CarRentalWebOption`, `ActivityWebOption`) (`trippy/models/web_research.py`) and exported them.  
- Integrated a `FirecrawlResearchAdapter` into the deep source-research pipeline and added `firecrawl` as a source adapter/mode and priority in the adapter selection (`trippy/services/source_research.py`, `trippy/models/source_research.py`).  
- Implemented a Travel Web Intelligence service that normalizes domain-specific extracts and enrichments for lodging, activities, flights, and cars (`trippy/services/web_intelligence.py`).  
- Exposed Firecrawl-backed agent/tools (`research_lodging_web`, `research_activities_web`, `enrich_flight_with_web_context`, `enrich_car_rental_with_web_context`, `extract_travel_page_context`) and wired execution handlers (`trippy/agent.py`).  
- Added environment configuration for Firecrawl (`FIRECRAWL_API_KEY`, `FIRECRAWL_BASE_URL`, `FIRECRAWL_ENABLED`, `FIRECRAWL_CACHE_TTL_SECONDS`, `FIRECRAWL_MAX_RESULTS`) (`trippy/config.py`) and updated docs/CLI help to include `firecrawl` (`README.md`, `trippy/cli.py`).  
- Added a cloud-safe dev probe script `scripts/firecrawl_travel_probe.py`.  
- Added unit and pipeline-style tests using mocked Firecrawl responses to validate disabled-key behavior, normalization, adapter observations, and pipeline merging (`tests/unit/test_firecrawl.py`).  

### Testing
- Ran linter/format: `uv run ruff format` and `uv run ruff check` on modified files (passed).  
- Unit tests executed: `uv run pytest tests/unit/test_firecrawl.py tests/unit/test_openclaw_adapter.py -q` (25 tests collected; all passed).  
- Pipeline test executed: `uv run pytest tests/unit/test_trip_planning_pipeline.py::test_lodging_deep_research_falls_back_when_openclaw_disabled -q` (1 test passed).  
- Notes: pushing the branch to GitHub failed in this environment due to missing remote credentials; the branch and commits exist locally on `feature/firecrawl-travel-intelligence`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0eb8cee40832f93b187bbba16db56)