### PR TITLE
Fix connector-safe trip geography for Chile and live searches

### DIFF
--- a/tests/unit/test_trip_geography.py
+++ b/tests/unit/test_trip_geography.py
@@ -1,0 +1,56 @@
+"""Regression tests for canonical trip geography and connector-safe locations."""
+
+from __future__ import annotations
+
+from trippy.models.trip_planning import TripIntake, TripIntakeMode
+from trippy.services.destination_profiles import profile_for_intake
+
+
+def test_chile_geography_separates_flight_airport_from_neighborhoods() -> None:
+    intake = TripIntake(
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Chile family trip",
+        destination_seeds=[
+            "Santiago-Providencia-Santiago-Bellavista-Santiago-Barrio-Italia-Maipo-Valley"
+        ],
+        departure_airports=["YYZ"],
+        duration_days=8,
+    )
+
+    assert intake.geography is not None
+    assert intake.geography.primary_origin_iata() == "YYZ"
+    assert intake.geography.primary_gateway_iata() == "SCL"
+    assert [airport.iata_code for airport in intake.geography.destination_airports] == ["SCL"]
+    assert "SANTIAGO-PROVIDENCIA" not in intake.geography.all_airport_codes()
+
+    map_queries = intake.geography.map_seed_queries()
+    assert any("Providencia" in query for query in map_queries)
+    assert any("Bellavista" in query for query in map_queries)
+    assert any("Barrio Italia" in query for query in map_queries)
+    assert any("Maipo Valley" in query for query in map_queries)
+
+
+def test_chile_destination_profile_feeds_each_connector_the_right_location_type() -> None:
+    intake = TripIntake(
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Chile",
+        destination_seeds=["Santiago, Providencia, Bellavista, Barrio Italia, Maipo Valley"],
+        departure_airports=["YYZ"],
+    )
+
+    profile = profile_for_intake(intake)
+
+    assert profile.key == "chile"
+    assert profile.gateway_airports == ["SCL"]
+    assert all(len(code) == 3 and code.isupper() for code in profile.gateway_airports)
+    assert any("SCL is the canonical" in note for note in profile.flight_notes)
+
+    lodging_text = " ".join(str(target) for target in profile.lodging_search_targets)
+    car_text = " ".join(str(target) for target in profile.car_search_targets)
+    activity_text = " ".join(str(target) for target in profile.activity_search_targets)
+
+    assert "Providencia" in lodging_text
+    assert "Barrio Italia" in lodging_text
+    assert "SCL" in car_text
+    assert "Maipo Valley" in activity_text
+    assert "SANTIAGO-PROVIDENCIA-SANTIAGO-BELLAVISTA" not in car_text

--- a/trippy/models/trip_planning.py
+++ b/trippy/models/trip_planning.py
@@ -100,6 +100,166 @@ class CarRentalExpectation(BaseModel):
     notes: str | None = None
 
 
+class TravelAirportRef(BaseModel):
+    """Canonical airport reference used by connector adapters."""
+
+    iata_code: str
+    name: str | None = None
+    city: str | None = None
+    country: str | None = None
+    role: str = "gateway"
+
+    @field_validator("iata_code")
+    @classmethod
+    def _iata_code_valid(cls, value: str) -> str:
+        cleaned = value.strip().upper()
+        if not re.fullmatch(r"[A-Z]{3}", cleaned):
+            raise ValueError("iata_code must be a three-letter IATA code")
+        return cleaned
+
+    def label(self) -> str:
+        parts = [self.iata_code]
+        if self.city:
+            parts.append(self.city)
+        if self.country:
+            parts.append(self.country)
+        return " · ".join(parts)
+
+
+class TripMapLocation(BaseModel):
+    """Canonical place reference for maps, lodging, cars, and activities."""
+
+    name: str
+    kind: str = "place"
+    city: str | None = None
+    region: str | None = None
+    country: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    iata_code: str | None = None
+    use_for: list[str] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def _name_required(cls, value: str) -> str:
+        cleaned = " ".join(value.strip().split())
+        if not cleaned:
+            raise ValueError("map location name is required")
+        return cleaned
+
+    @field_validator("iata_code")
+    @classmethod
+    def _optional_iata_code_valid(cls, value: str | None) -> str | None:
+        if value is None or not value.strip():
+            return None
+        cleaned = value.strip().upper()
+        if not re.fullmatch(r"[A-Z]{3}", cleaned):
+            raise ValueError("iata_code must be a three-letter IATA code")
+        return cleaned
+
+    def search_label(self) -> str:
+        parts = [self.name]
+        for value in [self.city, self.region, self.country]:
+            if value and value.casefold() not in {part.casefold() for part in parts}:
+                parts.append(value)
+        return ", ".join(parts)
+
+
+class TripGeography(BaseModel):
+    """Connector-safe canonical trip geography.
+
+    Flight adapters should only consume ``TravelAirportRef.iata_code`` values.
+    Maps, lodging, cars, and activities should consume named locations/regions.
+    This prevents neighborhood or itinerary strings from leaking into flight routes.
+    """
+
+    primary_destination_name: str = ""
+    primary_city: str | None = None
+    country: str | None = None
+    departure_airports: list[TravelAirportRef] = Field(default_factory=list)
+    destination_airports: list[TravelAirportRef] = Field(default_factory=list)
+    in_trip_airports: list[TravelAirportRef] = Field(default_factory=list)
+    map_locations: list[TripMapLocation] = Field(default_factory=list)
+    planning_regions: list[str] = Field(default_factory=list)
+    lodging_search_locations: list[str] = Field(default_factory=list)
+    car_search_locations: list[str] = Field(default_factory=list)
+    activity_search_locations: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    @field_validator(
+        "planning_regions",
+        "lodging_search_locations",
+        "car_search_locations",
+        "activity_search_locations",
+        "warnings",
+        mode="before",
+    )
+    @classmethod
+    def _clean_string_list(cls, value: object) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            raw: list[object] = [value]
+        elif isinstance(value, list):
+            raw = value
+        else:
+            raw = [value]
+        return _dedupe_strings(str(item).strip() for item in raw if str(item).strip())
+
+    def primary_origin_iata(self, fallback: str = "YYZ") -> str:
+        if self.departure_airports:
+            return self.departure_airports[0].iata_code
+        return fallback.strip().upper()
+
+    def primary_gateway_iata(self) -> str | None:
+        if self.destination_airports:
+            return self.destination_airports[0].iata_code
+        return None
+
+    def all_airport_codes(self) -> list[str]:
+        return _dedupe_strings(
+            [
+                *(airport.iata_code for airport in self.departure_airports),
+                *(airport.iata_code for airport in self.destination_airports),
+                *(airport.iata_code for airport in self.in_trip_airports),
+            ]
+        )
+
+    def region_names(self) -> list[str]:
+        regions = list(self.planning_regions)
+        regions.extend(location.search_label() for location in self.map_locations if "planning" in location.use_for)
+        if not regions and self.primary_destination_name:
+            regions.append(self.primary_destination_name)
+        return _dedupe_strings(regions)
+
+    def map_seed_queries(self) -> list[str]:
+        values = [location.search_label() for location in self.map_locations]
+        values.extend(self.region_names())
+        if self.primary_gateway_iata():
+            values.append(self.primary_gateway_iata() or "")
+        return _dedupe_strings(values)
+
+    def lodging_locations(self) -> list[str]:
+        values = list(self.lodging_search_locations)
+        values.extend(location.search_label() for location in self.map_locations if "lodging" in location.use_for)
+        values.extend(self.region_names())
+        return _dedupe_strings(values)
+
+    def car_locations(self) -> list[str]:
+        values = list(self.car_search_locations)
+        values.extend(
+            airport.iata_code for airport in [*self.destination_airports, *self.in_trip_airports]
+        )
+        values.extend(location.search_label() for location in self.map_locations if "car" in location.use_for)
+        return _dedupe_strings(values)
+
+    def activity_locations(self) -> list[str]:
+        values = list(self.activity_search_locations)
+        values.extend(location.search_label() for location in self.map_locations if "activity" in location.use_for)
+        values.extend(self.region_names())
+        return _dedupe_strings(values)
+
+
 class TripTraveler(BaseModel):
     name: str
     age: int | None = None
@@ -231,6 +391,7 @@ class TripIntake(BaseModel):
     travelers: int = 5
     party: TripParty = Field(default_factory=TripParty)
     departure_airports: list[str] = Field(default_factory=lambda: ["YYZ"])
+    geography: TripGeography | None = None
     budget_cad: float | None = None
     max_travel_time_hours: float | None = None
     flight_preferences: FlightPreferenceInput = Field(default_factory=FlightPreferenceInput)
@@ -305,6 +466,7 @@ class TripIntake(BaseModel):
             self.departure_airports = ["YYZ"]
         self._sync_party_with_travelers()
         self._sync_duration_range()
+        self._sync_geography()
         return self
 
     def _sync_party_with_travelers(self) -> None:
@@ -337,6 +499,19 @@ class TripIntake(BaseModel):
             and self.duration_max_days is not None
         ):
             self.duration_days = round((self.duration_min_days + self.duration_max_days) / 2)
+
+    def _sync_geography(self) -> None:
+        if self.geography is None:
+            self.geography = canonicalize_trip_geography(self)
+            return
+        if not self.geography.departure_airports and self.departure_airports:
+            self.geography.departure_airports = [
+                TravelAirportRef(iata_code=code, role="origin")
+                for code in self.departure_airports
+                if _looks_like_iata(code)
+            ]
+        if not self.geography.primary_destination_name and self.destination_seeds:
+            self.geography.primary_destination_name = self.destination_seeds[0]
 
     def duration_display(self) -> str:
         if self.duration_label:
@@ -421,6 +596,304 @@ class TripWorkspaceState(BaseModel):
     artifacts: dict[str, Any] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
     next_actions: list[str] = Field(default_factory=list)
+
+
+def canonicalize_trip_geography(intake: TripIntake) -> TripGeography:
+    """Create connector-safe geography from raw intake strings.
+
+    This is intentionally deterministic and conservative. Known destinations receive
+    strong airport/place structure. Unknown destinations keep map/search places but do
+    not invent flight airport codes.
+    """
+    text = _searchable_intake_text(intake)
+    origin_airports = [
+        TravelAirportRef(iata_code=code, role="origin")
+        for code in intake.departure_airports
+        if _looks_like_iata(code)
+    ]
+    if _looks_like_chile_trip(text):
+        return _chile_geography(origin_airports, text)
+    if "azores" in text:
+        return _azores_geography(origin_airports)
+    if _looks_like_grand_cayman_trip(text):
+        return _grand_cayman_geography(origin_airports)
+    return _generic_geography(intake, origin_airports)
+
+
+def _searchable_intake_text(intake: TripIntake) -> str:
+    parts = [intake.trip_name, *intake.destination_seeds, intake.freeform_notes or ""]
+    return " ".join(parts).lower().replace("_", "-")
+
+
+def _chile_geography(origin_airports: list[TravelAirportRef], text: str) -> TripGeography:
+    locations = [
+        TripMapLocation(
+            name="Santiago",
+            kind="city",
+            country="Chile",
+            iata_code="SCL",
+            use_for=["planning", "lodging", "activity", "car"],
+        ),
+        TripMapLocation(
+            name="Providencia",
+            kind="neighborhood",
+            city="Santiago",
+            country="Chile",
+            use_for=["lodging", "activity", "map"],
+        ),
+        TripMapLocation(
+            name="Bellavista",
+            kind="neighborhood",
+            city="Santiago",
+            country="Chile",
+            use_for=["activity", "map"],
+        ),
+        TripMapLocation(
+            name="Barrio Italia",
+            kind="neighborhood",
+            city="Santiago",
+            country="Chile",
+            use_for=["lodging", "activity", "map"],
+        ),
+        TripMapLocation(
+            name="Maipo Valley",
+            kind="region",
+            region="Santiago Metropolitan Region",
+            country="Chile",
+            use_for=["activity", "map", "car"],
+        ),
+    ]
+    planning_regions = ["Santiago"]
+    activity_locations = ["Santiago", "Providencia", "Bellavista", "Barrio Italia", "Maipo Valley"]
+    lodging_locations = ["Providencia, Santiago, Chile", "Barrio Italia, Santiago, Chile", "Santiago, Chile"]
+    car_locations = ["SCL", "Santiago, Chile", "Maipo Valley, Chile"]
+    in_trip_airports: list[TravelAirportRef] = []
+    if "atacama" in text or "san pedro" in text or "calama" in text:
+        planning_regions.append("Atacama")
+        activity_locations.append("San Pedro de Atacama")
+        lodging_locations.append("San Pedro de Atacama, Chile")
+        car_locations.append("CJC")
+        in_trip_airports.append(
+            TravelAirportRef(
+                iata_code="CJC",
+                name="El Loa Airport",
+                city="Calama",
+                country="Chile",
+                role="in_trip",
+            )
+        )
+        locations.append(
+            TripMapLocation(
+                name="San Pedro de Atacama",
+                kind="town",
+                region="Antofagasta Region",
+                country="Chile",
+                iata_code="CJC",
+                use_for=["planning", "lodging", "activity", "car", "map"],
+            )
+        )
+    if "patagonia" in text or "torres del paine" in text or "punta arenas" in text:
+        planning_regions.append("Patagonia")
+        activity_locations.append("Torres del Paine")
+        lodging_locations.append("Puerto Natales, Chile")
+        car_locations.append("PUQ")
+        in_trip_airports.append(
+            TravelAirportRef(
+                iata_code="PUQ",
+                name="Presidente Carlos Ibanez del Campo International Airport",
+                city="Punta Arenas",
+                country="Chile",
+                role="in_trip",
+            )
+        )
+        locations.append(
+            TripMapLocation(
+                name="Torres del Paine",
+                kind="national_park",
+                region="Patagonia",
+                country="Chile",
+                iata_code="PUQ",
+                use_for=["planning", "lodging", "activity", "car", "map"],
+            )
+        )
+    return TripGeography(
+        primary_destination_name="Santiago, Chile",
+        primary_city="Santiago",
+        country="Chile",
+        departure_airports=origin_airports,
+        destination_airports=[
+            TravelAirportRef(
+                iata_code="SCL",
+                name="Arturo Merino Benitez International Airport",
+                city="Santiago",
+                country="Chile",
+                role="gateway",
+            )
+        ],
+        in_trip_airports=in_trip_airports,
+        map_locations=_dedupe_locations(locations),
+        planning_regions=_dedupe_strings(planning_regions),
+        lodging_search_locations=_dedupe_strings(lodging_locations),
+        car_search_locations=_dedupe_strings(car_locations),
+        activity_search_locations=_dedupe_strings(activity_locations),
+        warnings=[
+            "Chile geography normalized: flight search uses SCL; Santiago neighborhoods and Maipo Valley are map/search locations, not flight route codes."
+        ],
+    )
+
+
+def _azores_geography(origin_airports: list[TravelAirportRef]) -> TripGeography:
+    return TripGeography(
+        primary_destination_name="Azores, Portugal",
+        country="Portugal",
+        departure_airports=origin_airports,
+        destination_airports=[
+            TravelAirportRef(
+                iata_code="PDL",
+                name="Joao Paulo II Airport",
+                city="Ponta Delgada",
+                country="Portugal",
+                role="gateway",
+            )
+        ],
+        in_trip_airports=[
+            TravelAirportRef(iata_code="PIX", city="Pico", country="Portugal", role="in_trip"),
+            TravelAirportRef(iata_code="HOR", city="Horta", country="Portugal", role="in_trip"),
+            TravelAirportRef(iata_code="TER", city="Terceira", country="Portugal", role="in_trip"),
+        ],
+        map_locations=[
+            TripMapLocation(name="Sao Miguel", kind="island", country="Portugal", use_for=["planning", "lodging", "activity", "car", "map"]),
+            TripMapLocation(name="Ponta Delgada", kind="city", country="Portugal", iata_code="PDL", use_for=["lodging", "activity", "car", "map"]),
+            TripMapLocation(name="Pico", kind="island", country="Portugal", iata_code="PIX", use_for=["planning", "lodging", "activity", "car", "map"]),
+            TripMapLocation(name="Faial", kind="island", country="Portugal", iata_code="HOR", use_for=["planning", "lodging", "activity", "car", "map"]),
+            TripMapLocation(name="Terceira", kind="island", country="Portugal", iata_code="TER", use_for=["planning", "lodging", "activity", "car", "map"]),
+        ],
+        planning_regions=["Sao Miguel", "Pico or Faial", "Terceira"],
+        lodging_search_locations=["Ponta Delgada", "Furnas", "Madalena", "Horta", "Angra do Heroismo"],
+        car_search_locations=["PDL", "PIX", "HOR", "TER"],
+        activity_search_locations=["Sao Miguel", "Furnas", "Sete Cidades", "Pico", "Faial", "Terceira"],
+    )
+
+
+def _grand_cayman_geography(origin_airports: list[TravelAirportRef]) -> TripGeography:
+    return TripGeography(
+        primary_destination_name="Grand Cayman, Cayman Islands",
+        country="Cayman Islands",
+        departure_airports=origin_airports,
+        destination_airports=[
+            TravelAirportRef(
+                iata_code="GCM",
+                name="Owen Roberts International Airport",
+                city="George Town",
+                country="Cayman Islands",
+                role="gateway",
+            )
+        ],
+        map_locations=[
+            TripMapLocation(name="Seven Mile Beach", kind="beach", country="Cayman Islands", use_for=["planning", "lodging", "activity", "map"]),
+            TripMapLocation(name="West Bay", kind="district", country="Cayman Islands", use_for=["planning", "lodging", "activity", "map"]),
+            TripMapLocation(name="Rum Point", kind="beach", country="Cayman Islands", use_for=["planning", "lodging", "activity", "map"]),
+            TripMapLocation(name="George Town", kind="city", country="Cayman Islands", iata_code="GCM", use_for=["planning", "lodging", "activity", "car", "map"]),
+        ],
+        planning_regions=["Seven Mile Beach", "West Bay", "Rum Point", "George Town"],
+        lodging_search_locations=["Seven Mile Beach", "West Bay", "Rum Point"],
+        car_search_locations=["GCM", "Seven Mile Beach"],
+        activity_search_locations=["Stingray City", "Seven Mile Beach", "West Bay", "Rum Point"],
+    )
+
+
+def _generic_geography(intake: TripIntake, origin_airports: list[TravelAirportRef]) -> TripGeography:
+    seeds = _dedupe_strings(intake.destination_seeds or [intake.trip_name])
+    destination_airports = [
+        TravelAirportRef(iata_code=seed, role="gateway")
+        for seed in seeds
+        if _looks_like_iata(seed)
+    ]
+    non_airport_seeds = [seed for seed in seeds if not _looks_like_iata(seed)]
+    destination = ", ".join(non_airport_seeds or seeds) or intake.trip_name
+    warnings = []
+    if not destination_airports:
+        warnings.append(
+            "No canonical gateway airport resolved yet; live flight adapters must fail closed until a valid IATA destination is known."
+        )
+    map_locations = [
+        TripMapLocation(name=seed, use_for=["planning", "lodging", "activity", "car", "map"])
+        for seed in non_airport_seeds
+    ]
+    return TripGeography(
+        primary_destination_name=destination,
+        departure_airports=origin_airports,
+        destination_airports=destination_airports,
+        map_locations=map_locations,
+        planning_regions=non_airport_seeds or seeds,
+        lodging_search_locations=non_airport_seeds or seeds,
+        car_search_locations=[*(airport.iata_code for airport in destination_airports), *(non_airport_seeds or seeds)],
+        activity_search_locations=non_airport_seeds or seeds,
+        warnings=warnings,
+    )
+
+
+def _looks_like_iata(value: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z]{3}", value.strip()))
+
+
+def _looks_like_chile_trip(text: str) -> bool:
+    return any(
+        term in text
+        for term in [
+            "chile",
+            "santiago",
+            "providencia",
+            "bellavista",
+            "barrio italia",
+            "barrio-italia",
+            "maipo",
+            "atacama",
+            "patagonia",
+            "torres del paine",
+        ]
+    )
+
+
+def _looks_like_grand_cayman_trip(text: str) -> bool:
+    return any(
+        term in text
+        for term in [
+            "cayman",
+            "seven mile beach",
+            "west bay",
+            "stingray city",
+            "rum point",
+            "grand cayman",
+        ]
+    )
+
+
+def _dedupe_strings(values: list[str] | tuple[str, ...] | object) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:  # type: ignore[operator]
+        text = " ".join(str(value).strip().split())
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(text)
+    return result
+
+
+def _dedupe_locations(locations: list[TripMapLocation]) -> list[TripMapLocation]:
+    seen: set[str] = set()
+    result: list[TripMapLocation] = []
+    for location in locations:
+        key = location.search_label().casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(location)
+    return result
 
 
 def make_trip_slug(name: str) -> str:

--- a/trippy/services/destination_profiles.py
+++ b/trippy/services/destination_profiles.py
@@ -154,7 +154,9 @@ def _chile_profile(intake: TripIntake) -> DestinationProfile:
         title="Santiago, Chile",
         country="Chile",
         gateway_airports=[gateway or "SCL"],
-        island_or_region_terms=regions,
+        # Empty by design: Santiago neighborhoods and side-trip areas should not be filtered
+        # out just because the planner selected one concatenated raw destination string.
+        island_or_region_terms=[],
         flight_notes=[
             "SCL is the canonical international gateway for Santiago/central Chile trips.",
             "Santiago neighborhoods, Barrio Italia, Bellavista, Providencia, and Maipo Valley are map/activity/lodging areas only; never pass them as flight route codes.",

--- a/trippy/services/destination_profiles.py
+++ b/trippy/services/destination_profiles.py
@@ -24,37 +24,61 @@ def profile_for_intake(intake: TripIntake) -> DestinationProfile:
     lower_text = text.lower()
     if "azores" in lower_text:
         return _AZORES
+    if _looks_like_chile(lower_text):
+        return _chile_profile(intake)
     if _looks_like_grand_cayman(lower_text):
         return _GRAND_CAYMAN
-    destination = ", ".join(intake.destination_seeds) or intake.trip_name
+    return _generic_profile(intake)
+
+
+def _generic_profile(intake: TripIntake) -> DestinationProfile:
+    geography = intake.geography
+    destination = (
+        geography.primary_destination_name
+        if geography and geography.primary_destination_name
+        else ", ".join(intake.destination_seeds) or intake.trip_name
+    )
+    gateway_airports = list(geography.destination_airports[0:1]) if geography else []
+    gateway_codes = [airport.iata_code for airport in gateway_airports]
+    regions = geography.region_names() if geography else list(intake.destination_seeds)
+    lodging_locations = geography.lodging_locations() if geography else regions or [destination]
+    car_locations = geography.car_locations() if geography else regions or [destination]
+    activity_locations = geography.activity_locations() if geography else regions or [destination]
+    notes = [
+        "Generic profile: validate gateway airport, seasonal service, and same-ticket routing."
+    ]
+    if geography and geography.warnings:
+        notes.extend(geography.warnings)
+    lodging_targets = [
+        {
+            "name": f"{location} family lodging search",
+            "location_area": location,
+            "island_or_region": location,
+            "lodging_type": "family lodging",
+            "query": f"{location} family lodging 3 beds parking",
+        }
+        for location in lodging_locations[:6]
+    ]
+    car_targets = [
+        {
+            "name": f"{location} family SUV or minivan",
+            "pickup": location,
+            "dropoff": location,
+            "vehicle_class": "SUV or minivan",
+            "query": f"{location} car rental SUV minivan family luggage",
+        }
+        for location in car_locations[:6]
+    ]
     return DestinationProfile(
         key="generic",
         title=destination,
-        country="",
-        gateway_airports=[],
-        island_or_region_terms=list(intake.destination_seeds),
-        flight_notes=[
-            "Generic profile: validate gateway airport, seasonal service, and same-ticket routing."
-        ],
-        lodging_search_targets=[
-            {
-                "name": f"{destination} family lodging search",
-                "location_area": destination,
-                "island_or_region": destination,
-                "lodging_type": "family lodging",
-                "query": f"{destination} family lodging 3 beds parking",
-            }
-        ],
-        car_search_targets=[
-            {
-                "name": f"{destination} airport family SUV or minivan",
-                "pickup": destination,
-                "dropoff": destination,
-                "vehicle_class": "SUV or minivan",
-                "query": f"{destination} car rental SUV minivan family luggage",
-            }
-        ],
-        activity_search_targets=_generic_activity_search_targets(intake, destination),
+        country=geography.country or "" if geography else "",
+        gateway_airports=gateway_codes,
+        island_or_region_terms=regions,
+        flight_notes=notes,
+        lodging_search_targets=lodging_targets,
+        car_search_targets=car_targets,
+        activity_search_targets=_generic_activity_search_targets(intake, destination, activity_locations),
     )
 
 
@@ -72,11 +96,117 @@ def _looks_like_grand_cayman(text: str) -> bool:
     )
 
 
+def _looks_like_chile(text: str) -> bool:
+    return any(
+        term in text
+        for term in [
+            "chile",
+            "santiago",
+            "providencia",
+            "bellavista",
+            "barrio italia",
+            "barrio-italia",
+            "maipo",
+            "atacama",
+            "patagonia",
+            "torres del paine",
+        ]
+    )
+
+
+def _chile_profile(intake: TripIntake) -> DestinationProfile:
+    geography = intake.geography
+    gateway = geography.primary_gateway_iata() if geography else "SCL"
+    regions = geography.region_names() if geography else ["Santiago"]
+    lodging_locations = geography.lodging_locations() if geography else ["Providencia, Santiago, Chile", "Barrio Italia, Santiago, Chile", "Santiago, Chile"]
+    car_locations = geography.car_locations() if geography else ["SCL", "Santiago, Chile", "Maipo Valley, Chile"]
+    activity_locations = geography.activity_locations() if geography else ["Santiago", "Providencia", "Bellavista", "Barrio Italia", "Maipo Valley"]
+    lodging_targets = [
+        {
+            "name": f"{location} family lodging search",
+            "location_area": location,
+            "island_or_region": _region_for_chile_location(location),
+            "lodging_type": "family hotel or apartment",
+            "query": f"{location} family hotel apartment 3 beds safe neighborhood parking",
+        }
+        for location in lodging_locations[:6]
+    ]
+    car_targets = [
+        {
+            "name": f"{location} family SUV or minivan",
+            "pickup": _car_pickup_label(location),
+            "dropoff": _car_pickup_label(location),
+            "vehicle_class": "SUV or minivan",
+            "query": f"{location} car rental automatic SUV minivan family luggage",
+        }
+        for location in car_locations[:6]
+    ]
+    activity_targets = [
+        {
+            "name": f"{location} family-friendly activity search",
+            "location": location,
+            "query": _chile_activity_query(location),
+        }
+        for location in activity_locations[:8]
+    ]
+    return DestinationProfile(
+        key="chile",
+        title="Santiago, Chile",
+        country="Chile",
+        gateway_airports=[gateway or "SCL"],
+        island_or_region_terms=regions,
+        flight_notes=[
+            "SCL is the canonical international gateway for Santiago/central Chile trips.",
+            "Santiago neighborhoods, Barrio Italia, Bellavista, Providencia, and Maipo Valley are map/activity/lodging areas only; never pass them as flight route codes.",
+            "If Atacama or Patagonia are selected, use CJC/PUQ as in-trip domestic airports only after the international gateway is set.",
+            *(geography.warnings if geography else []),
+        ],
+        lodging_search_targets=lodging_targets,
+        car_search_targets=car_targets,
+        activity_search_targets=activity_targets,
+    )
+
+
+def _region_for_chile_location(location: str) -> str:
+    lower = location.lower()
+    if "atacama" in lower:
+        return "Atacama"
+    if "patagonia" in lower or "natales" in lower or "torres" in lower:
+        return "Patagonia"
+    if "maipo" in lower:
+        return "Maipo Valley"
+    return "Santiago"
+
+
+def _car_pickup_label(location: str) -> str:
+    if location.upper() in {"SCL", "CJC", "PUQ"}:
+        return f"{location.upper()} airport"
+    return location
+
+
+def _chile_activity_query(location: str) -> str:
+    lower = location.lower()
+    if "maipo" in lower:
+        return "Maipo Valley small group family wine food day trip from Santiago"
+    if "bellavista" in lower:
+        return "Bellavista Santiago family culture food walking tour"
+    if "barrio italia" in lower:
+        return "Barrio Italia Santiago food design walking tour family"
+    if "providencia" in lower:
+        return "Providencia Santiago family-friendly neighborhood restaurants parks"
+    if "atacama" in lower:
+        return "San Pedro de Atacama family small group desert tour"
+    if "patagonia" in lower or "torres" in lower:
+        return "Torres del Paine family day tour small group"
+    return f"{location} Santiago Chile family friendly guided activity small group"
+
+
 def _generic_activity_search_targets(
     intake: TripIntake,
     destination: str,
+    locations: list[str] | None = None,
 ) -> list[dict[str, str]]:
-    seeds = [seed.strip() for seed in intake.destination_seeds if seed.strip()] or [destination]
+    seeds = [seed.strip() for seed in (locations or intake.destination_seeds) if seed.strip()] or [destination]
     targets: list[dict[str, str]] = []
     for seed in seeds[:5]:
         lower = seed.lower()

--- a/trippy/services/trip_planner.py
+++ b/trippy/services/trip_planner.py
@@ -171,20 +171,34 @@ class TripPlannerService:
 
     def _build_generic_selected_destination_draft(self, intake: TripIntake) -> TripPlanDraft:
         duration = intake.duration_days or 8
-        destination = ", ".join(intake.destination_seeds) or intake.trip_name or "Destination"
-        single_base_region = (
-            intake.destination_seeds[0] if intake.destination_seeds else destination
+        geography = intake.geography
+        geography_regions = geography.region_names() if geography else []
+        planning_regions = geography_regions or [seed for seed in intake.destination_seeds if seed.strip()]
+        destination = (
+            geography.primary_destination_name
+            if geography and geography.primary_destination_name
+            else ", ".join(planning_regions or intake.destination_seeds)
+            or intake.trip_name
+            or "Destination"
         )
-        balanced_regions = intake.destination_seeds[:2] or [single_base_region]
+        map_seed_queries = geography.map_seed_queries() if geography else list(intake.destination_seeds)
+        single_base_region = planning_regions[0] if planning_regions else destination
+        balanced_regions = planning_regions[:2] or [single_base_region]
+        signal_sources = [*intake.destination_seeds, destination]
+        if geography:
+            signal_sources.extend(
+                source for source in [geography.country, geography.primary_destination_name] if source
+            )
         signals = [
             signal.rationale
-            for seed in intake.destination_seeds
+            for seed in signal_sources
             for signal in self._country_priors.fit_for_text(seed)
         ]
         if not signals:
             signals = [
                 "No direct country prior matched; require live evidence and family-fit validation."
             ]
+        fuller_regions = _fuller_regions(planning_regions, single_base_region)
         options = [
             TripPlanOption(
                 option_id="single-base-easy",
@@ -212,7 +226,7 @@ class TripPlannerService:
                 car_strategy=intake.car_rental_expectations.notes
                 or "Validate car need against local roads, parking, and transfer options.",
                 country_prior_signals=signals,
-                map_seed_queries=intake.destination_seeds,
+                map_seed_queries=map_seed_queries,
                 required_research=_required_research(),
             ),
             TripPlanOption(
@@ -237,7 +251,7 @@ class TripPlannerService:
                 lodging_strategy=intake.lodging_preferences.non_city_strategy,
                 car_strategy="Likely local transfer or car rental depending on destination geography.",
                 country_prior_signals=signals,
-                map_seed_queries=intake.destination_seeds,
+                map_seed_queries=map_seed_queries,
                 required_research=_required_research(),
             ),
             TripPlanOption(
@@ -245,11 +259,8 @@ class TripPlannerService:
                 title=f"{destination} Fuller Multi-Spot Version",
                 summary="Keep the destination fixed, but spend time across more distinct areas or activity clusters.",
                 duration_days=duration,
-                regions=_fuller_regions(intake.destination_seeds, single_base_region),
-                nights_by_region=_even_nights(
-                    _fuller_regions(intake.destination_seeds, single_base_region),
-                    duration,
-                ),
+                regions=fuller_regions,
+                nights_by_region=_even_nights(fuller_regions, duration),
                 rationale=[
                     "Useful comparison if the family wants more variety within the chosen destination.",
                     "Only worth choosing if each extra stop materially improves beach, food, activity, or drive-time fit.",
@@ -272,7 +283,7 @@ class TripPlannerService:
                 ),
                 car_strategy="Compare rental-car coverage against private transfers and day-trip operators.",
                 country_prior_signals=signals,
-                map_seed_queries=intake.destination_seeds,
+                map_seed_queries=map_seed_queries,
                 required_research=_required_research()
                 + [
                     "Whether extra local bases improve the trip enough to justify packing and check-in friction.",
@@ -287,7 +298,8 @@ class TripPlannerService:
             options=options,
             recommended_option_id=recommended,
             assumptions=[
-                "Generic selected-destination draft; replace with a destination-specific planner once enough evidence exists."
+                "Generic selected-destination draft uses canonical TripGeography so connector inputs separate airports from map/search locations.",
+                "Replace with a destination-specific planner once enough evidence exists.",
             ],
             source_notes=["Generated without live availability."],
         )


### PR DESCRIPTION
## Summary
- Add canonical `TripGeography` to `TripIntake` so airports, map places, lodging areas, car pickup locations, and activity regions are separated in JSON
- Normalize Chile/Santiago trips so flights use `YYZ -> SCL`, while Providencia, Bellavista, Barrio Italia, and Maipo Valley stay as map/lodging/activity locations
- Add a Chile destination profile and update generic destination profiles to read from canonical geography instead of raw destination strings
- Update generic selected-destination planning so downstream connectors see normalized regions like `Santiago` instead of concatenated raw form text
- Add regression tests for the exact bad Chile route string that previously reached Duffel

## Why
The app was passing a place/activity blob into flight search:

```text
YYZ -> SANTIAGO-PROVIDENCIA-SANTIAGO-BELLAVISTA-SANTIAGO-BARRIO-ITALIA-MAIPO-VALLEY
```

Duffel correctly rejected it because only IATA route codes should reach flight APIs. This PR moves that constraint upstream so the same kind of bug does not leak into lodging, cars, activities, or map search.

## Connector contract after this PR
```json
{
  "departure_airports": [{ "iata_code": "YYZ", "role": "origin" }],
  "destination_airports": [{ "iata_code": "SCL", "city": "Santiago", "country": "Chile", "role": "gateway" }],
  "map_locations": [
    { "name": "Santiago", "kind": "city", "country": "Chile", "iata_code": "SCL" },
    { "name": "Providencia", "kind": "neighborhood", "city": "Santiago", "country": "Chile" },
    { "name": "Bellavista", "kind": "neighborhood", "city": "Santiago", "country": "Chile" },
    { "name": "Barrio Italia", "kind": "neighborhood", "city": "Santiago", "country": "Chile" },
    { "name": "Maipo Valley", "kind": "region", "country": "Chile" }
  ],
  "planning_regions": ["Santiago"],
  "lodging_search_locations": ["Providencia, Santiago, Chile", "Barrio Italia, Santiago, Chile", "Santiago, Chile"],
  "car_search_locations": ["SCL", "Santiago, Chile", "Maipo Valley, Chile"],
  "activity_search_locations": ["Santiago", "Providencia", "Bellavista", "Barrio Italia", "Maipo Valley"]
}
```

## Test plan
- Added `tests/unit/test_trip_geography.py`
- Tests assert Chile maps to `SCL`, does not produce the concatenated blob as an airport code, and keeps neighborhoods/wine regions available for non-flight connectors

Note: I was not able to run the repo test suite from this environment, so CI/local `pytest tests/unit/test_trip_geography.py` should be run before merge.