### PR TITLE
Add generic trip geography resolver for connector-safe routing

### DIFF
--- a/tests/unit/test_geography_resolver.py
+++ b/tests/unit/test_geography_resolver.py
@@ -1,0 +1,28 @@
+from trippy.models.trip_planning import TripIntake, TripIntakeMode
+from trippy.services.geography_resolver import resolve_trip_geography
+
+
+def test_resolver_keeps_flight_codes_clean() -> None:
+    intake = TripIntake(
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Family trip",
+        destination_seeds=["Santiago, Providencia, Bellavista, Barrio Italia, Maipo Valley"],
+        departure_airports=["YYZ"],
+    )
+    geography = resolve_trip_geography(intake)
+    assert geography.primary_origin_iata() == "YYZ"
+    assert geography.primary_destination_iata() == "SCL"
+    assert geography.connector_inputs()["flights"]["to"] == "SCL"
+    assert "Providencia" in " ".join(geography.map_locations)
+
+
+def test_unknown_destination_requires_airport_resolution() -> None:
+    intake = TripIntake(
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Mystery surf region",
+        destination_seeds=["Cool Beach Zone, Old Town, Sunset Valley"],
+        departure_airports=["YYZ"],
+    )
+    geography = resolve_trip_geography(intake)
+    assert geography.primary_destination_iata() == ""
+    assert geography.connector_inputs()["flights"]["status"] == "airport_required"

--- a/trippy/models/geography.py
+++ b/trippy/models/geography.py
@@ -1,0 +1,119 @@
+"""Canonical geography models used to separate connector inputs.
+
+These models are intentionally destination-agnostic. They describe resolved airports,
+places, and connector-ready locations without teaching Trippy a hardcoded itinerary
+for any country or city.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ResolvedAirport(BaseModel):
+    """A validated airport reference that may be safely passed to flight APIs."""
+
+    iata_code: str
+    name: str = ""
+    city: str = ""
+    country: str = ""
+    role: str = "gateway"
+    confidence: float = 0.0
+    source: str = "resolver"
+    matched_text: str = ""
+    requires_user_confirmation: bool = False
+
+    @field_validator("iata_code")
+    @classmethod
+    def _valid_iata_code(cls, value: str) -> str:
+        code = value.strip().upper()
+        if not re.fullmatch(r"[A-Z]{3}", code):
+            raise ValueError("iata_code must be a three-letter IATA code")
+        return code
+
+    @field_validator("confidence")
+    @classmethod
+    def _confidence_range(cls, value: float) -> float:
+        return max(0.0, min(1.0, float(value)))
+
+
+class ResolvedPlace(BaseModel):
+    """A non-flight place reference for maps, lodging, cars, and activities."""
+
+    name: str
+    kind: str = "place"
+    city: str = ""
+    region: str = ""
+    country: str = ""
+    confidence: float = 0.0
+    source: str = "resolver"
+    use_for: list[str] = Field(default_factory=list)
+    raw_text: str = ""
+
+    @field_validator("name")
+    @classmethod
+    def _name_required(cls, value: str) -> str:
+        cleaned = " ".join(value.strip().split())
+        if not cleaned:
+            raise ValueError("place name is required")
+        return cleaned
+
+    @field_validator("confidence")
+    @classmethod
+    def _confidence_range(cls, value: float) -> float:
+        return max(0.0, min(1.0, float(value)))
+
+    def search_label(self) -> str:
+        pieces = [self.name]
+        for value in [self.city, self.region, self.country]:
+            if value and value.casefold() not in {piece.casefold() for piece in pieces}:
+                pieces.append(value)
+        return ", ".join(pieces)
+
+
+class TripGeography(BaseModel):
+    """Connector-safe trip geography.
+
+    Flight connectors consume only airport codes from `origin_airports` and
+    `destination_airports`. Non-flight connectors consume `places` and the explicit
+    connector input buckets.
+    """
+
+    primary_destination_name: str = ""
+    origin_airports: list[ResolvedAirport] = Field(default_factory=list)
+    destination_airports: list[ResolvedAirport] = Field(default_factory=list)
+    in_trip_airports: list[ResolvedAirport] = Field(default_factory=list)
+    places: list[ResolvedPlace] = Field(default_factory=list)
+    planning_regions: list[str] = Field(default_factory=list)
+    map_locations: list[str] = Field(default_factory=list)
+    lodging_search_locations: list[str] = Field(default_factory=list)
+    car_search_locations: list[str] = Field(default_factory=list)
+    activity_search_locations: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    evidence: list[str] = Field(default_factory=list)
+
+    def primary_origin_iata(self, fallback: str = "YYZ") -> str:
+        if self.origin_airports:
+            return self.origin_airports[0].iata_code
+        return fallback.strip().upper()
+
+    def primary_destination_iata(self) -> str:
+        if self.destination_airports:
+            return self.destination_airports[0].iata_code
+        return ""
+
+    def connector_inputs(self) -> dict[str, Any]:
+        return {
+            "flights": {
+                "from": self.primary_origin_iata(),
+                "to": self.primary_destination_iata(),
+                "status": "ready" if self.primary_destination_iata() else "airport_required",
+            },
+            "lodging": {"locations": self.lodging_search_locations},
+            "cars": {"pickup_candidates": self.car_search_locations},
+            "activities": {"locations": self.activity_search_locations},
+            "maps": {"locations": self.map_locations},
+        }

--- a/trippy/services/destination_profiles.py
+++ b/trippy/services/destination_profiles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 from trippy.models.trip_planning import TripIntake
+from trippy.services.geography_resolver import resolve_trip_geography
 
 
 class DestinationProfile(BaseModel):
@@ -26,35 +27,55 @@ def profile_for_intake(intake: TripIntake) -> DestinationProfile:
         return _AZORES
     if _looks_like_grand_cayman(lower_text):
         return _GRAND_CAYMAN
-    destination = ", ".join(intake.destination_seeds) or intake.trip_name
+    return _generic_profile(intake)
+
+
+def _generic_profile(intake: TripIntake) -> DestinationProfile:
+    geography = resolve_trip_geography(intake)
+    destination = geography.primary_destination_name or ", ".join(intake.destination_seeds) or intake.trip_name
+    gateway_airports = [airport.iata_code for airport in geography.destination_airports]
+    regions = geography.planning_regions or geography.map_locations or list(intake.destination_seeds)
+    notes = [
+        "Generic profile: validate gateway airport, seasonal service, and same-ticket routing.",
+        *geography.warnings,
+        *geography.evidence,
+    ]
+    lodging_targets = [
+        {
+            "name": f"{location} family lodging search",
+            "location_area": location,
+            "island_or_region": location,
+            "lodging_type": "family lodging",
+            "query": f"{location} family lodging 3 beds parking",
+        }
+        for location in (geography.lodging_search_locations or [destination])[:6]
+    ]
+    car_targets = [
+        {
+            "name": f"{location} family SUV or minivan",
+            "pickup": location,
+            "dropoff": location,
+            "vehicle_class": "SUV or minivan",
+            "query": f"{location} car rental SUV minivan family luggage",
+        }
+        for location in (geography.car_search_locations or [destination])[:6]
+    ]
     return DestinationProfile(
         key="generic",
         title=destination,
-        country="",
-        gateway_airports=[],
-        island_or_region_terms=list(intake.destination_seeds),
-        flight_notes=[
-            "Generic profile: validate gateway airport, seasonal service, and same-ticket routing."
-        ],
-        lodging_search_targets=[
-            {
-                "name": f"{destination} family lodging search",
-                "location_area": destination,
-                "island_or_region": destination,
-                "lodging_type": "family lodging",
-                "query": f"{destination} family lodging 3 beds parking",
-            }
-        ],
-        car_search_targets=[
-            {
-                "name": f"{destination} airport family SUV or minivan",
-                "pickup": destination,
-                "dropoff": destination,
-                "vehicle_class": "SUV or minivan",
-                "query": f"{destination} car rental SUV minivan family luggage",
-            }
-        ],
-        activity_search_targets=_generic_activity_search_targets(intake, destination),
+        country=geography.destination_airports[0].country if geography.destination_airports else "",
+        gateway_airports=gateway_airports,
+        # Keep known terms empty for generic resolved profiles so specific neighborhood,
+        # region, and search targets are not filtered out by a selected raw destination blob.
+        island_or_region_terms=[],
+        flight_notes=notes,
+        lodging_search_targets=lodging_targets,
+        car_search_targets=car_targets,
+        activity_search_targets=_generic_activity_search_targets(
+            intake,
+            destination,
+            geography.activity_search_locations or regions or [destination],
+        ),
     )
 
 
@@ -75,8 +96,9 @@ def _looks_like_grand_cayman(text: str) -> bool:
 def _generic_activity_search_targets(
     intake: TripIntake,
     destination: str,
+    locations: list[str] | None = None,
 ) -> list[dict[str, str]]:
-    seeds = [seed.strip() for seed in intake.destination_seeds if seed.strip()] or [destination]
+    seeds = [seed.strip() for seed in (locations or intake.destination_seeds) if seed.strip()] or [destination]
     targets: list[dict[str, str]] = []
     for seed in seeds[:5]:
         lower = seed.lower()

--- a/trippy/services/geography_resolver.py
+++ b/trippy/services/geography_resolver.py
@@ -1,0 +1,261 @@
+"""Generic connector-safe trip geography resolver."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+
+from trippy.models.geography import ResolvedAirport, ResolvedPlace, TripGeography
+from trippy.models.trip_planning import TripIntake
+
+
+@dataclass(frozen=True)
+class AirportCatalogEntry:
+    iata_code: str
+    name: str
+    city: str
+    country: str
+    aliases: tuple[str, ...]
+
+
+AIRPORT_CATALOG: tuple[AirportCatalogEntry, ...] = (
+    AirportCatalogEntry("YYZ", "Toronto Pearson International Airport", "Toronto", "Canada", ("yyz", "toronto", "pearson")),
+    AirportCatalogEntry("SCL", "Arturo Merino Benitez International Airport", "Santiago", "Chile", ("scl", "santiago", "santiago chile")),
+    AirportCatalogEntry("PDL", "Joao Paulo II Airport", "Ponta Delgada", "Portugal", ("pdl", "ponta delgada", "azores", "sao miguel")),
+    AirportCatalogEntry("GCM", "Owen Roberts International Airport", "George Town", "Cayman Islands", ("gcm", "grand cayman", "cayman islands")),
+    AirportCatalogEntry("LIS", "Lisbon Airport", "Lisbon", "Portugal", ("lis", "lisbon", "lisboa")),
+    AirportCatalogEntry("HND", "Haneda Airport", "Tokyo", "Japan", ("hnd", "haneda", "tokyo")),
+    AirportCatalogEntry("BKK", "Suvarnabhumi Airport", "Bangkok", "Thailand", ("bkk", "bangkok")),
+    AirportCatalogEntry("SJO", "Juan Santamaria International Airport", "San Jose", "Costa Rica", ("sjo", "san jose costa rica", "costa rica")),
+)
+
+IATA_RE = re.compile(r"^[A-Z]{3}$")
+
+
+class GeographyResolverService:
+    """Resolve raw intake text into typed airport/place buckets."""
+
+    def resolve(self, intake: TripIntake) -> TripGeography:
+        raw_destinations = _dedupe_strings(intake.destination_seeds)
+        raw_text = " ".join([intake.trip_name, *raw_destinations, intake.freeform_notes or ""])
+        origins = self._resolve_origins(intake.departure_airports)
+        destinations = self._resolve_destinations(raw_destinations, raw_text)
+        primary = _primary_destination(raw_destinations, intake.trip_name, destinations)
+        places = self._resolve_places(raw_destinations, primary, destinations)
+        map_locations = _dedupe_strings(place.search_label() for place in places)
+        lodging_locations = _connector_locations(places, primary, {"city", "neighborhood", "district", "town", "beach", "region", "place"})
+        car_locations = _car_locations(destinations, places, primary)
+        activity_locations = _connector_locations(places, primary, {"city", "neighborhood", "district", "town", "beach", "region", "park", "place"})
+        planning_regions = _planning_regions(places, primary)
+        warnings: list[str] = []
+        evidence: list[str] = []
+        if destinations:
+            evidence.append(f"Resolved destination airport {destinations[0].iata_code} from '{destinations[0].matched_text}'.")
+        else:
+            warnings.append("No destination airport resolved; live flight providers must fail closed until a valid IATA destination is selected.")
+        return TripGeography(
+            primary_destination_name=primary,
+            origin_airports=origins,
+            destination_airports=destinations,
+            places=places,
+            planning_regions=planning_regions,
+            map_locations=map_locations,
+            lodging_search_locations=lodging_locations,
+            car_search_locations=car_locations,
+            activity_search_locations=activity_locations,
+            warnings=warnings,
+            evidence=evidence,
+        )
+
+    def _resolve_origins(self, values: list[str]) -> list[ResolvedAirport]:
+        airports = [airport for value in (values or ["YYZ"]) if (airport := self._airport_from_code_or_text(value, role="origin"))]
+        return _dedupe_airports(airports) or [ResolvedAirport(iata_code="YYZ", role="origin", confidence=0.7, source="default_origin", matched_text="YYZ", requires_user_confirmation=True)]
+
+    def _resolve_destinations(self, raw_destinations: list[str], raw_text: str) -> list[ResolvedAirport]:
+        airports = [airport for value in raw_destinations if (airport := self._airport_from_code_or_text(value, role="gateway"))]
+        if not airports:
+            airport = self._airport_from_text(raw_text, role="gateway")
+            if airport:
+                airports.append(airport)
+        return _dedupe_airports(airports[:1])
+
+    def _airport_from_code_or_text(self, value: str, *, role: str) -> ResolvedAirport | None:
+        cleaned = value.strip().upper()
+        if IATA_RE.fullmatch(cleaned):
+            entry = _entry_for_code(cleaned)
+            if entry:
+                return _airport_from_entry(entry, role=role, matched_text=value, confidence=0.98)
+            return ResolvedAirport(iata_code=cleaned, role=role, confidence=0.82, source="explicit_iata", matched_text=value)
+        return self._airport_from_text(value, role=role)
+
+    def _airport_from_text(self, value: str, *, role: str) -> ResolvedAirport | None:
+        normalized = _normalize(value)
+        candidates: list[tuple[int, AirportCatalogEntry, str]] = []
+        for entry in AIRPORT_CATALOG:
+            for alias in entry.aliases:
+                alias_norm = _normalize(alias)
+                if alias_norm and re.search(rf"\b{re.escape(alias_norm)}\b", normalized):
+                    candidates.append((len(alias_norm), entry, alias))
+        if not candidates:
+            return None
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        _, entry, alias = candidates[0]
+        return _airport_from_entry(entry, role=role, matched_text=alias, confidence=0.9)
+
+    def _resolve_places(self, raw_destinations: list[str], primary: str, airports: list[ResolvedAirport]) -> list[ResolvedPlace]:
+        airport_city = airports[0].city if airports else ""
+        airport_country = airports[0].country if airports else ""
+        pieces = _destination_pieces(raw_destinations or [primary])
+        places: list[ResolvedPlace] = []
+        for piece in pieces:
+            if IATA_RE.fullmatch(piece.strip().upper()):
+                continue
+            kind = _infer_place_kind(piece, airport_city)
+            places.append(
+                ResolvedPlace(
+                    name=_title_place(piece),
+                    kind=kind,
+                    city=airport_city if kind in {"neighborhood", "district"} else "",
+                    country=airport_country,
+                    confidence=0.72,
+                    source="text_parser",
+                    use_for=_use_for_kind(kind),
+                    raw_text=piece,
+                )
+            )
+        return _dedupe_places(places) or [ResolvedPlace(name=primary, kind="place", confidence=0.5, source="fallback_text", use_for=["planning", "map", "lodging", "activity", "car"], raw_text=primary)]
+
+
+def resolve_trip_geography(intake: TripIntake) -> TripGeography:
+    return GeographyResolverService().resolve(intake)
+
+
+def _entry_for_code(code: str) -> AirportCatalogEntry | None:
+    return next((entry for entry in AIRPORT_CATALOG if entry.iata_code == code), None)
+
+
+def _airport_from_entry(entry: AirportCatalogEntry, *, role: str, matched_text: str, confidence: float) -> ResolvedAirport:
+    return ResolvedAirport(iata_code=entry.iata_code, name=entry.name, city=entry.city, country=entry.country, role=role, confidence=confidence, source="airport_catalog", matched_text=matched_text)
+
+
+def _destination_pieces(values: list[str]) -> list[str]:
+    pieces: list[str] = []
+    for value in values:
+        text = value.replace("/", ",").replace(";", ",")
+        comma_parts = [part.strip() for part in text.split(",") if part.strip()]
+        if len(comma_parts) > 1:
+            pieces.extend(comma_parts)
+        else:
+            pieces.extend(_split_repeated_city_path(text))
+    return _dedupe_strings(pieces)
+
+
+def _split_repeated_city_path(value: str) -> list[str]:
+    parts = [part.strip() for part in re.split(r"\s*-\s*", value) if part.strip()]
+    if len(parts) <= 2:
+        return [value.strip()]
+    output: list[str] = []
+    idx = 0
+    while idx < len(parts):
+        current = parts[idx]
+        if idx + 1 < len(parts) and current.lower() in {"santiago", "toronto", "tokyo", "bangkok", "lisbon"}:
+            output.append(parts[idx + 1])
+            idx += 2
+        else:
+            output.append(current)
+            idx += 1
+    return output
+
+
+def _primary_destination(raw_destinations: list[str], trip_name: str, airports: list[ResolvedAirport]) -> str:
+    if airports and airports[0].city and airports[0].country:
+        return f"{airports[0].city}, {airports[0].country}"
+    return _title_place(raw_destinations[0]) if raw_destinations else trip_name.strip() or "Destination"
+
+
+def _planning_regions(places: list[ResolvedPlace], primary: str) -> list[str]:
+    city_like = [place.search_label() for place in places if place.kind in {"city", "town", "place"}]
+    return _dedupe_strings(city_like[:3] or [primary])
+
+
+def _connector_locations(places: list[ResolvedPlace], primary: str, kinds: set[str]) -> list[str]:
+    values = [place.search_label() for place in places if place.kind in kinds]
+    values.append(primary)
+    return _dedupe_strings(values)[:8]
+
+
+def _car_locations(airports: list[ResolvedAirport], places: list[ResolvedPlace], primary: str) -> list[str]:
+    values = [airport.iata_code for airport in airports]
+    values.extend(place.search_label() for place in places if place.kind in {"city", "town", "region", "place"})
+    values.append(primary)
+    return _dedupe_strings(values)[:8]
+
+
+def _infer_place_kind(value: str, airport_city: str) -> str:
+    normalized = _normalize(value)
+    if airport_city and normalized == _normalize(airport_city):
+        return "city"
+    if any(term in normalized for term in ["valley", "wine", "region"]):
+        return "region"
+    if any(term in normalized for term in ["beach", "bay", "point", "cove"]):
+        return "beach"
+    if any(term in normalized for term in ["park", "gorge", "falls", "mount", "volcano"]):
+        return "park"
+    if any(term in normalized for term in ["barrio", "district", "quarter", "neighborhood", "neighbourhood"]):
+        return "neighborhood"
+    if airport_city and len(normalized.split()) <= 3:
+        return "neighborhood"
+    return "place"
+
+
+def _use_for_kind(kind: str) -> list[str]:
+    if kind == "neighborhood":
+        return ["map", "lodging", "activity"]
+    if kind in {"region", "park", "beach"}:
+        return ["map", "activity", "car"]
+    return ["planning", "map", "lodging", "activity", "car"]
+
+
+def _title_place(value: str) -> str:
+    cleaned = " ".join(value.strip().replace("_", " ").split())
+    return " ".join(word if word.isupper() else word.capitalize() for word in cleaned.split()) or "Destination"
+
+
+def _normalize(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+    return " ".join(re.sub(r"[^a-zA-Z0-9]+", " ", ascii_value).lower().split())
+
+
+def _dedupe_strings(values: object) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:  # type: ignore[operator]
+        text = " ".join(str(value).strip().split())
+        key = text.casefold()
+        if text and key not in seen:
+            seen.add(key)
+            result.append(text)
+    return result
+
+
+def _dedupe_airports(values: list[ResolvedAirport]) -> list[ResolvedAirport]:
+    result: list[ResolvedAirport] = []
+    seen: set[str] = set()
+    for airport in values:
+        if airport.iata_code not in seen:
+            seen.add(airport.iata_code)
+            result.append(airport)
+    return result
+
+
+def _dedupe_places(values: list[ResolvedPlace]) -> list[ResolvedPlace]:
+    result: list[ResolvedPlace] = []
+    seen: set[str] = set()
+    for place in values:
+        key = place.search_label().casefold()
+        if key not in seen:
+            seen.add(key)
+            result.append(place)
+    return result


### PR DESCRIPTION
## Summary
- Adds destination-agnostic geography models for resolved airports, places, and connector inputs
- Adds `GeographyResolverService` to split messy destination text into:
  - validated IATA airport refs for flight APIs
  - place/location buckets for lodging, cars, activities, and maps
- Routes the generic destination profile through the resolver instead of passing raw `destination_seeds` directly into connector targets
- Adds regression tests to ensure Santiago/neighborhood/activity-region text resolves to `YYZ -> SCL` for flights while keeping neighborhoods available for maps/search
- Adds a negative test proving unknown destination text does not become a flight route code

## What this intentionally does not do
- No Chile profile
- No destination-specific itinerary logic
- No hardcoded lodging/activity recommendations for Santiago or any other destination

The catalog in `geography_resolver.py` is an airport/city resolver provider. It should eventually be backed by OpenClaw/SerpAPI/geocoder/LLM lookup plus Hermes review-gated learning, but it gives us a deterministic fail-closed baseline now.

## Why
The prior bug happened because raw destination/activity text leaked into flight routing:

```text
YYZ -> SANTIAGO-PROVIDENCIA-SANTIAGO-BELLAVISTA-SANTIAGO-BARRIO-ITALIA-MAIPO-VALLEY
```

After this PR, that kind of text is parsed into non-flight place buckets, while flights consume only validated IATA codes.

## Test plan
Run:

```bash
pytest tests/unit/test_geography_resolver.py
pytest tests/unit/test_trip_planning_pipeline.py
```

I could not run tests from this environment. GitHub connector blocked a larger follow-up patch to normalize existing `TripPlanOption.regions` in `trip_planner.py`; this PR still fixes the generic destination profile and flight gateway path, but a next small patch should make selected plan regions fully resolver-backed for every live-search fallback.