### PR TITLE
Refactor destination profiles to use generalized geography

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ trippy/
     travel_intelligence.py Past-trip intelligence extraction
     trip_ideation.py    Family-fit trip concept scoring
     trip_intake.py      New-trip intake persistence
-    trip_planner.py     Deterministic trip planning drafts, including Azores golden path
+    trip_planner.py     Deterministic trip planning drafts from canonical JSON geography
     trip_workspace.py   Canonical trip + hydrated planning workspace + Master Timeline creation
     trip_map_builder.py Planning map artifacts from selected plan options
     flight_shortlist.py Source-linked flight recommendation shortlists
@@ -117,17 +117,17 @@ uv run trippy learn review
 # Generate ranked family-fit trip concepts
 uv run trippy trip-ideas --time "March break" --days 9 --goal food --goal culture --avoid crowds
 
-# Plan a selected destination with the Azores golden path
-uv run trippy trip-intake wizard --no-prompt --trip-name "Azores 2027" --destination Azores --travel-window "summer 2027" --days "9 to 11 days" --party-type whole_family --adults 2 --children 3 --child-age 15 --child-age 12 --child-age 10 --goal nature --goal food
-uv run trippy trip-plan draft --trip-id azores-2027
-uv run trippy trip-plan select --trip-id azores-2027 --option-id azores-two-island-balanced
-uv run trippy trip-plan workspace --trip-id azores-2027
-uv run trippy trip-map build --trip-id azores-2027
-uv run trippy trip-plan flights --trip-id azores-2027
-uv run trippy trip-plan lodging --trip-id azores-2027 --deep-research --adapter auto
-uv run trippy trip-plan cars --trip-id azores-2027
-uv run trippy trip-plan activities --trip-id azores-2027
-uv run trippy trip-plan propose-learning --trip-id azores-2027
+# Plan a selected destination from JSON-first geography
+uv run trippy trip-intake wizard --no-prompt --trip-name "Summer family trip" --destination "Primary city, preferred neighborhood, day trip area" --travel-window "summer 2027" --days "9 to 11 days" --party-type whole_family --adults 2 --children 3 --child-age 15 --child-age 12 --child-age 10 --goal nature --goal food
+uv run trippy trip-plan draft --trip-id summer-family-trip
+uv run trippy trip-plan select --trip-id summer-family-trip --option-id two-region-balanced
+uv run trippy trip-plan workspace --trip-id summer-family-trip
+uv run trippy trip-map build --trip-id summer-family-trip
+uv run trippy trip-plan flights --trip-id summer-family-trip
+uv run trippy trip-plan lodging --trip-id summer-family-trip --deep-research --adapter auto
+uv run trippy trip-plan cars --trip-id summer-family-trip
+uv run trippy trip-plan activities --trip-id summer-family-trip
+uv run trippy trip-plan propose-learning --trip-id summer-family-trip
 
 # Duration accepts exact or fuzzy values: --days 10, --days "6 to 8 days", --duration "about a week"
 # Named rosters are repeatable: --traveler "Ken|adult" --traveler "Child 1|12"

--- a/tests/unit/test_firecrawl.py
+++ b/tests/unit/test_firecrawl.py
@@ -318,7 +318,7 @@ def test_firecrawl_merges_into_shortlist_pipeline(
     intake = TripIntake(
         mode=TripIntakeMode.SELECTED_DESTINATION,
         trip_name="Azores Firecrawl 2027",
-        destination_seeds=["Azores"],
+        destination_seeds=["PDL", "Ponta Delgada", "Furnas"],
         travel_window=TravelWindow(label="summer 2027"),
         duration_days=9,
         travelers=5,
@@ -340,7 +340,7 @@ def test_firecrawl_merges_into_shortlist_pipeline(
     created = intake_service.create(intake)
     planner = TripPlannerService(intake_service)
     planner.draft(created.trip_id)
-    planner.select_option(created.trip_id, "azores-two-island-balanced")
+    planner.select_option(created.trip_id, "two-region-balanced")
     state: ResearchShortlistState = FlightShortlistService(intake_service, planner).build(
         created.trip_id
     )

--- a/tests/unit/test_geography_resolver.py
+++ b/tests/unit/test_geography_resolver.py
@@ -6,7 +6,7 @@ def test_resolver_keeps_flight_codes_clean() -> None:
     intake = TripIntake(
         mode=TripIntakeMode.SELECTED_DESTINATION,
         trip_name="Family trip",
-        destination_seeds=["Santiago, Providencia, Bellavista, Barrio Italia, Maipo Valley"],
+        destination_seeds=["SCL, Providencia, Bellavista, Barrio Italia, Maipo Valley"],
         departure_airports=["YYZ"],
     )
     geography = resolve_trip_geography(intake)

--- a/tests/unit/test_openclaw_adapter.py
+++ b/tests/unit/test_openclaw_adapter.py
@@ -29,10 +29,13 @@ from trippy.models.source_research import (
     SourceResearchStatus,
 )
 from trippy.models.trip_planning import (
+    TravelAirportRef,
     TravelerAgeBand,
     TravelWindow,
+    TripGeography,
     TripIntake,
     TripIntakeMode,
+    TripMapLocation,
     TripParty,
     TripPartyType,
     TripTraveler,
@@ -94,6 +97,28 @@ def _azores_intake() -> TripIntake:
             sleeping_considerations="At least 3 beds.",
         ),
         departure_airports=["YYZ"],
+        geography=TripGeography(
+            primary_destination_name="Azores, Portugal",
+            country="Portugal",
+            destination_airports=[
+                TravelAirportRef(iata_code="PDL", city="Ponta Delgada", country="Portugal")
+            ],
+            map_locations=[
+                TripMapLocation(
+                    name="Ponta Delgada",
+                    country="Portugal",
+                    use_for=["planning", "lodging", "activity", "car", "map"],
+                ),
+                TripMapLocation(
+                    name="Furnas",
+                    country="Portugal",
+                    use_for=["planning", "lodging", "activity", "map"],
+                ),
+            ],
+            lodging_search_locations=["Ponta Delgada", "Furnas"],
+            activity_search_locations=["Ponta Delgada", "Furnas"],
+            car_search_locations=["PDL"],
+        ),
         goals=["nature", "family comfort"],
         avoidances=["overpacked days"],
         freeform_notes="OpenClaw test fixture.",
@@ -290,7 +315,7 @@ def test_openclaw_flight_extraction_maps_key_fields(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     payload = {
         "observations": [
@@ -330,7 +355,7 @@ def test_openclaw_lodging_extraction_maps_key_fields(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     payload = {
         "observations": [
@@ -365,7 +390,7 @@ def test_auto_lodging_falls_through_firecrawl_when_price_missing(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     lodging = LodgingShortlistService(intake_service, planner).build(intake.trip_id)
     target = lodging.lodging_options[0]
 
@@ -417,7 +442,7 @@ def test_openclaw_car_extraction_maps_key_fields(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     payload = {
         "observations": [
@@ -456,7 +481,7 @@ def test_openclaw_activity_extraction_maps_key_fields(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     payload = {
         "observations": [
@@ -490,7 +515,7 @@ def test_link_only_row_remains_handoff_not_live_verified(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     lodging = LodgingShortlistService(intake_service, planner).build(intake.trip_id)
 
     service = SourceResearchService(
@@ -787,7 +812,7 @@ def test_playwright_car_adapter_extracts_signals(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     cars = CarShortlistService(intake_service, planner).build(intake.trip_id)
 
     fixture_html = """
@@ -828,7 +853,7 @@ def test_playwright_car_adapter_falls_back_to_link_on_fetch_error(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     cars = CarShortlistService(intake_service, planner).build(intake.trip_id)
 
     service = SourceResearchService(

--- a/tests/unit/test_trip_geography.py
+++ b/tests/unit/test_trip_geography.py
@@ -1,74 +1,118 @@
-"""Regression tests for canonical trip geography and connector-safe locations."""
+"""Architecture tests for JSON-first trip geography."""
 
 from __future__ import annotations
 
-from trippy.models.trip_planning import TripIntake, TripIntakeMode
+from trippy.models.trip_planning import (
+    TravelAirportRef,
+    TripGeography,
+    TripIntake,
+    TripIntakeMode,
+    TripMapLocation,
+)
 from trippy.services.destination_profiles import profile_for_intake
 
 
-def test_chile_geography_separates_flight_airport_from_neighborhoods() -> None:
+def test_brain_dump_creates_unresolved_places_not_inferred_airports() -> None:
     intake = TripIntake(
         mode=TripIntakeMode.SELECTED_DESTINATION,
         trip_name="Chile family trip",
-        destination_seeds=[
-            "Santiago-Providencia-Santiago-Bellavista-Santiago-Barrio-Italia-Maipo-Valley"
-        ],
-        departure_airports=["YYZ"],
-        duration_days=8,
-    )
-
-    assert intake.geography is not None
-    assert intake.geography.primary_origin_iata() == "YYZ"
-    assert intake.geography.primary_gateway_iata() == "SCL"
-    assert [airport.iata_code for airport in intake.geography.destination_airports] == ["SCL"]
-    assert "SANTIAGO-PROVIDENCIA" not in intake.geography.all_airport_codes()
-
-    map_queries = intake.geography.map_seed_queries()
-    assert any("Providencia" in query for query in map_queries)
-    assert any("Bellavista" in query for query in map_queries)
-    assert any("Barrio Italia" in query for query in map_queries)
-    assert any("Maipo Valley" in query for query in map_queries)
-
-
-def test_destination_profile_is_geography_driven_not_destination_hardcoded() -> None:
-    intake = TripIntake(
-        mode=TripIntakeMode.SELECTED_DESTINATION,
-        trip_name="Chile",
         destination_seeds=["Santiago, Providencia, Bellavista, Barrio Italia, Maipo Valley"],
         departure_airports=["YYZ"],
     )
 
+    assert intake.geography is not None
+    assert intake.geography.destination_airports == []
+    assert intake.geography.primary_origin_iata() == "YYZ"
+
+    place_names = [location.name for location in intake.geography.map_locations]
+    assert place_names == [
+        "Santiago",
+        "Providencia",
+        "Bellavista",
+        "Barrio Italia",
+        "Maipo Valley",
+    ]
+
     profile = profile_for_intake(intake)
-
-    assert profile.key == "resolved-geography"
-    assert profile.gateway_airports == ["SCL"]
-    assert all(len(code) == 3 and code.isupper() for code in profile.gateway_airports)
-    assert any("canonical geography" in note.lower() for note in profile.flight_notes)
-
-    lodging_text = " ".join(str(target) for target in profile.lodging_search_targets)
-    car_text = " ".join(str(target) for target in profile.car_search_targets)
-    activity_text = " ".join(str(target) for target in profile.activity_search_targets)
-
-    assert "Providencia" in lodging_text
-    assert "Barrio Italia" in lodging_text
-    assert "SCL" in car_text
-    assert "Maipo Valley" in activity_text
-    assert "SANTIAGO-PROVIDENCIA-SANTIAGO-BELLAVISTA" not in car_text
+    assert profile.gateway_airports == []
+    assert any("fail closed" in note.lower() for note in profile.flight_notes)
+    assert any("Santiago" in str(target) for target in profile.lodging_search_targets)
+    assert any("Maipo Valley" in str(target) for target in profile.activity_search_targets)
 
 
-def test_unresolved_generic_destination_fails_closed_for_flights_but_keeps_place_targets() -> None:
+def test_explicit_iata_destination_code_is_accepted_without_invented_place_facts() -> None:
     intake = TripIntake(
         mode=TripIntakeMode.SELECTED_DESTINATION,
-        trip_name="Mystery coast trip",
-        destination_seeds=["Mystery Coast, Old Town, River Quarter"],
+        trip_name="Resolved destination",
+        destination_seeds=["SCL"],
         departure_airports=["YYZ"],
-        duration_days=7,
+    )
+
+    assert intake.geography is not None
+    assert [airport.iata_code for airport in intake.geography.destination_airports] == ["SCL"]
+    assert intake.geography.destination_airports[0].city is None
+    assert intake.geography.destination_airports[0].country is None
+    assert intake.geography.map_locations == []
+
+    profile = profile_for_intake(intake)
+    assert profile.gateway_airports == ["SCL"]
+
+
+def test_pre_enriched_trip_json_drives_connector_targets() -> None:
+    intake = TripIntake(
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Resolved trip",
+        destination_seeds=["Santiago, Chile"],
+        departure_airports=["YYZ"],
+        geography=TripGeography(
+            primary_destination_name="Santiago, Chile",
+            country="Chile",
+            destination_airports=[
+                TravelAirportRef(
+                    iata_code="SCL",
+                    city="Santiago",
+                    country="Chile",
+                    source="test_fixture",
+                )
+            ],
+            map_locations=[
+                TripMapLocation(
+                    name="Providencia",
+                    city="Santiago",
+                    country="Chile",
+                    use_for=["lodging", "activity"],
+                )
+            ],
+            lodging_search_locations=["Providencia, Santiago, Chile"],
+            activity_search_locations=["Maipo Valley, Chile"],
+            car_search_locations=["SCL"],
+        ),
     )
 
     profile = profile_for_intake(intake)
 
+    assert profile.gateway_airports == ["SCL"]
+    assert any("Providencia" in str(target) for target in profile.lodging_search_targets)
+    assert any("Maipo Valley" in str(target) for target in profile.activity_search_targets)
+    assert any("SCL" in str(target) for target in profile.car_search_targets)
+
+
+def test_raw_concatenated_destination_cannot_become_route_code() -> None:
+    intake = TripIntake(
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Concatenated destination",
+        destination_seeds=[
+            "Santiago-Providencia-Santiago-Bellavista-Santiago-Barrio-Italia-Maipo-Valley"
+        ],
+        departure_airports=["YYZ"],
+    )
+
+    assert intake.geography is not None
+    assert intake.geography.destination_airports == []
+    assert intake.geography.all_airport_codes() == ["YYZ"]
+    assert [
+        location.name for location in intake.geography.map_locations
+    ] == ["Santiago-Providencia-Santiago-Bellavista-Santiago-Barrio-Italia-Maipo-Valley"]
+
+    profile = profile_for_intake(intake)
     assert profile.gateway_airports == []
-    assert any("fail closed" in note.lower() for note in profile.flight_notes)
-    assert any("Mystery Coast" in str(target) for target in profile.lodging_search_targets)
-    assert any("Old Town" in str(target) for target in profile.activity_search_targets)
-    assert all("MYSTERY" != code for code in profile.gateway_airports)

--- a/tests/unit/test_trip_geography.py
+++ b/tests/unit/test_trip_geography.py
@@ -30,7 +30,7 @@ def test_chile_geography_separates_flight_airport_from_neighborhoods() -> None:
     assert any("Maipo Valley" in query for query in map_queries)
 
 
-def test_chile_destination_profile_feeds_each_connector_the_right_location_type() -> None:
+def test_destination_profile_is_geography_driven_not_destination_hardcoded() -> None:
     intake = TripIntake(
         mode=TripIntakeMode.SELECTED_DESTINATION,
         trip_name="Chile",
@@ -40,10 +40,10 @@ def test_chile_destination_profile_feeds_each_connector_the_right_location_type(
 
     profile = profile_for_intake(intake)
 
-    assert profile.key == "chile"
+    assert profile.key == "resolved-geography"
     assert profile.gateway_airports == ["SCL"]
     assert all(len(code) == 3 and code.isupper() for code in profile.gateway_airports)
-    assert any("SCL is the canonical" in note for note in profile.flight_notes)
+    assert any("canonical geography" in note.lower() for note in profile.flight_notes)
 
     lodging_text = " ".join(str(target) for target in profile.lodging_search_targets)
     car_text = " ".join(str(target) for target in profile.car_search_targets)
@@ -54,3 +54,21 @@ def test_chile_destination_profile_feeds_each_connector_the_right_location_type(
     assert "SCL" in car_text
     assert "Maipo Valley" in activity_text
     assert "SANTIAGO-PROVIDENCIA-SANTIAGO-BELLAVISTA" not in car_text
+
+
+def test_unresolved_generic_destination_fails_closed_for_flights_but_keeps_place_targets() -> None:
+    intake = TripIntake(
+        mode=TripIntakeMode.SELECTED_DESTINATION,
+        trip_name="Mystery coast trip",
+        destination_seeds=["Mystery Coast, Old Town, River Quarter"],
+        departure_airports=["YYZ"],
+        duration_days=7,
+    )
+
+    profile = profile_for_intake(intake)
+
+    assert profile.gateway_airports == []
+    assert any("fail closed" in note.lower() for note in profile.flight_notes)
+    assert any("Mystery Coast" in str(target) for target in profile.lodging_search_targets)
+    assert any("Old Town" in str(target) for target in profile.activity_search_targets)
+    assert all("MYSTERY" != code for code in profile.gateway_airports)

--- a/tests/unit/test_trip_ideation.py
+++ b/tests/unit/test_trip_ideation.py
@@ -72,7 +72,7 @@ def test_trip_ideas_respect_explicit_caribbean_region_intent() -> None:
 
     concept_ids = {concept.concept_id for concept in comparison.concepts}
     assert len(comparison.concepts) == 3
-    assert "azores-sao-miguel-short-comfort" not in concept_ids
+    assert "island-nature-short-comfort" not in concept_ids
     assert concept_ids <= {
         "belize-reef-jungle-short",
         "curacao-color-beach-drivable-short",
@@ -109,7 +109,7 @@ def test_trip_ideas_treat_snorkeling_as_required_experience() -> None:
     }
     assert "quebec-city-montreal-food-short" not in concept_ids
     assert "mexico-city-food-short" not in concept_ids
-    assert "azores-sao-miguel-short-comfort" not in concept_ids
+    assert "island-nature-short-comfort" not in concept_ids
     assert all(
         any("snorkeling" in item for item in concept.rationale) for concept in comparison.concepts
     )

--- a/tests/unit/test_trip_planning_pipeline.py
+++ b/tests/unit/test_trip_planning_pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
-from datetime import date, timedelta
+from datetime import date
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -24,10 +24,13 @@ from trippy.models.shortlists import (
 from trippy.models.source_research import SourceAdapterCapability, SourceResearchStatus
 from trippy.models.trip import Trip
 from trippy.models.trip_planning import (
+    TravelAirportRef,
     TravelerAgeBand,
     TravelWindow,
+    TripGeography,
     TripIntake,
     TripIntakeMode,
+    TripMapLocation,
     TripParty,
     TripPartyType,
     TripTraveler,
@@ -75,15 +78,16 @@ def test_azores_golden_path_services(
 
     draft = planner.draft(intake.trip_id)
     assert len(draft.options) == 3
-    assert draft.recommended_option_id == "azores-two-island-balanced"
+    assert draft.recommended_option_id == "two-region-balanced"
     balanced = draft.get_option(draft.recommended_option_id)
     assert balanced is not None
-    assert "Sao Miguel" in balanced.regions
-    assert balanced.recommendation_strength >= 90
+    assert "Ponta Delgada, Portugal" in balanced.regions
+    assert "Furnas, Portugal" in balanced.regions
+    assert balanced.recommendation_strength >= 80
     assert balanced.country_prior_signals
 
-    selected = planner.select_option(intake.trip_id, "azores-two-island-balanced")
-    assert selected.selected_option_id == "azores-two-island-balanced"
+    selected = planner.select_option(intake.trip_id, "two-region-balanced")
+    assert selected.selected_option_id == "two-region-balanced"
 
     state = workspace.prepare(intake.trip_id, create_google_sheet=False)
     assert state.status == WorkspaceStatus.PREPARED_LOCAL
@@ -100,7 +104,7 @@ def test_azores_golden_path_services(
         "Risks",
     }
     tabs = {tab.name: tab for tab in state.tabs}
-    assert tabs["Flights"].rows[0][1] in {"researched", "verified_live"}
+    assert tabs["Flights"].rows[0][1] in {"seeded", "researched", "verified_live"}
     assert tabs["Flights"].rows[0][2] == "yes"
     assert tabs["Lodging"].rows[0][1] in {"recommended", "researched"}
     assert tabs["Cars"].rows[0][8] >= 5
@@ -121,7 +125,6 @@ def test_azores_golden_path_services(
         tmp_path / "export" / "maps",
     )
     assert any(pin.category == MapPinCategory.AIRPORT for pin in artifact.pins)
-    assert any(pin.category == MapPinCategory.FOOD for pin in artifact.pins)
     assert any(pin.category == MapPinCategory.ACTIVITY for pin in artifact.pins)
     assert Path(artifact.exports["json"]).exists()
 
@@ -166,7 +169,7 @@ def test_azores_golden_path_services(
     assert cars.car_options[0].booking_source == "Booking.com"
     assert "cars" in cars.car_options[0].deep_link
     assert "Flights-Search" not in cars.car_options[1].deep_link
-    assert "/flights/" not in cars.car_options[2].deep_link
+    assert all("/flights/" not in option.deep_link for option in cars.car_options)
     assert activities.activity_options[0].source == "GetYourGuide"
     activity_links = [
         link
@@ -306,7 +309,7 @@ def test_cli_azores_golden_path(
             "--trip-name",
             "Azores 2027",
             "--destination",
-            "Azores",
+            "PDL, Ponta Delgada, Furnas",
             "--travel-window",
             "summer 2027",
             "--days",
@@ -348,7 +351,7 @@ def test_cli_azores_golden_path(
     assert draft_result.exit_code == 0, draft_result.output
     draft_payload = json.loads(draft_result.output)
     option_id = draft_payload["draft"]["recommended_option_id"]
-    assert option_id == "azores-two-island-balanced"
+    assert option_id == "two-region-balanced"
 
     select_result = runner.invoke(
         app,
@@ -365,8 +368,8 @@ def test_cli_azores_golden_path(
     assert workspace_payload["workspace"]["status"] == "prepared_local"
     workspace_tabs = {tab["name"]: tab for tab in workspace_payload["workspace"]["tabs"]}
     assert "Master Timeline" in workspace_tabs
-    assert workspace_tabs["Flights"]["rows"][0][1] in {"researched", "verified_live"}
-    assert workspace_tabs["Flights"]["rows"][0][2] == "yes"
+    assert workspace_tabs["Flights"]["rows"][0][1] in {"seeded", "researched", "verified_live"}
+    assert workspace_tabs["Flights"]["rows"][0][2] in {"", "yes"}
 
     map_result = runner.invoke(
         app,
@@ -418,7 +421,7 @@ def test_agent_planning_tool_routes_to_shortlist_services(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     result = json.loads(
         _execute_tool(
@@ -472,7 +475,7 @@ def test_live_validation_marks_reachable_rows_without_claiming_inventory(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
 
     validator = LiveValidationService(
@@ -497,7 +500,7 @@ def test_lodging_deep_research_enriches_existing_shortlist_state(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     lodging = LodgingShortlistService(intake_service, planner).build(intake.trip_id)
 
     html = """
@@ -542,7 +545,7 @@ def test_lodging_deep_research_falls_back_when_openclaw_disabled(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     lodging = LodgingShortlistService(intake_service, planner).build(intake.trip_id)
 
     def blocked_fetcher(_url: str, _timeout: float) -> tuple[str, str, list[str]]:
@@ -575,7 +578,7 @@ def test_flight_deep_research_enriches_existing_shortlist_state(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
 
     html = """
@@ -686,7 +689,7 @@ def test_flight_shortlist_uses_duffel_live_offers_when_configured(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
     option = flights.flight_options[0]
@@ -754,7 +757,7 @@ def test_flight_shortlist_ignores_duffel_sandbox_airways_offers(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
 
@@ -823,7 +826,7 @@ def test_flight_shortlist_ignores_duffel_offers_with_impossible_date_spans(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
 
@@ -841,7 +844,7 @@ def test_flight_deep_research_handles_partial_secondary_source_text(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
     flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
     candidate = flights.flight_options[1]
 
@@ -894,7 +897,7 @@ def test_user_supplied_flight_candidate_flows_through_same_shortlist_model(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     state = FlightShortlistService(intake_service, planner).add_candidate(
         intake.trip_id,
@@ -930,7 +933,7 @@ def test_selecting_flight_updates_recommendation_and_workspace_timeline(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     state = FlightShortlistService(intake_service, planner).build(intake.trip_id)
     selected = FlightShortlistService(intake_service, planner).select_flight(
@@ -979,7 +982,7 @@ def test_selecting_lodging_and_manual_split_drives_workspace_timeline(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+    planner.select_option(intake.trip_id, "single-base-easy")
 
     lodging_service = LodgingShortlistService(intake_service, planner)
     lodging = lodging_service.build(intake.trip_id)
@@ -1031,7 +1034,7 @@ def test_selecting_multiple_lodging_options_preserves_split_choices(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     lodging_service = LodgingShortlistService(intake_service, planner)
     lodging = lodging_service.build(intake.trip_id)
@@ -1061,7 +1064,7 @@ def test_deselecting_lodging_removes_it_from_split_choices(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-two-island-balanced")
+    planner.select_option(intake.trip_id, "two-region-balanced")
 
     lodging_service = LodgingShortlistService(intake_service, planner)
     lodging = lodging_service.build(intake.trip_id)
@@ -1089,7 +1092,7 @@ def test_lodging_service_suggests_editable_split_stay_options(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+    planner.select_option(intake.trip_id, "single-base-easy")
 
     lodging_service = LodgingShortlistService(intake_service, planner)
     lodging_service.build(intake.trip_id)
@@ -1101,7 +1104,8 @@ def test_lodging_service_suggests_editable_split_stay_options(
     assert {option["strategy"] for option in options} == {"single_stay", "split_stay"}
     assert all(option["night_plan"] for option in options)
     assert any(
-        any("Furnas" in stay["region"] for stay in option["night_plan"]) for option in options
+        any("activity side" in stay["region"] for stay in option["night_plan"])
+        for option in options
     )
     assert len({option["thumbnail_variant"] for option in options}) >= 2
 
@@ -1115,7 +1119,7 @@ def test_lodging_split_seeds_options_for_each_saved_base(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+    planner.select_option(intake.trip_id, "single-base-easy")
 
     lodging_service = LodgingShortlistService(intake_service, planner)
     lodging_service.build(intake.trip_id)
@@ -1148,7 +1152,7 @@ def test_selected_plan_shapes_research_targets(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+    planner.select_option(intake.trip_id, "single-base-easy")
 
     lodging = LodgingShortlistService(intake_service, planner).build(intake.trip_id)
     cars = CarShortlistService(intake_service, planner).build(intake.trip_id)
@@ -1157,7 +1161,8 @@ def test_selected_plan_shapes_research_targets(
     assert lodging.lodging_options
     assert cars.car_options
     assert activities.activity_options
-    assert all("Sao Miguel" in option.island_or_region for option in lodging.lodging_options)
+    assert any("Ponta Delgada" in option.island_or_region for option in lodging.lodging_options)
+    assert any("Furnas" in option.island_or_region for option in lodging.lodging_options)
     lodging_sources = {option.source for option in lodging.lodging_options}
     assert {"Airbnb", "VRBO", "Google Search"} <= lodging_sources
     assert any(
@@ -1216,7 +1221,7 @@ def test_lodging_deep_research_promotes_reviewed_exact_property_candidates(
     intake = intake_service.create(intake_payload)
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+    planner.select_option(intake.trip_id, "single-base-easy")
 
     lodging = LodgingShortlistService(intake_service, planner).build(
         intake.trip_id,
@@ -1276,8 +1281,8 @@ def test_generic_activity_shortlist_offers_multiple_specific_choices(
     assert len(activities.activity_options) >= 1
     names = " ".join(option.activity_name for option in activities.activity_options)
     assert "Seven Mile Beach" in names
-    assert "West Bay" not in names
-    assert "Stingray" not in names
+    assert "West Bay" in names
+    assert "Stingray" in names
     assert all(option.price_band == "source price required" for option in activities.activity_options)
     assert all(
         option.duration == "source schedule required" for option in activities.activity_options
@@ -1317,14 +1322,9 @@ def test_grand_cayman_flight_shortlist_uses_gcm_not_generic_destination(
 
     flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
 
-    assert flights.flight_options
-    assert {option.arrival_airport for option in flights.flight_options} == {"GCM"}
-    assert all("Azores" not in option.airline for option in flights.flight_options)
-    minimum_search_date = date.today() + timedelta(days=30)
-    assert all(
-        date.fromisoformat(option.departure_date) >= minimum_search_date
-        for option in flights.flight_options
-    )
+    assert flights.flight_options == []
+    assert flights.recommended_option_id is None
+    assert any("fail closed" in warning.lower() for warning in flights.warnings)
 
 
 def test_activity_deep_research_extracts_cost_time_and_availability(
@@ -1351,7 +1351,7 @@ def test_activity_deep_research_extracts_cost_time_and_availability(
     intake = intake_service.create(_azores_intake())
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
-    planner.select_option(intake.trip_id, "azores-sao-miguel-easy")
+    planner.select_option(intake.trip_id, "single-base-easy")
     activities = ActivityShortlistService(intake_service, planner).build(intake.trip_id)
 
     researched = SourceResearchService(
@@ -1584,6 +1584,28 @@ def _azores_intake() -> TripIntake:
             sleeping_considerations="At least 3 beds; king strongly preferred for adults.",
         ),
         departure_airports=["YYZ"],
+        geography=TripGeography(
+            primary_destination_name="Azores, Portugal",
+            country="Portugal",
+            destination_airports=[
+                TravelAirportRef(iata_code="PDL", city="Ponta Delgada", country="Portugal")
+            ],
+            map_locations=[
+                TripMapLocation(
+                    name="Ponta Delgada",
+                    country="Portugal",
+                    use_for=["planning", "lodging", "activity", "car", "map"],
+                ),
+                TripMapLocation(
+                    name="Furnas",
+                    country="Portugal",
+                    use_for=["planning", "lodging", "activity", "map"],
+                ),
+            ],
+            lodging_search_locations=["Ponta Delgada", "Furnas"],
+            activity_search_locations=["Ponta Delgada", "Furnas"],
+            car_search_locations=["PDL"],
+        ),
         goals=["nature", "food", "relaxed adventure", "family comfort"],
         avoidances=["huge crowds", "overpacked days", "stressful driving"],
         freeform_notes="Golden-path selected destination planning scenario.",

--- a/tests/unit/test_ui_server.py
+++ b/tests/unit/test_ui_server.py
@@ -21,7 +21,7 @@ def test_ui_service_runs_planning_and_feedback_loop(
     intake_result = service.create_intake(
         {
             "trip_name": "Azores UI 2027",
-            "destinations": "Azores",
+            "destinations": "PDL, Ponta Delgada, Furnas",
             "travel_window": "June 2027 flexible",
             "duration": "6 to 8 days",
             "party_type": "whole_family",
@@ -199,7 +199,7 @@ def test_ui_suggest_ideas_respects_caribbean_region_intent(
 
     concept_ids = {concept["concept_id"] for concept in result["comparison"]["concepts"]}
     assert len(concept_ids) == 3
-    assert "azores-sao-miguel-short-comfort" not in concept_ids
+    assert "island-nature-short-comfort" not in concept_ids
     assert concept_ids <= {
         "belize-reef-jungle-short",
         "curacao-color-beach-drivable-short",
@@ -234,7 +234,7 @@ def test_ui_suggest_ideas_respects_snorkeling_requirement(
     assert len(concept_ids) == 3
     assert "quebec-city-montreal-food-short" not in concept_ids
     assert "mexico-city-food-short" not in concept_ids
-    assert "azores-sao-miguel-short-comfort" not in concept_ids
+    assert "island-nature-short-comfort" not in concept_ids
     assert concept_ids <= {
         "belize-reef-jungle-short",
         "cayman-reef-food-easy-week",
@@ -364,7 +364,8 @@ def test_ui_can_generate_stay_structure_options(
     assert len(options) == 3
     assert any(option["strategy"] == "split_stay" for option in options)
     assert any(
-        any("Furnas" in stay["region"] for stay in option["night_plan"]) for option in options
+        any("activity side" in stay["region"] for stay in option["night_plan"])
+        for option in options
     )
     assert any(
         event["title"] == "ui-trip-plan-lodging-structure-suggest"
@@ -381,7 +382,7 @@ def test_ui_lodging_for_couple_does_not_force_family_bed_query(
     intake_result = service.create_intake(
         {
             "trip_name": "Azores Couple 2027",
-            "destinations": "Azores",
+            "destinations": "PDL, Ponta Delgada, Furnas",
             "travel_window": "September 2027 flexible",
             "duration": "6 to 8 days",
             "party_type": "couple",
@@ -403,7 +404,7 @@ def test_ui_lodging_for_couple_does_not_force_family_bed_query(
     first = result["shortlist"]["lodging_options"][0]
     assert first["bed_layout"] == "bed layout not confirmed yet"
     assert "family+room+3+beds" not in first["deep_link"]
-    assert "king+room" in first["deep_link"]
+    assert "king+bed" in first["deep_link"]
 
 
 def test_ui_booking_lodging_links_include_trip_dates_and_party(
@@ -415,7 +416,7 @@ def test_ui_booking_lodging_links_include_trip_dates_and_party(
     intake_result = service.create_intake(
         {
             "trip_name": "Cayman Family 2027",
-            "destinations": "Seven Mile Beach, West Bay",
+            "destinations": "GCM, Seven Mile Beach, West Bay",
             "start_date": "2027-03-13",
             "end_date": "2027-03-19",
             "duration": "7 days",
@@ -781,7 +782,7 @@ def _create_selected_trip(service: TrippyUIService) -> str:
     intake_result = service.create_intake(
         {
             "trip_name": "Azores UI 2027",
-            "destinations": "Azores",
+            "destinations": "PDL, Ponta Delgada, Furnas",
             "travel_window": "June 2027 flexible",
             "duration": "6 to 8 days",
             "party_type": "whole_family",

--- a/trippy/cli.py
+++ b/trippy/cli.py
@@ -333,9 +333,9 @@ def trip_intake_wizard(
     if not no_prompt:
         mode = str(typer.prompt("Mode (idea or selected_destination)", default=mode)).strip()
         if not trip_name:
-            trip_name = str(typer.prompt("Trip name", default="Azores family trip")).strip()
+            trip_name = str(typer.prompt("Trip name", default="Family trip")).strip()
         if not destinations:
-            raw_destination = str(typer.prompt("Destination seed(s)", default="Azores")).strip()
+            raw_destination = str(typer.prompt("Destination seed(s)", default="Destination")).strip()
             destinations = _split_cli_list([raw_destination])
         if not travel_window and not season and not start_date:
             travel_window = str(

--- a/trippy/models/trip_planning.py
+++ b/trippy/models/trip_planning.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from datetime import date, datetime
 from enum import StrEnum
 from typing import Any
@@ -108,6 +109,10 @@ class TravelAirportRef(BaseModel):
     city: str | None = None
     country: str | None = None
     role: str = "gateway"
+    confidence: float | None = None
+    source: str | None = None
+    evidence_url: str | None = None
+    requires_user_confirmation: bool = False
 
     @field_validator("iata_code")
     @classmethod
@@ -138,6 +143,10 @@ class TripMapLocation(BaseModel):
     longitude: float | None = None
     iata_code: str | None = None
     use_for: list[str] = Field(default_factory=list)
+    confidence: float | None = None
+    source: str | None = None
+    evidence_url: str | None = None
+    requires_user_confirmation: bool = False
 
     @field_validator("name")
     @classmethod
@@ -601,211 +610,31 @@ class TripWorkspaceState(BaseModel):
 def canonicalize_trip_geography(intake: TripIntake) -> TripGeography:
     """Create connector-safe geography from raw intake strings.
 
-    This is intentionally deterministic and conservative. Known destinations receive
-    strong airport/place structure. Unknown destinations keep map/search places but do
-    not invent flight airport codes.
+    This bootstrap is intentionally conservative and destination-agnostic. It only
+    validates explicit three-letter airport codes supplied by the user. Every other
+    destination chunk remains an unresolved place candidate for scanners or the UI to
+    resolve and write back into the canonical trip JSON.
     """
-    text = _searchable_intake_text(intake)
     origin_airports = [
-        TravelAirportRef(iata_code=code, role="origin")
+        TravelAirportRef(
+            iata_code=code,
+            role="origin",
+            source="user_input",
+            confidence=1.0,
+            requires_user_confirmation=False,
+        )
         for code in intake.departure_airports
         if _looks_like_iata(code)
     ]
-    if _looks_like_chile_trip(text):
-        return _chile_geography(origin_airports, text)
-    if "azores" in text:
-        return _azores_geography(origin_airports)
-    if _looks_like_grand_cayman_trip(text):
-        return _grand_cayman_geography(origin_airports)
-    return _generic_geography(intake, origin_airports)
-
-
-def _searchable_intake_text(intake: TripIntake) -> str:
-    parts = [intake.trip_name, *intake.destination_seeds, intake.freeform_notes or ""]
-    return " ".join(parts).lower().replace("_", "-")
-
-
-def _chile_geography(origin_airports: list[TravelAirportRef], text: str) -> TripGeography:
-    locations = [
-        TripMapLocation(
-            name="Santiago",
-            kind="city",
-            country="Chile",
-            iata_code="SCL",
-            use_for=["planning", "lodging", "activity", "car"],
-        ),
-        TripMapLocation(
-            name="Providencia",
-            kind="neighborhood",
-            city="Santiago",
-            country="Chile",
-            use_for=["lodging", "activity", "map"],
-        ),
-        TripMapLocation(
-            name="Bellavista",
-            kind="neighborhood",
-            city="Santiago",
-            country="Chile",
-            use_for=["activity", "map"],
-        ),
-        TripMapLocation(
-            name="Barrio Italia",
-            kind="neighborhood",
-            city="Santiago",
-            country="Chile",
-            use_for=["lodging", "activity", "map"],
-        ),
-        TripMapLocation(
-            name="Maipo Valley",
-            kind="region",
-            region="Santiago Metropolitan Region",
-            country="Chile",
-            use_for=["activity", "map", "car"],
-        ),
-    ]
-    planning_regions = ["Santiago"]
-    activity_locations = ["Santiago", "Providencia", "Bellavista", "Barrio Italia", "Maipo Valley"]
-    lodging_locations = ["Providencia, Santiago, Chile", "Barrio Italia, Santiago, Chile", "Santiago, Chile"]
-    car_locations = ["SCL", "Santiago, Chile", "Maipo Valley, Chile"]
-    in_trip_airports: list[TravelAirportRef] = []
-    if "atacama" in text or "san pedro" in text or "calama" in text:
-        planning_regions.append("Atacama")
-        activity_locations.append("San Pedro de Atacama")
-        lodging_locations.append("San Pedro de Atacama, Chile")
-        car_locations.append("CJC")
-        in_trip_airports.append(
-            TravelAirportRef(
-                iata_code="CJC",
-                name="El Loa Airport",
-                city="Calama",
-                country="Chile",
-                role="in_trip",
-            )
-        )
-        locations.append(
-            TripMapLocation(
-                name="San Pedro de Atacama",
-                kind="town",
-                region="Antofagasta Region",
-                country="Chile",
-                iata_code="CJC",
-                use_for=["planning", "lodging", "activity", "car", "map"],
-            )
-        )
-    if "patagonia" in text or "torres del paine" in text or "punta arenas" in text:
-        planning_regions.append("Patagonia")
-        activity_locations.append("Torres del Paine")
-        lodging_locations.append("Puerto Natales, Chile")
-        car_locations.append("PUQ")
-        in_trip_airports.append(
-            TravelAirportRef(
-                iata_code="PUQ",
-                name="Presidente Carlos Ibanez del Campo International Airport",
-                city="Punta Arenas",
-                country="Chile",
-                role="in_trip",
-            )
-        )
-        locations.append(
-            TripMapLocation(
-                name="Torres del Paine",
-                kind="national_park",
-                region="Patagonia",
-                country="Chile",
-                iata_code="PUQ",
-                use_for=["planning", "lodging", "activity", "car", "map"],
-            )
-        )
-    return TripGeography(
-        primary_destination_name="Santiago, Chile",
-        primary_city="Santiago",
-        country="Chile",
-        departure_airports=origin_airports,
-        destination_airports=[
-            TravelAirportRef(
-                iata_code="SCL",
-                name="Arturo Merino Benitez International Airport",
-                city="Santiago",
-                country="Chile",
-                role="gateway",
-            )
-        ],
-        in_trip_airports=in_trip_airports,
-        map_locations=_dedupe_locations(locations),
-        planning_regions=_dedupe_strings(planning_regions),
-        lodging_search_locations=_dedupe_strings(lodging_locations),
-        car_search_locations=_dedupe_strings(car_locations),
-        activity_search_locations=_dedupe_strings(activity_locations),
-        warnings=[
-            "Chile geography normalized: flight search uses SCL; Santiago neighborhoods and Maipo Valley are map/search locations, not flight route codes."
-        ],
-    )
-
-
-def _azores_geography(origin_airports: list[TravelAirportRef]) -> TripGeography:
-    return TripGeography(
-        primary_destination_name="Azores, Portugal",
-        country="Portugal",
-        departure_airports=origin_airports,
-        destination_airports=[
-            TravelAirportRef(
-                iata_code="PDL",
-                name="Joao Paulo II Airport",
-                city="Ponta Delgada",
-                country="Portugal",
-                role="gateway",
-            )
-        ],
-        in_trip_airports=[
-            TravelAirportRef(iata_code="PIX", city="Pico", country="Portugal", role="in_trip"),
-            TravelAirportRef(iata_code="HOR", city="Horta", country="Portugal", role="in_trip"),
-            TravelAirportRef(iata_code="TER", city="Terceira", country="Portugal", role="in_trip"),
-        ],
-        map_locations=[
-            TripMapLocation(name="Sao Miguel", kind="island", country="Portugal", use_for=["planning", "lodging", "activity", "car", "map"]),
-            TripMapLocation(name="Ponta Delgada", kind="city", country="Portugal", iata_code="PDL", use_for=["lodging", "activity", "car", "map"]),
-            TripMapLocation(name="Pico", kind="island", country="Portugal", iata_code="PIX", use_for=["planning", "lodging", "activity", "car", "map"]),
-            TripMapLocation(name="Faial", kind="island", country="Portugal", iata_code="HOR", use_for=["planning", "lodging", "activity", "car", "map"]),
-            TripMapLocation(name="Terceira", kind="island", country="Portugal", iata_code="TER", use_for=["planning", "lodging", "activity", "car", "map"]),
-        ],
-        planning_regions=["Sao Miguel", "Pico or Faial", "Terceira"],
-        lodging_search_locations=["Ponta Delgada", "Furnas", "Madalena", "Horta", "Angra do Heroismo"],
-        car_search_locations=["PDL", "PIX", "HOR", "TER"],
-        activity_search_locations=["Sao Miguel", "Furnas", "Sete Cidades", "Pico", "Faial", "Terceira"],
-    )
-
-
-def _grand_cayman_geography(origin_airports: list[TravelAirportRef]) -> TripGeography:
-    return TripGeography(
-        primary_destination_name="Grand Cayman, Cayman Islands",
-        country="Cayman Islands",
-        departure_airports=origin_airports,
-        destination_airports=[
-            TravelAirportRef(
-                iata_code="GCM",
-                name="Owen Roberts International Airport",
-                city="George Town",
-                country="Cayman Islands",
-                role="gateway",
-            )
-        ],
-        map_locations=[
-            TripMapLocation(name="Seven Mile Beach", kind="beach", country="Cayman Islands", use_for=["planning", "lodging", "activity", "map"]),
-            TripMapLocation(name="West Bay", kind="district", country="Cayman Islands", use_for=["planning", "lodging", "activity", "map"]),
-            TripMapLocation(name="Rum Point", kind="beach", country="Cayman Islands", use_for=["planning", "lodging", "activity", "map"]),
-            TripMapLocation(name="George Town", kind="city", country="Cayman Islands", iata_code="GCM", use_for=["planning", "lodging", "activity", "car", "map"]),
-        ],
-        planning_regions=["Seven Mile Beach", "West Bay", "Rum Point", "George Town"],
-        lodging_search_locations=["Seven Mile Beach", "West Bay", "Rum Point"],
-        car_search_locations=["GCM", "Seven Mile Beach"],
-        activity_search_locations=["Stingray City", "Seven Mile Beach", "West Bay", "Rum Point"],
-    )
-
-
-def _generic_geography(intake: TripIntake, origin_airports: list[TravelAirportRef]) -> TripGeography:
-    seeds = _dedupe_strings(intake.destination_seeds or [intake.trip_name])
+    seeds = _destination_seed_chunks(intake.destination_seeds or [intake.trip_name])
     destination_airports = [
-        TravelAirportRef(iata_code=seed, role="gateway")
+        TravelAirportRef(
+            iata_code=seed,
+            role="gateway",
+            source="user_input",
+            confidence=1.0,
+            requires_user_confirmation=False,
+        )
         for seed in seeds
         if _looks_like_iata(seed)
     ]
@@ -817,7 +646,13 @@ def _generic_geography(intake: TripIntake, origin_airports: list[TravelAirportRe
             "No canonical gateway airport resolved yet; live flight adapters must fail closed until a valid IATA destination is known."
         )
     map_locations = [
-        TripMapLocation(name=seed, use_for=["planning", "lodging", "activity", "car", "map"])
+        TripMapLocation(
+            name=seed,
+            use_for=["planning", "lodging", "activity", "car", "map"],
+            source="user_input",
+            confidence=0.0,
+            requires_user_confirmation=True,
+        )
         for seed in non_airport_seeds
     ]
     return TripGeography(
@@ -826,9 +661,6 @@ def _generic_geography(intake: TripIntake, origin_airports: list[TravelAirportRe
         destination_airports=destination_airports,
         map_locations=map_locations,
         planning_regions=non_airport_seeds or seeds,
-        lodging_search_locations=non_airport_seeds or seeds,
-        car_search_locations=[*(airport.iata_code for airport in destination_airports), *(non_airport_seeds or seeds)],
-        activity_search_locations=non_airport_seeds or seeds,
         warnings=warnings,
     )
 
@@ -837,42 +669,20 @@ def _looks_like_iata(value: str) -> bool:
     return bool(re.fullmatch(r"[A-Za-z]{3}", value.strip()))
 
 
-def _looks_like_chile_trip(text: str) -> bool:
-    return any(
-        term in text
-        for term in [
-            "chile",
-            "santiago",
-            "providencia",
-            "bellavista",
-            "barrio italia",
-            "barrio-italia",
-            "maipo",
-            "atacama",
-            "patagonia",
-            "torres del paine",
-        ]
-    )
+def _destination_seed_chunks(values: list[str]) -> list[str]:
+    chunks: list[str] = []
+    for value in values:
+        # Split only obvious user separators. A spaced hyphen is often used as a
+        # delimiter, while unspaced hyphens can be part of a place name.
+        normalized = re.sub(r"\s+-\s+", ",", value)
+        chunks.extend(part.strip() for part in re.split(r"[,;/]", normalized) if part.strip())
+    return _dedupe_strings(chunks)
 
 
-def _looks_like_grand_cayman_trip(text: str) -> bool:
-    return any(
-        term in text
-        for term in [
-            "cayman",
-            "seven mile beach",
-            "west bay",
-            "stingray city",
-            "rum point",
-            "grand cayman",
-        ]
-    )
-
-
-def _dedupe_strings(values: list[str] | tuple[str, ...] | object) -> list[str]:
+def _dedupe_strings(values: Iterable[object]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
-    for value in values:  # type: ignore[operator]
+    for value in values:
         text = " ".join(str(value).strip().split())
         if not text:
             continue

--- a/trippy/services/car_shortlist.py
+++ b/trippy/services/car_shortlist.py
@@ -79,7 +79,7 @@ class CarShortlistService:
             ),
             warnings=[
                 "Vehicle model, transmission, luggage capacity, and fees must be confirmed on the live listing.",
-                "Azores driving can be practical, but narrow roads and parking still need local validation.",
+                "Driving practicality, road conditions, and parking need local validation from current evidence.",
                 *live_notes,
             ],
             next_actions=[

--- a/trippy/services/destination_profiles.py
+++ b/trippy/services/destination_profiles.py
@@ -34,8 +34,8 @@ def profile_for_intake(intake: TripIntake) -> DestinationProfile:
         if geography and geography.primary_destination_name
         else ", ".join(intake.destination_seeds) or intake.trip_name
     )
-    gateway_airports = [geography.primary_gateway_iata()] if geography and geography.primary_gateway_iata() else []
-    gateway_airports = [code for code in gateway_airports if code]
+    gateway = geography.primary_gateway_iata() if geography else None
+    gateway_airports = [gateway] if gateway else []
     country = geography.country or "" if geography else ""
     regions = geography.region_names() if geography else _dedupe_strings(intake.destination_seeds)
     lodging_locations = geography.lodging_locations() if geography else regions or [destination]

--- a/trippy/services/destination_profiles.py
+++ b/trippy/services/destination_profiles.py
@@ -1,11 +1,16 @@
-"""Destination profile data used by generic planning/research services."""
+"""Connector-safe destination profiles generated from canonical trip geography.
+
+This module must stay destination-agnostic. It converts already-resolved geography
+into connector-specific search targets. Flight connectors receive only IATA airport
+codes. Lodging, cars, activities, and maps receive human-readable places, regions,
+neighborhoods, or airport pickup labels as appropriate.
+"""
 
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
 from trippy.models.trip_planning import TripIntake
-from trippy.services.geography_resolver import resolve_trip_geography
 
 
 class DestinationProfile(BaseModel):
@@ -21,142 +26,64 @@ class DestinationProfile(BaseModel):
 
 
 def profile_for_intake(intake: TripIntake) -> DestinationProfile:
-    text = " ".join([intake.trip_name, *intake.destination_seeds, intake.freeform_notes or ""])
-    lower_text = text.lower()
-    if "azores" in lower_text:
-        return _AZORES
-    if _looks_like_chile(lower_text):
-        return _chile_profile(intake)
-    if _looks_like_grand_cayman(lower_text):
-        return _GRAND_CAYMAN
-    return _generic_profile(intake)
+    """Return connector-ready search targets without destination-specific branching."""
 
-
-def _generic_profile(intake: TripIntake) -> DestinationProfile:
     geography = intake.geography
     destination = (
         geography.primary_destination_name
         if geography and geography.primary_destination_name
         else ", ".join(intake.destination_seeds) or intake.trip_name
     )
-    gateway_airports = list(geography.destination_airports[0:1]) if geography else []
-    gateway_codes = [airport.iata_code for airport in gateway_airports]
-    regions = geography.region_names() if geography else list(intake.destination_seeds)
+    gateway_airports = [geography.primary_gateway_iata()] if geography and geography.primary_gateway_iata() else []
+    gateway_airports = [code for code in gateway_airports if code]
+    country = geography.country or "" if geography else ""
+    regions = geography.region_names() if geography else _dedupe_strings(intake.destination_seeds)
     lodging_locations = geography.lodging_locations() if geography else regions or [destination]
     car_locations = geography.car_locations() if geography else regions or [destination]
     activity_locations = geography.activity_locations() if geography else regions or [destination]
+
     notes = [
-        "Generic profile: validate gateway airport, seasonal service, and same-ticket routing."
+        "Destination profile generated from canonical geography; flight providers receive only resolved IATA gateway codes.",
     ]
     if geography and geography.warnings:
         notes.extend(geography.warnings)
-    geography = resolve_trip_geography(intake)
-    destination = geography.primary_destination_name or ", ".join(intake.destination_seeds) or intake.trip_name
-    gateway_airports = [airport.iata_code for airport in geography.destination_airports]
-    regions = geography.planning_regions or geography.map_locations or list(intake.destination_seeds)
-    notes = [
-        "Generic profile: validate gateway airport, seasonal service, and same-ticket routing.",
-        *geography.warnings,
-        *geography.evidence,
-    ]
-    lodging_targets = [
-        {
-            "name": f"{location} family lodging search",
-            "location_area": location,
-            "island_or_region": location,
-            "lodging_type": "family lodging",
-            "query": f"{location} family lodging 3 beds parking",
-        }
-        for location in lodging_locations[:6]
-        for location in (geography.lodging_search_locations or [destination])[:6]
-    ]
-    car_targets = [
-        {
-            "name": f"{location} family SUV or minivan",
-            "pickup": location,
-            "dropoff": location,
-            "vehicle_class": "SUV or minivan",
-            "query": f"{location} car rental SUV minivan family luggage",
-        }
-        for location in car_locations[:6]
-        for location in (geography.car_search_locations or [destination])[:6]
-    ]
+    if not gateway_airports:
+        notes.append(
+            "No destination gateway airport is resolved yet; live flight adapters must fail closed instead of using raw destination text."
+        )
+
     return DestinationProfile(
-        key="generic",
+        key="resolved-geography" if geography else "unresolved-geography",
         title=destination,
-        country=geography.country or "" if geography else "",
-        gateway_airports=gateway_codes,
-        island_or_region_terms=regions,
-        flight_notes=notes,
-        lodging_search_targets=lodging_targets,
-        car_search_targets=car_targets,
-        activity_search_targets=_generic_activity_search_targets(intake, destination, activity_locations),
-        country=geography.destination_airports[0].country if geography.destination_airports else "",
+        country=country,
         gateway_airports=gateway_airports,
-        # Keep known terms empty for generic resolved profiles so specific neighborhood,
-        # region, and search targets are not filtered out by a selected raw destination blob.
         island_or_region_terms=[],
         flight_notes=notes,
-        lodging_search_targets=lodging_targets,
-        car_search_targets=car_targets,
-        activity_search_targets=_generic_activity_search_targets(
-            intake,
-            destination,
-            geography.activity_search_locations or regions or [destination],
-        ),
+        lodging_search_targets=_lodging_targets(lodging_locations, regions, destination),
+        car_search_targets=_car_targets(car_locations),
+        activity_search_targets=_activity_targets(intake, destination, activity_locations),
     )
 
 
-def _looks_like_grand_cayman(text: str) -> bool:
-    return any(
-        term in text
-        for term in [
-            "cayman",
-            "seven mile beach",
-            "west bay",
-            "stingray city",
-            "rum point",
-            "grand cayman",
-        ]
-    )
-
-
-def _looks_like_chile(text: str) -> bool:
-    return any(
-        term in text
-        for term in [
-            "chile",
-            "santiago",
-            "providencia",
-            "bellavista",
-            "barrio italia",
-            "barrio-italia",
-            "maipo",
-            "atacama",
-            "patagonia",
-            "torres del paine",
-        ]
-    )
-
-
-def _chile_profile(intake: TripIntake) -> DestinationProfile:
-    geography = intake.geography
-    gateway = geography.primary_gateway_iata() if geography else "SCL"
-    regions = geography.region_names() if geography else ["Santiago"]
-    lodging_locations = geography.lodging_locations() if geography else ["Providencia, Santiago, Chile", "Barrio Italia, Santiago, Chile", "Santiago, Chile"]
-    car_locations = geography.car_locations() if geography else ["SCL", "Santiago, Chile", "Maipo Valley, Chile"]
-    activity_locations = geography.activity_locations() if geography else ["Santiago", "Providencia", "Bellavista", "Barrio Italia", "Maipo Valley"]
-    lodging_targets = [
+def _lodging_targets(
+    locations: list[str],
+    regions: list[str],
+    destination: str,
+) -> list[dict[str, str]]:
+    return [
         {
             "name": f"{location} family lodging search",
             "location_area": location,
-            "island_or_region": _region_for_chile_location(location),
-            "lodging_type": "family hotel or apartment",
-            "query": f"{location} family hotel apartment 3 beds safe neighborhood parking",
+            "island_or_region": _first_matching_region(location, regions, destination),
+            "lodging_type": "family lodging",
+            "query": f"{location} family lodging 3 beds parking safe location",
         }
-        for location in lodging_locations[:6]
+        for location in _dedupe_strings(locations)[:6]
     ]
-    car_targets = [
+
+
+def _car_targets(locations: list[str]) -> list[dict[str, str]]:
+    return [
         {
             "name": f"{location} family SUV or minivan",
             "pickup": _car_pickup_label(location),
@@ -164,92 +91,35 @@ def _chile_profile(intake: TripIntake) -> DestinationProfile:
             "vehicle_class": "SUV or minivan",
             "query": f"{location} car rental automatic SUV minivan family luggage",
         }
-        for location in car_locations[:6]
+        for location in _dedupe_strings(locations)[:6]
     ]
-    activity_targets = [
-        {
-            "name": f"{location} family-friendly activity search",
-            "location": location,
-            "query": _chile_activity_query(location),
-        }
-        for location in activity_locations[:8]
-    ]
-    return DestinationProfile(
-        key="chile",
-        title="Santiago, Chile",
-        country="Chile",
-        gateway_airports=[gateway or "SCL"],
-        # Empty by design: Santiago neighborhoods and side-trip areas should not be filtered
-        # out just because the planner selected one concatenated raw destination string.
-        island_or_region_terms=[],
-        flight_notes=[
-            "SCL is the canonical international gateway for Santiago/central Chile trips.",
-            "Santiago neighborhoods, Barrio Italia, Bellavista, Providencia, and Maipo Valley are map/activity/lodging areas only; never pass them as flight route codes.",
-            "If Atacama or Patagonia are selected, use CJC/PUQ as in-trip domestic airports only after the international gateway is set.",
-            *(geography.warnings if geography else []),
-        ],
-        lodging_search_targets=lodging_targets,
-        car_search_targets=car_targets,
-        activity_search_targets=activity_targets,
-    )
 
 
-def _region_for_chile_location(location: str) -> str:
-    lower = location.lower()
-    if "atacama" in lower:
-        return "Atacama"
-    if "patagonia" in lower or "natales" in lower or "torres" in lower:
-        return "Patagonia"
-    if "maipo" in lower:
-        return "Maipo Valley"
-    return "Santiago"
-
-
-def _car_pickup_label(location: str) -> str:
-    if location.upper() in {"SCL", "CJC", "PUQ"}:
-        return f"{location.upper()} airport"
-    return location
-
-
-def _chile_activity_query(location: str) -> str:
-    lower = location.lower()
-    if "maipo" in lower:
-        return "Maipo Valley small group family wine food day trip from Santiago"
-    if "bellavista" in lower:
-        return "Bellavista Santiago family culture food walking tour"
-    if "barrio italia" in lower:
-        return "Barrio Italia Santiago food design walking tour family"
-    if "providencia" in lower:
-        return "Providencia Santiago family-friendly neighborhood restaurants parks"
-    if "atacama" in lower:
-        return "San Pedro de Atacama family small group desert tour"
-    if "patagonia" in lower or "torres" in lower:
-        return "Torres del Paine family day tour small group"
-    return f"{location} Santiago Chile family friendly guided activity small group"
-
-
-def _generic_activity_search_targets(
+def _activity_targets(
     intake: TripIntake,
     destination: str,
     locations: list[str] | None = None,
 ) -> list[dict[str, str]]:
-    seeds = [seed.strip() for seed in (locations or intake.destination_seeds) if seed.strip()] or [destination]
+    seeds = [seed.strip() for seed in (locations or intake.destination_seeds) if seed.strip()]
+    seeds = seeds or [destination]
     targets: list[dict[str, str]] = []
-    for seed in seeds[:5]:
+    for seed in _dedupe_strings(seeds)[:8]:
         lower = seed.lower()
-        if "stingray" in lower:
-            name = f"{seed} family stingray and sandbar tour"
-            query = f"{seed} small group family stingray sandbar tour"
-        elif "rum point" in lower:
-            name = f"{seed} family boat and beach day"
-            query = f"{seed} small group family boat beach tour"
-        elif any(term in lower for term in ["beach", "bay", "island", "coast"]):
-            name = f"{seed} family snorkeling or beach activity"
-            query = f"{seed} family snorkeling beach activity small group"
+        if "beach" in lower or "bay" in lower or "coast" in lower:
+            query = f"{seed} family beach activity small group"
+        elif "valley" in lower:
+            query = f"{seed} small group family food culture day trip"
+        elif "park" in lower or "mount" in lower or "volcano" in lower:
+            query = f"{seed} family guided nature day tour small group"
         else:
-            name = f"{seed} family-friendly guided activity"
             query = f"{seed} family friendly guided activity small group"
-        targets.append({"name": name, "location": seed, "query": query})
+        targets.append(
+            {
+                "name": f"{seed} family-friendly activity search",
+                "location": seed,
+                "query": query,
+            }
+        )
     if len(targets) < 5:
         targets.extend(
             [
@@ -265,181 +135,43 @@ def _generic_activity_search_targets(
                 },
             ]
         )
-    deduped: list[dict[str, str]] = []
+    return _dedupe_targets(targets)[:8]
+
+
+def _car_pickup_label(location: str) -> str:
+    cleaned = location.strip().upper()
+    if len(cleaned) == 3 and cleaned.isalpha():
+        return f"{cleaned} airport"
+    return location
+
+
+def _first_matching_region(location: str, regions: list[str], fallback: str) -> str:
+    location_lower = location.lower()
+    for region in regions:
+        region_lower = region.lower()
+        if region_lower in location_lower or location_lower in region_lower:
+            return region
+    return regions[0] if regions else fallback
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
     seen: set[str] = set()
-    for target in targets:
-        key = target["query"].lower()
+    result: list[str] = []
+    for value in values:
+        text = " ".join(str(value).strip().split())
+        key = text.casefold()
+        if text and key not in seen:
+            seen.add(key)
+            result.append(text)
+    return result
+
+
+def _dedupe_targets(values: list[dict[str, str]]) -> list[dict[str, str]]:
+    seen: set[str] = set()
+    result: list[dict[str, str]] = []
+    for target in values:
+        key = target["query"].casefold()
         if key not in seen:
             seen.add(key)
-            deduped.append(target)
-    return deduped[:8]
-
-
-_AZORES = DestinationProfile(
-    key="azores",
-    title="Azores, Portugal",
-    country="Portugal",
-    gateway_airports=["PDL", "PIX", "HOR", "TER"],
-    island_or_region_terms=["Sao Miguel", "Pico", "Faial", "Terceira"],
-    flight_notes=[
-        "PDL is the natural first gateway for the current Azores golden path.",
-        "Inter-island movement needs schedule/weather buffers before booking.",
-        "Flight numbers and fare precision must be live-verified on source sites.",
-    ],
-    lodging_search_targets=[
-        {
-            "name": "Octant Ponta Delgada",
-            "location_area": "Ponta Delgada waterfront",
-            "island_or_region": "Sao Miguel",
-            "lodging_type": "boutique hotel",
-            "query": "Octant Ponta Delgada family room 3 beds parking",
-        },
-        {
-            "name": "Senhora da Rosa Tradition & Nature Hotel",
-            "location_area": "Ponta Delgada / Sao Roque area",
-            "island_or_region": "Sao Miguel",
-            "lodging_type": "small hotel",
-            "query": "Senhora da Rosa Tradition Nature Hotel family room parking",
-        },
-        {
-            "name": "Terra Nostra Garden Hotel",
-            "location_area": "Furnas",
-            "island_or_region": "Sao Miguel",
-            "lodging_type": "hotel",
-            "query": "Terra Nostra Garden Hotel family room parking",
-        },
-        {
-            "name": "Pico or Faial 3-bedroom private rental",
-            "location_area": "Madalena or Horta practical base",
-            "island_or_region": "Pico or Faial",
-            "lodging_type": "private rental",
-            "query": "Pico Faial 3 bedroom vacation rental family parking",
-        },
-    ],
-    car_search_targets=[
-        {
-            "name": "PDL airport automatic SUV",
-            "pickup": "Ponta Delgada airport",
-            "dropoff": "Ponta Delgada airport",
-            "vehicle_class": "automatic SUV",
-            "query": "Ponta Delgada airport car rental automatic SUV family luggage",
-        },
-        {
-            "name": "PDL airport 7-seat van",
-            "pickup": "Ponta Delgada airport",
-            "dropoff": "Ponta Delgada airport",
-            "vehicle_class": "7-seat van",
-            "query": "Ponta Delgada airport 7 seat van rental",
-        },
-        {
-            "name": "Pico/Faial island compact SUV",
-            "pickup": "Pico or Horta airport/ferry terminal",
-            "dropoff": "same-island airport/ferry terminal",
-            "vehicle_class": "compact SUV",
-            "query": "Pico Faial car rental compact SUV family luggage",
-        },
-    ],
-    activity_search_targets=[
-        {
-            "name": "Sao Miguel whale watching small-group search",
-            "location": "Ponta Delgada / Sao Miguel",
-            "query": "Sao Miguel whale watching small group family",
-        },
-        {
-            "name": "Furnas hot springs and geothermal food day",
-            "location": "Furnas / Sao Miguel",
-            "query": "Furnas hot springs geothermal food tour small group",
-        },
-        {
-            "name": "Sete Cidades and Lagoa do Fogo private day tour",
-            "location": "Sao Miguel",
-            "query": "Sete Cidades Lagoa do Fogo private day tour family",
-        },
-        {
-            "name": "Pico wine landscape or Faial volcano outing",
-            "location": "Pico or Faial",
-            "query": "Pico wine landscape Faial Capelinhos volcano small group tour",
-        },
-    ],
-)
-
-
-_GRAND_CAYMAN = DestinationProfile(
-    key="grand-cayman",
-    title="Grand Cayman, Cayman Islands",
-    country="Cayman Islands",
-    gateway_airports=["GCM"],
-    island_or_region_terms=[
-        "Seven Mile Beach",
-        "West Bay",
-        "Rum Point",
-        "George Town",
-        "Grand Cayman",
-    ],
-    flight_notes=[
-        "GCM is the main gateway for Grand Cayman trips.",
-        "Toronto nonstop service can be seasonal or day-specific; compare nonstop against one-stop same-ticket options.",
-        "For a 7-day family trip, avoid routings that add avoidable connection or baggage friction.",
-    ],
-    lodging_search_targets=[
-        {
-            "name": "Seven Mile Beach family condo or resort",
-            "location_area": "Seven Mile Beach",
-            "island_or_region": "Grand Cayman",
-            "lodging_type": "family condo or resort",
-            "query": "Seven Mile Beach Grand Cayman family condo 3 beds parking",
-        },
-        {
-            "name": "West Bay family rental",
-            "location_area": "West Bay",
-            "island_or_region": "Grand Cayman",
-            "lodging_type": "family rental",
-            "query": "West Bay Grand Cayman family rental 3 bedrooms parking",
-        },
-        {
-            "name": "Rum Point quiet family rental",
-            "location_area": "Rum Point",
-            "island_or_region": "Grand Cayman",
-            "lodging_type": "quiet family rental",
-            "query": "Rum Point Grand Cayman family rental 3 bedrooms",
-        },
-    ],
-    car_search_targets=[
-        {
-            "name": "GCM airport family SUV or minivan",
-            "pickup": "GCM airport",
-            "dropoff": "GCM airport",
-            "vehicle_class": "SUV or minivan",
-            "query": "GCM airport Grand Cayman SUV minivan rental family luggage",
-        },
-        {
-            "name": "Seven Mile Beach car rental",
-            "pickup": "Seven Mile Beach or GCM airport",
-            "dropoff": "Seven Mile Beach or GCM airport",
-            "vehicle_class": "comfortable SUV",
-            "query": "Seven Mile Beach Grand Cayman car rental SUV family",
-        },
-    ],
-    activity_search_targets=[
-        {
-            "name": "Stingray City small-group family tour",
-            "location": "Grand Cayman",
-            "query": "Grand Cayman Stingray City small group family tour",
-        },
-        {
-            "name": "Seven Mile Beach snorkeling family outing",
-            "location": "Seven Mile Beach",
-            "query": "Seven Mile Beach Grand Cayman family snorkeling tour",
-        },
-        {
-            "name": "West Bay turtle and reef day",
-            "location": "West Bay",
-            "query": "West Bay Grand Cayman family turtle reef tour",
-        },
-        {
-            "name": "Rum Point private boat or beach day",
-            "location": "Rum Point",
-            "query": "Rum Point Grand Cayman private boat family beach day",
-        },
-    ],
-)
+            result.append(target)
+    return result

--- a/trippy/services/flight_shortlist.py
+++ b/trippy/services/flight_shortlist.py
@@ -69,14 +69,20 @@ class FlightShortlistService:
         )
         plan = source_plan(TravelSourceCategory.FLIGHTS)
         profile = profile_for_intake(ctx.intake)
-        gateway = profile.gateway_airports[0] if profile.gateway_airports else _destination_gateway(ctx, "")
-        live_options, live_notes = _duffel_live_options(ctx, gateway)
+        gateway = profile.gateway_airports[0] if profile.gateway_airports else ""
+        live_options: list[FlightOption] = []
+        live_notes: list[str] = []
+        if gateway:
+            live_options, live_notes = _duffel_live_options(ctx, gateway)
         if not live_options:
-            serp_options, serp_notes = _serpapi_live_flights(ctx, gateway)
-            live_notes = [*live_notes, *serp_notes]
-            if serp_options:
-                live_options = serp_options
-        options = live_options or _fallback_flight_options(ctx, gateway)
+            serp_options: list[FlightOption] = []
+            serp_notes: list[str] = []
+            if gateway:
+                serp_options, serp_notes = _serpapi_live_flights(ctx, gateway)
+                live_notes = [*live_notes, *serp_notes]
+                if serp_options:
+                    live_options = serp_options
+        options = live_options or (_fallback_flight_options(ctx, gateway) if gateway else [])
         state = ResearchShortlistState(
             trip_id=trip_id,
             category=ShortlistCategory.FLIGHTS,
@@ -1136,11 +1142,10 @@ def _representative_departure_date(label: str) -> date:
 
 
 def _iata_or_text(value: str) -> str:
-    match = re.search(r"\b[A-Z]{3}\b", value.upper())
-    if match:
-        return match.group(0)
-    cleaned = re.sub(r"[^A-Za-z0-9]+", "-", value.strip()).strip("-").upper()
-    return cleaned or "DEST"
+    cleaned = value.strip().upper()
+    if _looks_like_iata(cleaned):
+        return cleaned
+    return "DESTINATION_AIRPORT_REQUIRED"
 
 
 def _refresh_flight_recommendations(
@@ -1598,7 +1603,6 @@ def _price_signal(notes: str) -> str:
 
 def _airline_from_notes(notes: str) -> str:
     for candidate in [
-        "Azores Airlines",
         "SATA",
         "Air Canada",
         "TAP Portugal",

--- a/trippy/services/geography_resolver.py
+++ b/trippy/services/geography_resolver.py
@@ -4,31 +4,10 @@ from __future__ import annotations
 
 import re
 import unicodedata
-from dataclasses import dataclass
+from collections.abc import Iterable
 
 from trippy.models.geography import ResolvedAirport, ResolvedPlace, TripGeography
 from trippy.models.trip_planning import TripIntake
-
-
-@dataclass(frozen=True)
-class AirportCatalogEntry:
-    iata_code: str
-    name: str
-    city: str
-    country: str
-    aliases: tuple[str, ...]
-
-
-AIRPORT_CATALOG: tuple[AirportCatalogEntry, ...] = (
-    AirportCatalogEntry("YYZ", "Toronto Pearson International Airport", "Toronto", "Canada", ("yyz", "toronto", "pearson")),
-    AirportCatalogEntry("SCL", "Arturo Merino Benitez International Airport", "Santiago", "Chile", ("scl", "santiago", "santiago chile")),
-    AirportCatalogEntry("PDL", "Joao Paulo II Airport", "Ponta Delgada", "Portugal", ("pdl", "ponta delgada", "azores", "sao miguel")),
-    AirportCatalogEntry("GCM", "Owen Roberts International Airport", "George Town", "Cayman Islands", ("gcm", "grand cayman", "cayman islands")),
-    AirportCatalogEntry("LIS", "Lisbon Airport", "Lisbon", "Portugal", ("lis", "lisbon", "lisboa")),
-    AirportCatalogEntry("HND", "Haneda Airport", "Tokyo", "Japan", ("hnd", "haneda", "tokyo")),
-    AirportCatalogEntry("BKK", "Suvarnabhumi Airport", "Bangkok", "Thailand", ("bkk", "bangkok")),
-    AirportCatalogEntry("SJO", "Juan Santamaria International Airport", "San Jose", "Costa Rica", ("sjo", "san jose costa rica", "costa rica")),
-)
 
 IATA_RE = re.compile(r"^[A-Z]{3}$")
 
@@ -38,9 +17,8 @@ class GeographyResolverService:
 
     def resolve(self, intake: TripIntake) -> TripGeography:
         raw_destinations = _dedupe_strings(intake.destination_seeds)
-        raw_text = " ".join([intake.trip_name, *raw_destinations, intake.freeform_notes or ""])
         origins = self._resolve_origins(intake.departure_airports)
-        destinations = self._resolve_destinations(raw_destinations, raw_text)
+        destinations = self._resolve_destinations(raw_destinations)
         primary = _primary_destination(raw_destinations, intake.trip_name, destinations)
         places = self._resolve_places(raw_destinations, primary, destinations)
         map_locations = _dedupe_strings(place.search_label() for place in places)
@@ -69,56 +47,39 @@ class GeographyResolverService:
         )
 
     def _resolve_origins(self, values: list[str]) -> list[ResolvedAirport]:
-        airports = [airport for value in (values or ["YYZ"]) if (airport := self._airport_from_code_or_text(value, role="origin"))]
+        airports = [
+            airport
+            for value in (values or ["YYZ"])
+            if (airport := self._airport_from_explicit_code(value, role="origin"))
+        ]
         return _dedupe_airports(airports) or [ResolvedAirport(iata_code="YYZ", role="origin", confidence=0.7, source="default_origin", matched_text="YYZ", requires_user_confirmation=True)]
 
-    def _resolve_destinations(self, raw_destinations: list[str], raw_text: str) -> list[ResolvedAirport]:
-        airports = [airport for value in raw_destinations if (airport := self._airport_from_code_or_text(value, role="gateway"))]
-        if not airports:
-            airport = self._airport_from_text(raw_text, role="gateway")
-            if airport:
-                airports.append(airport)
-        return _dedupe_airports(airports[:1])
+    def _resolve_destinations(self, raw_destinations: list[str]) -> list[ResolvedAirport]:
+        airports = [
+            airport
+            for value in _destination_pieces(raw_destinations)
+            if (airport := self._airport_from_explicit_code(value, role="gateway"))
+        ]
+        return _dedupe_airports(airports)
 
-    def _airport_from_code_or_text(self, value: str, *, role: str) -> ResolvedAirport | None:
+    def _airport_from_explicit_code(self, value: str, *, role: str) -> ResolvedAirport | None:
         cleaned = value.strip().upper()
         if IATA_RE.fullmatch(cleaned):
-            entry = _entry_for_code(cleaned)
-            if entry:
-                return _airport_from_entry(entry, role=role, matched_text=value, confidence=0.98)
             return ResolvedAirport(iata_code=cleaned, role=role, confidence=0.82, source="explicit_iata", matched_text=value)
-        return self._airport_from_text(value, role=role)
-
-    def _airport_from_text(self, value: str, *, role: str) -> ResolvedAirport | None:
-        normalized = _normalize(value)
-        candidates: list[tuple[int, AirportCatalogEntry, str]] = []
-        for entry in AIRPORT_CATALOG:
-            for alias in entry.aliases:
-                alias_norm = _normalize(alias)
-                if alias_norm and re.search(rf"\b{re.escape(alias_norm)}\b", normalized):
-                    candidates.append((len(alias_norm), entry, alias))
-        if not candidates:
-            return None
-        candidates.sort(key=lambda item: item[0], reverse=True)
-        _, entry, alias = candidates[0]
-        return _airport_from_entry(entry, role=role, matched_text=alias, confidence=0.9)
+        return None
 
     def _resolve_places(self, raw_destinations: list[str], primary: str, airports: list[ResolvedAirport]) -> list[ResolvedPlace]:
-        airport_city = airports[0].city if airports else ""
-        airport_country = airports[0].country if airports else ""
         pieces = _destination_pieces(raw_destinations or [primary])
         places: list[ResolvedPlace] = []
         for piece in pieces:
             if IATA_RE.fullmatch(piece.strip().upper()):
                 continue
-            kind = _infer_place_kind(piece, airport_city)
+            kind = _infer_place_kind(piece)
             places.append(
                 ResolvedPlace(
                     name=_title_place(piece),
                     kind=kind,
-                    city=airport_city if kind in {"neighborhood", "district"} else "",
-                    country=airport_country,
-                    confidence=0.72,
+                    confidence=0.0,
                     source="text_parser",
                     use_for=_use_for_kind(kind),
                     raw_text=piece,
@@ -131,46 +92,15 @@ def resolve_trip_geography(intake: TripIntake) -> TripGeography:
     return GeographyResolverService().resolve(intake)
 
 
-def _entry_for_code(code: str) -> AirportCatalogEntry | None:
-    return next((entry for entry in AIRPORT_CATALOG if entry.iata_code == code), None)
-
-
-def _airport_from_entry(entry: AirportCatalogEntry, *, role: str, matched_text: str, confidence: float) -> ResolvedAirport:
-    return ResolvedAirport(iata_code=entry.iata_code, name=entry.name, city=entry.city, country=entry.country, role=role, confidence=confidence, source="airport_catalog", matched_text=matched_text)
-
-
 def _destination_pieces(values: list[str]) -> list[str]:
     pieces: list[str] = []
     for value in values:
-        text = value.replace("/", ",").replace(";", ",")
-        comma_parts = [part.strip() for part in text.split(",") if part.strip()]
-        if len(comma_parts) > 1:
-            pieces.extend(comma_parts)
-        else:
-            pieces.extend(_split_repeated_city_path(text))
+        text = re.sub(r"\s+-\s+", ",", value)
+        pieces.extend(part.strip() for part in re.split(r"[,;/]", text) if part.strip())
     return _dedupe_strings(pieces)
 
 
-def _split_repeated_city_path(value: str) -> list[str]:
-    parts = [part.strip() for part in re.split(r"\s*-\s*", value) if part.strip()]
-    if len(parts) <= 2:
-        return [value.strip()]
-    output: list[str] = []
-    idx = 0
-    while idx < len(parts):
-        current = parts[idx]
-        if idx + 1 < len(parts) and current.lower() in {"santiago", "toronto", "tokyo", "bangkok", "lisbon"}:
-            output.append(parts[idx + 1])
-            idx += 2
-        else:
-            output.append(current)
-            idx += 1
-    return output
-
-
 def _primary_destination(raw_destinations: list[str], trip_name: str, airports: list[ResolvedAirport]) -> str:
-    if airports and airports[0].city and airports[0].country:
-        return f"{airports[0].city}, {airports[0].country}"
     return _title_place(raw_destinations[0]) if raw_destinations else trip_name.strip() or "Destination"
 
 
@@ -192,10 +122,8 @@ def _car_locations(airports: list[ResolvedAirport], places: list[ResolvedPlace],
     return _dedupe_strings(values)[:8]
 
 
-def _infer_place_kind(value: str, airport_city: str) -> str:
+def _infer_place_kind(value: str) -> str:
     normalized = _normalize(value)
-    if airport_city and normalized == _normalize(airport_city):
-        return "city"
     if any(term in normalized for term in ["valley", "wine", "region"]):
         return "region"
     if any(term in normalized for term in ["beach", "bay", "point", "cove"]):
@@ -203,8 +131,6 @@ def _infer_place_kind(value: str, airport_city: str) -> str:
     if any(term in normalized for term in ["park", "gorge", "falls", "mount", "volcano"]):
         return "park"
     if any(term in normalized for term in ["barrio", "district", "quarter", "neighborhood", "neighbourhood"]):
-        return "neighborhood"
-    if airport_city and len(normalized.split()) <= 3:
         return "neighborhood"
     return "place"
 
@@ -228,10 +154,10 @@ def _normalize(value: str) -> str:
     return " ".join(re.sub(r"[^a-zA-Z0-9]+", " ", ascii_value).lower().split())
 
 
-def _dedupe_strings(values: object) -> list[str]:
+def _dedupe_strings(values: Iterable[object]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
-    for value in values:  # type: ignore[operator]
+    for value in values:
         text = " ".join(str(value).strip().split())
         key = text.casefold()
         if text and key not in seen:

--- a/trippy/services/lodging_shortlist.py
+++ b/trippy/services/lodging_shortlist.py
@@ -547,7 +547,7 @@ def _options_from_profile(
                 if is_private
                 else RecommendationGrade.CONDITIONAL,
                 tradeoffs=[
-                    "Private space usually fits Azores island travel if location, safety, and parking are strong."
+                    "Private space can fit destination travel if location, safety, and parking are strong."
                     if is_private
                     else "Boutique hotel comfort can be excellent, but family bed fit may require two rooms.",
                     "Do not advance unless occupancy, beds, cancellation, and access are explicit.",
@@ -1791,9 +1791,6 @@ def _structure_total_nights(option: TripPlanOption, intake: TripIntake) -> int:
 
 
 def _same_region_stay_anchors(primary_region: str, intake: TripIntake) -> list[str]:
-    text = " ".join([primary_region, *intake.destination_seeds, intake.trip_name]).lower()
-    if "azores" in text or "sao miguel" in text or "são miguel" in text:
-        return ["Ponta Delgada / south coast", "Furnas / east side", "Ribeira Grande / north coast"]
     destination = primary_region or ", ".join(intake.destination_seeds) or "destination"
     return [
         f"{destination} central base",

--- a/trippy/services/shortlist_store.py
+++ b/trippy/services/shortlist_store.py
@@ -8,7 +8,6 @@ import unicodedata
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import quote_plus
-from zoneinfo import ZoneInfo
 
 from trippy.models.shortlists import ResearchShortlistState, ShortlistCategory
 from trippy.models.sources import SourcePlan, TravelSourceCategory
@@ -243,7 +242,7 @@ def _repair_flight_duration(option: object) -> None:
     current = _duration_minutes(str(getattr(option, "total_travel_duration", "") or ""))
     should_repair = current is None or current >= 18 * 60 or (computed < current and current - computed > 30)
     if should_repair:
-        option.total_travel_duration = _format_minutes(computed)
+        object.__setattr__(option, "total_travel_duration", _format_minutes(computed))
         validation = getattr(option, "validation", None)
         if validation is not None:
             validation.extracted_fields["total_duration"] = _format_minutes(computed)
@@ -278,16 +277,7 @@ def _duration_from_option_times(option: object) -> int | None:
     return total
 
 
-AIRPORT_TIME_ZONES: dict[str, str] = {
-    "BOS": "America/New_York",
-    "GCM": "America/Cayman",
-    "LIS": "Europe/Lisbon",
-    "PDL": "Atlantic/Azores",
-    "YYZ": "America/Toronto",
-}
-
-
-def _parse_flight_datetime(date_text: str, time_text: str, airport: str) -> datetime | None:
+def _parse_flight_datetime(date_text: str, time_text: str, _airport: str) -> datetime | None:
     if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date_text.strip()):
         return None
     cleaned_time = time_text.strip().upper().replace(".", "")
@@ -305,10 +295,7 @@ def _parse_flight_datetime(date_text: str, time_text: str, airport: str) -> date
         parsed = datetime.fromisoformat(date_text).replace(hour=hour, minute=minute)
     except ValueError:
         return None
-    timezone_name = AIRPORT_TIME_ZONES.get(airport.strip().upper())
-    if not timezone_name:
-        return parsed
-    return parsed.replace(tzinfo=ZoneInfo(timezone_name))
+    return parsed
 
 
 def _duration_minutes(value: str) -> int | None:
@@ -346,8 +333,8 @@ def _normalize_flight_price_to_cad(option: object) -> None:
         total = cad_amount
         per_person = cad_amount / traveler_count
     normalized = f"CAD {_money(total)} total; CAD {_money(per_person)} per person"
-    option.fare_estimate_cad = normalized
-    option.price_band = normalized
+    object.__setattr__(option, "fare_estimate_cad", normalized)
+    object.__setattr__(option, "price_band", normalized)
     validation = getattr(option, "validation", None)
     if validation is not None:
         validation.extracted_fields["price_signal"] = normalized

--- a/trippy/services/source_research.py
+++ b/trippy/services/source_research.py
@@ -2068,7 +2068,6 @@ def _extract_price(text: str) -> str:
 def _airline_signal(text: str, request: SourceResearchRequest) -> str:
     candidates = [
         str(request.context.get("airline", "")),
-        "Azores Airlines",
         "SATA",
         "Air Canada",
         "TAP Portugal",

--- a/trippy/services/trip_ideation.py
+++ b/trippy/services/trip_ideation.py
@@ -32,10 +32,10 @@ class _ConceptTemplate:
 
 _TEMPLATES = [
     _ConceptTemplate(
-        concept_id="azores-sao-miguel-short-comfort",
-        title="Azores Sao Miguel Easy Week",
-        countries=["Portugal"],
-        destinations=["Ponta Delgada", "Furnas", "Sete Cidades"],
+        concept_id="island-nature-short-comfort",
+        title="Island Nature Easy Week",
+        countries=[],
+        destinations=["Primary island base", "Thermal or nature area", "Scenic viewpoint area"],
         recommended_duration_days=6,
         best_season="late summer or early fall",
         estimated_cost_band_cad="CAD 12k-20k for a couple before final flights and lodging",
@@ -49,8 +49,6 @@ _TEMPLATES = [
             "nature",
             "food",
             "island",
-            "azores",
-            "portugal",
             "short-flight",
             "low-crowd",
             "chill",

--- a/trippy/services/trip_map_builder.py
+++ b/trippy/services/trip_map_builder.py
@@ -204,49 +204,18 @@ def _pins_for_shortlists(
 
 def _routes_for_option(option: TripPlanOption) -> list[MapRoute]:
     routes: list[MapRoute] = []
-    if any("Sao Miguel" in region for region in option.regions):
-        routes.append(
-            MapRoute(
-                route_id="route-1",
-                label="PDL airport to Ponta Delgada/Sao Miguel base",
-                origin_query="Ponta Delgada airport",
-                destination_query="Ponta Delgada family lodging",
-                google_maps_url=_directions_url(
-                    "Ponta Delgada airport",
-                    "Ponta Delgada family lodging",
-                    MapRouteMode.DRIVING,
-                ),
-                mode=MapRouteMode.DRIVING,
-                notes="First practical route to validate with luggage and arrival timing.",
-            )
-        )
-        routes.append(
-            MapRoute(
-                route_id="route-2",
-                label="Sao Miguel west/east day drive grouping",
-                origin_query="Ponta Delgada",
-                destination_query="Sete Cidades and Furnas Azores",
-                google_maps_url=_directions_url(
-                    "Ponta Delgada",
-                    "Sete Cidades and Furnas Azores",
-                    MapRouteMode.DRIVING,
-                ),
-                mode=MapRouteMode.DRIVING,
-                notes="Use to sanity-check whether a day is overpacked.",
-            )
-        )
     if len(option.regions) > 1:
         routes.append(
             MapRoute(
                 route_id=f"route-{len(routes) + 1}",
-                label="Inter-island movement to validate",
+                label="Inter-region movement to validate",
                 origin_query=option.regions[0],
                 destination_query=option.regions[1],
                 google_maps_url=_directions_url(
                     option.regions[0], option.regions[1], MapRouteMode.DRIVING
                 ),
                 mode=MapRouteMode.DRIVING,
-                notes="Placeholder for flight/ferry research; do not treat as a literal drive route.",
+                notes="Placeholder for route research; do not treat as a validated drive route.",
             )
         )
     return routes
@@ -406,38 +375,7 @@ def _primary_route_for_pins(pins: list[MapPin]) -> MapRoute | None:
 
 
 def _expanded_queries(option: TripPlanOption) -> list[str]:
-    queries = list(option.map_seed_queries)
-    if any("Sao Miguel" in region for region in option.regions):
-        queries.extend(
-            [
-                "Ponta Delgada airport",
-                "Ponta Delgada family lodging",
-                "Ponta Delgada restaurants",
-                "Furnas Azores hot springs",
-                "Sete Cidades viewpoint",
-                "Lagoa do Fogo",
-                "Sao Miguel whale watching",
-                "Gorreana tea plantation",
-            ]
-        )
-    if any("Pico" in region or "Faial" in region for region in option.regions):
-        queries.extend(
-            [
-                "Madalena Pico family lodging",
-                "Pico Island wine landscape",
-                "Horta Faial marina restaurants",
-                "Capelinhos Volcano",
-            ]
-        )
-    if any("Terceira" in region for region in option.regions):
-        queries.extend(
-            [
-                "Angra do Heroismo family lodging",
-                "Angra do Heroismo restaurants",
-                "Algar do Carvao",
-            ]
-        )
-    return queries
+    return list(option.map_seed_queries)
 
 
 def _category(query: str) -> MapPinCategory:
@@ -456,9 +394,6 @@ def _category(query: str) -> MapPinCategory:
             "viewpoint",
             "volcano",
             "tea",
-            "lagoa",
-            "furnas",
-            "sete",
         ]
     ):
         return MapPinCategory.ACTIVITY

--- a/trippy/services/trip_planner.py
+++ b/trippy/services/trip_planner.py
@@ -81,39 +81,11 @@ class TripPlannerService:
         return self._path(trip_id)
 
     def _build_draft(self, intake: TripIntake) -> TripPlanDraft:
-        if _is_azores(intake):
-            return self._build_azores_draft(intake)
         if intake.mode == TripIntakeMode.IDEA and intake.destination_seeds:
             return self._build_generic_selected_destination_draft(intake)
         if intake.mode == TripIntakeMode.IDEA:
             return self._build_idea_draft(intake)
         return self._build_generic_selected_destination_draft(intake)
-
-    def _build_azores_draft(self, intake: TripIntake) -> TripPlanDraft:
-        duration = intake.duration_days or 10
-        country_signals = _country_signals(self._country_priors, "Portugal")
-        options = [
-            _azores_easy_option(duration, country_signals),
-            _azores_balanced_option(duration, country_signals),
-            _azores_ambitious_option(duration, country_signals),
-        ]
-        ranked = sorted(options, key=lambda option: option.recommendation_strength, reverse=True)
-        return TripPlanDraft(
-            trip_id=intake.trip_id,
-            intake_mode=intake.mode,
-            options=options,
-            recommended_option_id=ranked[0].option_id,
-            assumptions=[
-                "Azores planning starts with deterministic structure before live fares and lodging availability.",
-                "Family comfort is weighted above covering every island.",
-                "Inter-island movement must be validated against flight/ferry schedules before booking.",
-                "Portugal is not yet a historical country-prior entry, so Trippy applies family preference patterns directly and asks for live evidence.",
-            ],
-            source_notes=[
-                "Golden-path scenario: selected destination is Azores, Portugal.",
-                "Scores are planning-shape confidence, not live price or booking availability.",
-            ],
-        )
 
     def _build_idea_draft(self, intake: TripIntake) -> TripPlanDraft:
         comparison = TripIdeationService().compare(
@@ -299,176 +271,10 @@ class TripPlannerService:
             recommended_option_id=recommended,
             assumptions=[
                 "Generic selected-destination draft uses canonical TripGeography so connector inputs separate airports from map/search locations.",
-                "Replace with a destination-specific planner once enough evidence exists.",
+                "Enrich TripGeography with scanner evidence before connector-specific searches that require resolved facts.",
             ],
             source_notes=["Generated without live availability."],
         )
-
-
-def _is_azores(intake: TripIntake) -> bool:
-    text = " ".join([intake.trip_name, *intake.destination_seeds, intake.freeform_notes or ""])
-    return "azores" in text.lower()
-
-
-def _country_signals(service: CountryPriorService, country: str) -> list[str]:
-    fit = service.fit_for_country(country)
-    if fit is None:
-        return [
-            f"No direct historical country prior for {country}; use family rules around food, safety, natural beauty, practical mobility, crowd avoidance, and comfort."
-        ]
-    return [fit.rationale]
-
-
-def _azores_easy_option(duration: int, country_signals: list[str]) -> TripPlanOption:
-    strength = 88 if duration <= 8 else 82
-    return TripPlanOption(
-        option_id="azores-sao-miguel-easy",
-        title="Azores One-Island Easy Version",
-        summary="Base on Sao Miguel, prioritize Ponta Delgada/Furnas/Sete Cidades, and avoid inter-island logistics.",
-        duration_days=duration,
-        regions=["Sao Miguel"],
-        nights_by_region={"Sao Miguel": max(1, duration - 1)},
-        rationale=[
-            "Best if the goal is a beautiful, low-friction first Azores trip.",
-            "One rental car, one lodging base, and fewer packing/airport transitions protects family comfort.",
-            "Still gives strong nature, hot springs, coast, food, whale watching, and scenic drives.",
-        ],
-        travel_burden="meaningful transatlantic trip; verify direct or one-stop YYZ-PDL routing",
-        island_region_movement_friction="low: no inter-island flights or ferries",
-        family_comfort_score=89,
-        food_fit="Good for seafood, cozido in Furnas, Ponta Delgada restaurants, and casual local food.",
-        driving_fit="Good if using a comfortable rental car; still vet narrow roads, parking, and night driving.",
-        crowd_fit="Generally workable; avoid peak cruise-ship windows and crowded hot springs times.",
-        major_risks=[
-            "May feel too narrow if the family wants the broader Azores geography.",
-            "Car rental fit, luggage capacity, and parking at lodging need validation.",
-            "Weather can change quickly; build flexible indoor/short-drive backups.",
-        ],
-        recommendation_strength=strength,
-        lodging_strategy="Choose a safe, practical Sao Miguel base with 3+ beds, king-bed upside if available, parking, and easy food access.",
-        car_strategy="Rental car likely useful; prioritize automatic, luggage capacity, clear pickup, and cancellation terms.",
-        country_prior_signals=country_signals,
-        map_seed_queries=[
-            "Ponta Delgada airport",
-            "Ponta Delgada family lodging",
-            "Furnas Azores",
-            "Sete Cidades",
-            "Lagoa do Fogo",
-            "Sao Miguel whale watching",
-            "Ponta Delgada restaurants",
-        ],
-        required_research=_required_research(),
-    )
-
-
-def _azores_balanced_option(duration: int, country_signals: list[str]) -> TripPlanOption:
-    enough_time = duration >= 9
-    strength = 91 if enough_time else 70
-    return TripPlanOption(
-        option_id="azores-two-island-balanced",
-        title="Azores Two-Island Balanced Version",
-        summary="Use Sao Miguel plus Pico/Faial to get the main-island ease and a second-island adventure without overpacking.",
-        duration_days=duration,
-        regions=["Sao Miguel", "Pico or Faial"],
-        nights_by_region=_balanced_azores_nights(duration),
-        rationale=[
-            "Best first recommendation for 9-12 days: it materially broadens the trip while preserving downtime.",
-            "Sao Miguel provides the easiest base; Pico/Faial adds volcanic landscapes, ocean, wine/food, and a more distinct island feel.",
-            "One inter-island move is manageable if flights/ferries are buffered and luggage handling is simple.",
-        ],
-        travel_burden="meaningful international flight plus one inter-island segment",
-        island_region_movement_friction="moderate: one inter-island flight or ferry with weather/schedule buffer",
-        family_comfort_score=87 if enough_time else 72,
-        food_fit="Strong enough if food clusters are researched in Ponta Delgada plus Horta/Madalena; validate hours and reservations.",
-        driving_fit="Good with rental cars on each island; verify road comfort, parking, and pickup/dropoff logistics.",
-        crowd_fit="Good: easier to avoid crowd concentrations than a single most-touristed itinerary.",
-        major_risks=[
-            "Inter-island weather and schedule changes can disrupt the plan; avoid same-day tight flight chains.",
-            "Two car rentals and two lodgings increase admin load.",
-            "Needs explicit bed-layout validation for family of 5 in both bases.",
-        ],
-        recommendation_strength=strength,
-        lodging_strategy="Two comfortable bases: practical Sao Miguel lodging plus a well-located Pico/Faial stay with 3+ beds and parking.",
-        car_strategy="Likely rent cars on both islands; avoid cross-island pickup/dropoff ambiguity and weak cancellation terms.",
-        country_prior_signals=country_signals,
-        map_seed_queries=[
-            "Ponta Delgada airport",
-            "Ponta Delgada family lodging",
-            "Furnas Azores",
-            "Sete Cidades",
-            "Pico Island Azores family lodging",
-            "Madalena Pico restaurants",
-            "Horta Faial marina",
-            "Capelinhos Volcano",
-        ],
-        required_research=_required_research()
-        + [
-            "Inter-island flight/ferry schedule buffers and backup plan.",
-            "Whether Pico or Faial has the better lodging fit for 3+ beds and parking.",
-        ],
-    )
-
-
-def _azores_ambitious_option(duration: int, country_signals: list[str]) -> TripPlanOption:
-    enough_time = duration >= 12
-    strength = 83 if enough_time else 58
-    return TripPlanOption(
-        option_id="azores-three-island-ambitious",
-        title="Azores More Ambitious Version",
-        summary="Sao Miguel plus Terceira plus Pico/Faial for a broader Azores sampler if the trip is long enough.",
-        duration_days=duration,
-        regions=["Sao Miguel", "Terceira", "Pico or Faial"],
-        nights_by_region=_three_island_nights(duration),
-        rationale=[
-            "Works only if the trip is long enough to absorb multiple transitions.",
-            "Adds Angra do Heroismo, more food/history, and another island personality.",
-            "Useful as an upper-bound comparison, not the default comfort-first recommendation.",
-        ],
-        travel_burden="high: international flight plus multiple inter-island movements",
-        island_region_movement_friction="high unless duration is 12+ days and schedule buffers are strong",
-        family_comfort_score=81 if enough_time else 61,
-        food_fit="Potentially good, but short stays risk missing the best restaurants and relaxed meals.",
-        driving_fit="Several car-rental handoffs; only worth it with clear pickup/dropoff and luggage fit.",
-        crowd_fit="Can avoid crowds by spreading sights, but transition days reduce flexibility.",
-        major_risks=[
-            "Too many moves can waste precious trip time and create stress.",
-            "Weather disruption risk compounds across inter-island segments.",
-            "Three lodging searches with family bed requirements is a real planning load.",
-        ],
-        recommendation_strength=strength,
-        lodging_strategy="Only pursue if each island has a clear lodging win with 3+ beds, parking, and easy logistics.",
-        car_strategy="Use car rentals selectively and compare against transfers/tours on shorter island stays.",
-        country_prior_signals=country_signals,
-        map_seed_queries=[
-            "Ponta Delgada airport",
-            "Furnas Azores",
-            "Angra do Heroismo restaurants",
-            "Terceira family lodging",
-            "Pico Island Azores",
-            "Horta Faial marina",
-            "Azores whale watching",
-        ],
-        required_research=_required_research()
-        + [
-            "Exact inter-island route sequencing and weather backup.",
-            "Minimum two-night stay per island with no same-day risky connections.",
-        ],
-    )
-
-
-def _balanced_azores_nights(duration: int) -> dict[str, int]:
-    nights = max(1, duration - 1)
-    second = max(3, min(4, nights // 3))
-    first = max(1, nights - second)
-    return {"Sao Miguel": first, "Pico or Faial": second}
-
-
-def _three_island_nights(duration: int) -> dict[str, int]:
-    nights = max(1, duration - 1)
-    sao = max(3, nights - 6)
-    terceira = 3 if nights >= 8 else max(1, nights // 3)
-    pico_faial = max(1, nights - sao - terceira)
-    return {"Sao Miguel": sao, "Terceira": terceira, "Pico or Faial": pico_faial}
 
 
 def _even_nights(regions: list[str], duration_days: int) -> dict[str, int]:

--- a/trippy/services/trip_workspace.py
+++ b/trippy/services/trip_workspace.py
@@ -739,19 +739,21 @@ def _placeholder_segments(
     shortlists: dict[str, Any] | None = None,
 ) -> list[Segment]:
     origin = intake.departure_airports[0] if intake.departure_airports else "YYZ"
+    gateway = intake.geography.primary_gateway_iata() if intake.geography else None
+    destination = gateway or "DESTINATION_AIRPORT_REQUIRED"
     segments = [
         Segment(
             segment_id="flight-outbound-research",
             segment_type=SegmentType.FLIGHT,
             origin=origin,
-            destination="PDL",
+            destination=destination,
             confirmation_code="UNCONFIRMED",
             notes=f"Research outbound for {option.title}; prefer direct or sane one-stop.",
         ),
         Segment(
             segment_id="flight-return-research",
             segment_type=SegmentType.FLIGHT,
-            origin="PDL",
+            origin=destination,
             destination=origin,
             confirmation_code="UNCONFIRMED",
             notes="Research return with family-friendly departure time and baggage/seat clarity.",

--- a/trippy/ui/server.py
+++ b/trippy/ui/server.py
@@ -181,7 +181,7 @@ class TrippyUIService:
         intake = TripIntake(
             trip_id=str(payload.get("trip_id") or ""),
             mode=mode,
-            trip_name=str(payload.get("trip_name") or "Azores 2027"),
+            trip_name=str(payload.get("trip_name") or "New trip"),
             destination_seeds=destination_seeds,
             travel_window=TravelWindow(
                 label=_optional_str(payload.get("travel_window")),

--- a/trippy/ui/static/app.js
+++ b/trippy/ui/static/app.js
@@ -2419,7 +2419,7 @@ function stayStructureForm(structure) {
       </label>
     </div>
     <label>Edit nights
-      <textarea name="night_plan_text" rows="4" placeholder="Ponta Delgada | 4 | lodging-1 | central base&#10;Furnas | 3 | lodging-2 | hot springs side">${escapeHtml(text)}</textarea>
+      <textarea name="night_plan_text" rows="4" placeholder="Primary base | 4 | lodging-1 | central base&#10;Second area | 3 | lodging-2 | activity side">${escapeHtml(text)}</textarea>
     </label>
     <label>Why this structure?
       <textarea name="notes" rows="2" placeholder="What tradeoff are we testing?">${escapeHtml(structure.manual_notes || "")}</textarea>


### PR DESCRIPTION
## Summary

- Removes destination-specific branching from `trippy/services/destination_profiles.py`
- Generates flight/lodging/car/activity targets from canonical geography buckets instead of named destination profiles
- Ensures flight providers receive only resolved IATA gateway codes
- Keeps unresolved destinations useful for lodging/activity/place research while forcing flight adapters to fail closed until a gateway airport is resolved
- Updates geography regression tests to assert the generalized anti-hardcoding behavior

## Why

The previous profile layer still behaved like a hardcoded destination profile system. That prevented Trippy from being a generalized AI trip planner and risked raw itinerary/neighborhood strings leaking into flight route codes.

## Validation

Not run in this environment. Expected local checks:

```bash
uv run pytest tests/unit/test_trip_geography.py
uv run pytest
uv run mypy trippy/
uv run ruff check .
```