### PR TITLE
[codex] qa: enforce JSON-first destination-agnostic trip state

### DIFF
--- a/docs/qa/json_first_destination_agnostic_audit.md
+++ b/docs/qa/json_first_destination_agnostic_audit.md
@@ -63,11 +63,14 @@ uv run ruff check .
 - `trippy/services/trip_planner.py`: selected-destination drafts used country priors by matching raw seeds/destination text. Restricted country-prior lookup to explicit `geography.country`.
 - `tests/unit/test_trip_planning_pipeline.py`: tests expected canned flight fallback rows. Updated to assert fail-closed behavior and to use user-supplied candidates where candidate workflow behavior is under test.
 
-### P1 Remaining
+### P1 Fixed In Follow-Up
 
-- `trippy/services/trip_ideation.py`: idea-stage trip generation is still based on destination-specific templates such as Cayman, Lisbon/Portugal, Japan, Costa Rica, and Italy. This is acceptable only for explicit idea inspiration, not selected-destination planning. Recommended next PR: replace templates with provider/scanner-backed idea sources or clearly mark the module as inspiration-only and keep it out of downstream trip execution.
-- `trippy/services/country_priors.py`: country prior data contains destination facts. Selected-destination planning no longer scans raw seeds for these priors, but idea ranking still uses them. Recommended next PR: require explicit user-approved country field or past-trip evidence scope before applying priors.
-- `trippy/skills/runners/itinerary_builder.py`: skill runner can synthesize itinerary city rows from destination summaries. It appears skill-scoped rather than connector/bookable output, but should be hardened to require canonical trip state and mark unresolved rows.
+- `trippy/services/trip_ideation.py`: replaced destination-specific idea templates with destination-agnostic scanner briefs. Idea output no longer names cities, countries, airports, neighborhoods, or known destinations.
+- `trippy/services/trip_planner.py`, `trippy/services/planning_advisor.py`, and `trippy/services/friction_detector.py`: removed raw destination-text country-prior matching. Country priors now require explicit enriched country fields, such as canonical lodging country or `TripGeography.country`.
+- `trippy/skills/runners/itinerary_builder.py`: removed fallback splitting of `destination_summary`; the runner now requires explicit destinations from canonical JSON or user-approved resolver output and marks generated rows as requiring confirmation.
+- `trippy/skills/runners/trip_sheet_creator.py` and its skill definition: removed destination-specific checklist flags and destination examples.
+- `trippy/services/phase_planner.py`, `trippy/integrations/telegram_bot.py`, and `trippy/models/trip.py`: replaced named destination examples in runtime-facing copy/docstrings with destination-neutral examples.
+- `trippy/ui/server.py`: added `/api/trip-json` export/import for enriched `TripIntake` JSON plus resolver evidence.
 
 ### P2 Accepted
 
@@ -83,7 +86,7 @@ uv run ruff check .
 - Lodging/activity/car targets can still use unresolved user-entered place text for scanner/search handoff.
 - Flight live providers require IATA route codes; no raw destination string is used as a flight route after this patch.
 - Workspace reads selected plan, canonical geography, and shortlist state. Remaining placeholders are marked unconfirmed/seeded, not live/bookable.
-- UI/API exposes `/api/state`, `/api/trip`, intake creation, shortlist, workspace, and map endpoints. A dedicated JSON import/export editing path and resolver evidence editor are not yet first-class UI flows.
+- UI/API exposes `/api/state`, `/api/trip`, `/api/trip-json`, intake creation, shortlist, workspace, and map endpoints. `/api/trip-json` returns enriched `TripIntake` JSON plus resolver evidence and accepts edited/enriched JSON back into canonical intake state.
 
 ## Tests Added or Changed
 
@@ -103,24 +106,25 @@ uv run ruff check .
 - Blocked raw destination text from becoming user-candidate arrival airport/routes.
 - Removed Portugal/Schengen/euro workspace defaults.
 - Restricted selected-destination country-prior lookup to explicit enriched geography.
+- Replaced hardcoded idea-stage destination templates with generic scanner briefs.
+- Added enriched TripIntake JSON import/export and resolver-evidence payloads.
+- Hardened itinerary and trip-sheet skills to avoid destination-specific examples, flags, and summary-splitting.
+- Removed remaining runtime-facing named-destination example strings outside explicit priors/demos.
 
 ## Remaining Risks
 
-- Idea generation still uses hardcoded concept templates and can return named destinations as suggestions.
-- UI does not yet provide a dedicated enriched JSON import/export editor or resolver evidence confirmation workflow.
-- Some skill definitions and runners still contain example destination itinerary structures and should be reviewed before being used as production planning paths.
+- `trippy/services/country_priors.py` still stores historical country priors for explicit country use. This is acceptable only when the country is present in enriched JSON or canonical stay data, not when inferred from raw destination text.
+- Named destinations remain in fixtures, tests, docs, and `trippy/thin_slice.py` demo data.
 
 ## Check Results
 
 - `uv run pytest tests/unit/test_trip_geography.py`: 6 passed.
 - `uv run pytest tests/unit/test_trip_planning_pipeline.py`: 28 passed.
-- `uv run pytest`: 345 passed, 5 skipped.
+- `uv run pytest`: 346 passed, 5 skipped.
 - `uv run mypy trippy/`: success, no issues in 91 source files.
 - `uv run ruff check .`: all checks passed.
 
 ## Recommended Next PRs
 
-1. Replace or quarantine `trip_ideation.py` templates behind an explicit "inspiration examples" mode.
-2. Add a UI/API path for importing, viewing, editing, and exporting enriched `TripIntake` JSON, including resolver evidence and user confirmation status.
-3. Harden itinerary-builder skill runner so it can only create itinerary rows from canonical trip JSON or explicit user-supplied rows.
-4. Add CI grep checks for destination-specific production code and generated fallback flight/lodging/car/activity rows.
+1. Add CI grep checks for destination-specific production code and generated fallback flight/lodging/car/activity rows.
+2. Build a richer browser editor around `/api/trip-json` for field-by-field resolver confirmation.

--- a/docs/qa/json_first_destination_agnostic_audit.md
+++ b/docs/qa/json_first_destination_agnostic_audit.md
@@ -1,0 +1,126 @@
+# JSON-First Destination-Agnostic Audit
+
+Date: 2026-04-30
+Branch: `codex/json-first-qa-hardening`
+
+## Executive Summary
+
+Trippy is mostly aligned around canonical `TripIntake.geography` and `DestinationProfile`, but the audit found production paths that could still move planning away from explicit JSON state:
+
+- Flight shortlists created canned Google Flights/Kayak candidate rows when live providers returned nothing.
+- User-supplied flight candidates could build route links from raw destination text when no destination IATA was resolved.
+- Workspace logistics contained Portugal/Schengen/euro defaults.
+- Selected-destination planning used country priors by scanning raw destination text.
+
+Those P0/P1 production issues were fixed in this branch. Flights now fail closed without live provider rows or user-supplied itinerary evidence, and flight route links require IATA origin and destination codes.
+
+## Files Inspected
+
+- `trippy/models/trip_planning.py`
+- `trippy/services/destination_profiles.py`
+- `trippy/services/geography_resolver.py`
+- `trippy/services/flight_shortlist.py`
+- `trippy/services/lodging_shortlist.py`
+- `trippy/services/car_shortlist.py`
+- `trippy/services/activity_shortlist.py`
+- `trippy/services/trip_planner.py`
+- `trippy/services/trip_workspace.py`
+- `trippy/services/trip_ideation.py`
+- `trippy/services/country_priors.py`
+- `trippy/services/shortlist_store.py`
+- `trippy/ui/server.py`
+- `trippy/ui/static/app.js`
+- `tests/unit/test_trip_geography.py`
+- `tests/unit/test_trip_planning_pipeline.py`
+- `README.md`, `AGENTS.md`, `pyproject.toml`
+
+## Commands Run
+
+```bash
+grep -RIn "Chile\|Santiago\|Grand Cayman\|Azores\|Cayman\|Providencia\|Bellavista\|Barrio Italia\|Maipo\|SCL\|GCM\|PDL\|Ponta Delgada\|Seven Mile\|Rum Point\|Stingray\|Tokyo\|Bangkok\|Costa Rica\|Lisbon\|Paris\|London\|Rome\|New York" trippy tests README.md docs .env.example pyproject.toml
+grep -RIn "golden path\|demo\|sample\|fixture\|fallback\|hardcoded\|static\|canned\|template\|mock\|stub\|fake\|placeholder\|known destination\|profile_for\|destination_profile\|if .*destination\|if .*trip_name\|if .*seed" trippy tests README.md docs
+grep -RIn "IATA\|airport_catalog\|AIRPORT_CATALOG\|primary_gateway\|gateway_airport\|destination_airports\|iata_code" trippy tests
+rg -n "weather|beach|island|city scoring|family friendly|best areas|avoid this region|gateway|neighborhood|destination contains|contains\(.*destination|if .* in .*destination|Google Flights|Booking|Expedia|Hotels|rental|maps\.google|deep link|deeplink" trippy tests
+rg -n "country=\"Portugal\"|Schengen|euros|Duffel Airways|flight-direct-route|one-stop same-ticket candidate|price sanity-check candidate|DESTINATION_AIRPORT_REQUIRED|fit_for_text\(seed\)|destination_seeds\).*flight|destination_seeds.*gateway" trippy tests
+uv run pytest tests/unit/test_trip_geography.py
+uv run pytest tests/unit/test_trip_planning_pipeline.py
+uv run pytest
+uv run mypy trippy/
+uv run ruff check .
+```
+
+## Findings
+
+### P0 Fixed
+
+- `trippy/services/flight_shortlist.py`: provider failure generated three canned flight options with airline labels, Google Flights/Kayak links, fare language, comfort scores, and recommendation grades. Fixed by removing fallback flight option generation. The shortlist now records warnings and zero flight rows unless live providers or user evidence supply rows.
+- `trippy/services/flight_shortlist.py`: user flight candidates without resolved gateway could use raw `destination_seeds` as the arrival airport and build comparison links. Fixed by returning `DESTINATION_AIRPORT_REQUIRED` and suppressing route links unless both origin and destination are valid IATA codes.
+
+### P1 Fixed
+
+- `trippy/services/trip_workspace.py`: workspace logistics rows included Portugal/Schengen/euro defaults. Replaced with destination-agnostic entry/currency/local-movement language.
+- `trippy/services/trip_workspace.py`: placeholder stay country was hardcoded to Portugal. Replaced with `intake.geography.country` when explicitly present, otherwise blank.
+- `trippy/services/trip_planner.py`: selected-destination drafts used country priors by matching raw seeds/destination text. Restricted country-prior lookup to explicit `geography.country`.
+- `tests/unit/test_trip_planning_pipeline.py`: tests expected canned flight fallback rows. Updated to assert fail-closed behavior and to use user-supplied candidates where candidate workflow behavior is under test.
+
+### P1 Remaining
+
+- `trippy/services/trip_ideation.py`: idea-stage trip generation is still based on destination-specific templates such as Cayman, Lisbon/Portugal, Japan, Costa Rica, and Italy. This is acceptable only for explicit idea inspiration, not selected-destination planning. Recommended next PR: replace templates with provider/scanner-backed idea sources or clearly mark the module as inspiration-only and keep it out of downstream trip execution.
+- `trippy/services/country_priors.py`: country prior data contains destination facts. Selected-destination planning no longer scans raw seeds for these priors, but idea ranking still uses them. Recommended next PR: require explicit user-approved country field or past-trip evidence scope before applying priors.
+- `trippy/skills/runners/itinerary_builder.py`: skill runner can synthesize itinerary city rows from destination summaries. It appears skill-scoped rather than connector/bookable output, but should be hardened to require canonical trip state and mark unresolved rows.
+
+### P2 Accepted
+
+- Named destinations in docs, fixtures, importer/parser tests, friction tests, and OpenClaw/Firecrawl tests are mostly sample strings or isolated fixture evidence.
+- `trippy/thin_slice.py` is an explicit demo path and does not appear to be default runtime state.
+- UI placeholder copy and docs examples mention destinations but do not directly drive scanner/provider behavior.
+- `shortlist_store.py` retains Duffel sandbox filtering strings for "Duffel Airways"; this is provider-sandbox defense, not destination steering.
+
+## JSON-First Verification
+
+- Intake canonicalization only accepts explicit three-letter airport strings as airport refs; non-airport destination chunks become unresolved `TripMapLocation` values.
+- `DestinationProfile` exposes flight gateways only from `TripGeography.destination_airports`.
+- Lodging/activity/car targets can still use unresolved user-entered place text for scanner/search handoff.
+- Flight live providers require IATA route codes; no raw destination string is used as a flight route after this patch.
+- Workspace reads selected plan, canonical geography, and shortlist state. Remaining placeholders are marked unconfirmed/seeded, not live/bookable.
+- UI/API exposes `/api/state`, `/api/trip`, intake creation, shortlist, workspace, and map endpoints. A dedicated JSON import/export editing path and resolver evidence editor are not yet first-class UI flows.
+
+## Tests Added or Changed
+
+- Added/updated `tests/unit/test_trip_geography.py` coverage for:
+  - arbitrary brain dump remains unresolved
+  - explicit IATA accepted without invented city/country
+  - enriched JSON drives gateway/lodging/activity/car targets
+  - concatenated raw destination cannot become a route
+  - provider failure creates no fake flight rows
+  - user flight candidate without destination IATA gets no route links
+- Updated `tests/unit/test_trip_planning_pipeline.py` to stop expecting generated fallback flight rows and to use explicit user candidates for candidate selection/research tests.
+
+## Fixes Made
+
+- Removed canned fallback flight row creation.
+- Added IATA guard to flight deep-link builders.
+- Blocked raw destination text from becoming user-candidate arrival airport/routes.
+- Removed Portugal/Schengen/euro workspace defaults.
+- Restricted selected-destination country-prior lookup to explicit enriched geography.
+
+## Remaining Risks
+
+- Idea generation still uses hardcoded concept templates and can return named destinations as suggestions.
+- UI does not yet provide a dedicated enriched JSON import/export editor or resolver evidence confirmation workflow.
+- Some skill definitions and runners still contain example destination itinerary structures and should be reviewed before being used as production planning paths.
+
+## Check Results
+
+- `uv run pytest tests/unit/test_trip_geography.py`: 6 passed.
+- `uv run pytest tests/unit/test_trip_planning_pipeline.py`: 28 passed.
+- `uv run pytest`: 345 passed, 5 skipped.
+- `uv run mypy trippy/`: success, no issues in 91 source files.
+- `uv run ruff check .`: all checks passed.
+
+## Recommended Next PRs
+
+1. Replace or quarantine `trip_ideation.py` templates behind an explicit "inspiration examples" mode.
+2. Add a UI/API path for importing, viewing, editing, and exporting enriched `TripIntake` JSON, including resolver evidence and user confirmation status.
+3. Harden itinerary-builder skill runner so it can only create itinerary rows from canonical trip JSON or explicit user-supplied rows.
+4. Add CI grep checks for destination-specific production code and generated fallback flight/lodging/car/activity rows.

--- a/tests/unit/test_firecrawl.py
+++ b/tests/unit/test_firecrawl.py
@@ -341,8 +341,12 @@ def test_firecrawl_merges_into_shortlist_pipeline(
     planner = TripPlannerService(intake_service)
     planner.draft(created.trip_id)
     planner.select_option(created.trip_id, "two-region-balanced")
-    state: ResearchShortlistState = FlightShortlistService(intake_service, planner).build(
-        created.trip_id
+    state: ResearchShortlistState = FlightShortlistService(
+        intake_service, planner
+    ).add_candidate(
+        created.trip_id,
+        link="https://www.google.com/travel/flights/search",
+        notes="YYZ to PDL flight candidate; source policy evidence pending.",
     )
 
     firecrawl = FirecrawlService(api_key="test-key", enabled=True)

--- a/tests/unit/test_openclaw_adapter.py
+++ b/tests/unit/test_openclaw_adapter.py
@@ -286,7 +286,11 @@ def _build_state_with_openclaw(
         return _completed(stdout=json.dumps(openclaw_payload), returncode=runner_returncode)
 
     if category == ShortlistCategory.FLIGHTS:
-        state = FlightShortlistService(intake_service, planner).build("azores-family-2027")
+        state = FlightShortlistService(intake_service, planner).add_candidate(
+            "azores-family-2027",
+            link="https://www.google.com/travel/flights/search",
+            notes="YYZ to PDL flight candidate; OpenClaw evidence pending.",
+        )
     elif category == ShortlistCategory.LODGING:
         state = LodgingShortlistService(intake_service, planner).build("azores-family-2027")
     elif category == ShortlistCategory.CARS:

--- a/tests/unit/test_trip_geography.py
+++ b/tests/unit/test_trip_geography.py
@@ -10,6 +10,9 @@ from trippy.models.trip_planning import (
     TripMapLocation,
 )
 from trippy.services.destination_profiles import profile_for_intake
+from trippy.services.flight_shortlist import FlightShortlistService
+from trippy.services.trip_intake import TripIntakeService
+from trippy.services.trip_planner import TripPlannerService
 
 
 def test_brain_dump_creates_unresolved_places_not_inferred_airports() -> None:
@@ -61,40 +64,41 @@ def test_explicit_iata_destination_code_is_accepted_without_invented_place_facts
 def test_pre_enriched_trip_json_drives_connector_targets() -> None:
     intake = TripIntake(
         mode=TripIntakeMode.SELECTED_DESTINATION,
-        trip_name="Resolved trip",
-        destination_seeds=["Santiago, Chile"],
+        trip_name="Resolved JSON trip",
+        destination_seeds=["Somewhere"],
         departure_airports=["YYZ"],
         geography=TripGeography(
-            primary_destination_name="Santiago, Chile",
-            country="Chile",
+            primary_destination_name="Somewhere",
             destination_airports=[
                 TravelAirportRef(
-                    iata_code="SCL",
-                    city="Santiago",
-                    country="Chile",
+                    iata_code="ABC",
+                    city="User Supplied City",
+                    country="User Supplied Country",
                     source="test_fixture",
                 )
             ],
             map_locations=[
                 TripMapLocation(
-                    name="Providencia",
-                    city="Santiago",
-                    country="Chile",
+                    name="User Supplied District",
+                    city="User Supplied City",
                     use_for=["lodging", "activity"],
                 )
             ],
-            lodging_search_locations=["Providencia, Santiago, Chile"],
-            activity_search_locations=["Maipo Valley, Chile"],
-            car_search_locations=["SCL"],
+            lodging_search_locations=["User Supplied District"],
+            activity_search_locations=["User Supplied Activity Area"],
+            car_search_locations=["ABC"],
         ),
     )
 
     profile = profile_for_intake(intake)
 
-    assert profile.gateway_airports == ["SCL"]
-    assert any("Providencia" in str(target) for target in profile.lodging_search_targets)
-    assert any("Maipo Valley" in str(target) for target in profile.activity_search_targets)
-    assert any("SCL" in str(target) for target in profile.car_search_targets)
+    assert profile.gateway_airports == ["ABC"]
+    assert any("User Supplied District" in str(target) for target in profile.lodging_search_targets)
+    assert any(
+        "User Supplied Activity Area" in str(target)
+        for target in profile.activity_search_targets
+    )
+    assert any("ABC" in str(target) for target in profile.car_search_targets)
 
 
 def test_raw_concatenated_destination_cannot_become_route_code() -> None:
@@ -116,3 +120,67 @@ def test_raw_concatenated_destination_cannot_become_route_code() -> None:
 
     profile = profile_for_intake(intake)
     assert profile.gateway_airports == []
+
+
+def test_provider_failure_does_not_create_fake_bookable_flight_rows(
+    tmp_path, monkeypatch
+) -> None:
+    from trippy import config
+
+    monkeypatch.setattr(config, "INTAKES_PATH", tmp_path / "intakes")
+    monkeypatch.setattr(config, "PLANS_PATH", tmp_path / "plans")
+    monkeypatch.setattr(config, "SHORTLISTS_PATH", tmp_path / "shortlists")
+
+    intake_service = TripIntakeService()
+    intake = intake_service.create(
+        TripIntake(
+            mode=TripIntakeMode.SELECTED_DESTINATION,
+            trip_name="Resolved gateway",
+            destination_seeds=["SCL"],
+            departure_airports=["YYZ"],
+        )
+    )
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+
+    flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
+
+    assert flights.flight_options == []
+    assert flights.recommended_option_id is None
+    assert any("failed closed" in warning for warning in flights.warnings)
+    assert not any("CAD" in warning for warning in flights.warnings)
+
+
+def test_user_flight_candidate_without_destination_iata_gets_no_route_links(
+    tmp_path, monkeypatch
+) -> None:
+    from trippy import config
+
+    monkeypatch.setattr(config, "INTAKES_PATH", tmp_path / "intakes")
+    monkeypatch.setattr(config, "PLANS_PATH", tmp_path / "plans")
+    monkeypatch.setattr(config, "SHORTLISTS_PATH", tmp_path / "shortlists")
+
+    intake_service = TripIntakeService()
+    intake = intake_service.create(
+        TripIntake(
+            mode=TripIntakeMode.SELECTED_DESTINATION,
+            trip_name="Chile family trip",
+            destination_seeds=[
+                "Santiago-Providencia-Santiago-Bellavista-Santiago-Barrio-Italia-Maipo-Valley"
+            ],
+            departure_airports=["YYZ"],
+        )
+    )
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+
+    flights = FlightShortlistService(intake_service, planner).add_candidate(
+        intake.trip_id,
+        link="",
+        notes="raw destination text only; no destination airport supplied",
+    )
+    candidate = flights.flight_options[0]
+
+    assert candidate.arrival_airport == "DESTINATION_AIRPORT_REQUIRED"
+    assert candidate.comparison_links == {}
+    assert "Santiago-Providencia" not in candidate.deep_link

--- a/tests/unit/test_trip_ideation.py
+++ b/tests/unit/test_trip_ideation.py
@@ -33,8 +33,10 @@ def test_trip_ideas_penalize_long_flights_for_short_max() -> None:
         limit=20,
     )
 
-    japan = next(c for c in comparison.concepts if c.concept_id == "japan-food-rail-cities")
-    assert any("exceeds requested max" in reason for reason in japan.why_it_may_not_fit)
+    long_burden = next(
+        c for c in comparison.concepts if c.concept_id == "json-first-activity-led-sampler"
+    )
+    assert any("exceeds requested max" in reason for reason in long_burden.why_it_may_not_fit)
 
 
 def test_trip_ideas_respect_short_duration_before_generic_ranking() -> None:
@@ -51,14 +53,15 @@ def test_trip_ideas_respect_short_duration_before_generic_ranking() -> None:
 
     assert len(comparison.concepts) == 3
     assert all(concept.recommended_duration_days <= 6 for concept in comparison.concepts)
-    assert not any(
-        concept.concept_id in {"mexico-city-oaxaca-food", "portugal-food-cities-coast"}
-        for concept in comparison.concepts
-    )
+    assert {concept.concept_id for concept in comparison.concepts} <= {
+        "json-first-low-friction-single-base",
+        "json-first-food-culture-base",
+        "json-first-nature-water-base",
+    }
     assert any("Requested duration is 6" in note for note in comparison.scoring_notes)
 
 
-def test_trip_ideas_respect_explicit_caribbean_region_intent() -> None:
+def test_trip_ideas_do_not_convert_region_words_to_destination_catalog() -> None:
     comparison = TripIdeationService().compare(
         TripIdeaRequest(
             duration_days=6,
@@ -70,18 +73,19 @@ def test_trip_ideas_respect_explicit_caribbean_region_intent() -> None:
         limit=3,
     )
 
-    concept_ids = {concept.concept_id for concept in comparison.concepts}
     assert len(comparison.concepts) == 3
-    assert "island-nature-short-comfort" not in concept_ids
-    assert concept_ids <= {
-        "belize-reef-jungle-short",
-        "curacao-color-beach-drivable-short",
-        "st-lucia-private-rental-food-short",
-        "mexico-caribbean-food-beach-short",
-    }
+    output_text = " ".join(
+        [
+            *(concept.title for concept in comparison.concepts),
+            *(slot for concept in comparison.concepts for slot in concept.destinations),
+            *comparison.scoring_notes,
+        ]
+    ).lower()
+    assert "caribbean" not in output_text
+    assert all(not concept.country_prior_signals for concept in comparison.concepts)
     assert all(concept.recommended_duration_days <= 6 for concept in comparison.concepts)
     assert any(
-        "Explicit destination intent detected: caribbean" in note
+        "Regional wording was treated as user intent only" in note
         for note in comparison.scoring_notes
     )
 
@@ -99,17 +103,15 @@ def test_trip_ideas_treat_snorkeling_as_required_experience() -> None:
         limit=3,
     )
 
-    concept_ids = {concept.concept_id for concept in comparison.concepts}
     assert len(comparison.concepts) == 3
-    assert concept_ids <= {
-        "belize-reef-jungle-short",
-        "cayman-reef-food-easy-week",
-        "curacao-color-beach-drivable-short",
-        "mexico-caribbean-food-beach-short",
-    }
-    assert "quebec-city-montreal-food-short" not in concept_ids
-    assert "mexico-city-food-short" not in concept_ids
-    assert "island-nature-short-comfort" not in concept_ids
+    output_text = " ".join(
+        [
+            *(concept.title for concept in comparison.concepts),
+            *(slot for concept in comparison.concepts for slot in concept.destinations),
+        ]
+    ).lower()
+    assert "cayman" not in output_text
+    assert "belize" not in output_text
     assert all(
         any("snorkeling" in item for item in concept.rationale) for concept in comparison.concepts
     )
@@ -118,16 +120,16 @@ def test_trip_ideas_treat_snorkeling_as_required_experience() -> None:
     )
 
 
-def test_trip_ideas_include_country_prior_rationale() -> None:
+def test_trip_ideas_do_not_include_country_prior_rationale() -> None:
     comparison = TripIdeationService().compare(
         TripIdeaRequest(duration_days=14, goals=["food", "culture"]),
         limit=10,
     )
 
-    japan = next(c for c in comparison.concepts if c.concept_id == "japan-food-rail-cities")
-    italy = next(c for c in comparison.concepts if c.concept_id == "italy-food-culture-rail")
-
-    assert japan.country_prior_signals
-    assert any("past country-level history" in item for item in japan.rationale)
-    assert any("expense" in item for item in japan.why_it_may_not_fit)
-    assert any("summer heat" in item for item in italy.why_it_may_not_fit)
+    assert all(not concept.country_prior_signals for concept in comparison.concepts)
+    assert not any(
+        "past country-level history" in item
+        for concept in comparison.concepts
+        for item in concept.rationale
+    )
+    assert any("destination-agnostic scanner briefs" in note for note in comparison.scoring_notes)

--- a/tests/unit/test_trip_planning_pipeline.py
+++ b/tests/unit/test_trip_planning_pipeline.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import base64
 import json
 from datetime import date
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from typer.testing import CliRunner
@@ -105,7 +103,7 @@ def test_azores_golden_path_services(
     }
     tabs = {tab.name: tab for tab in state.tabs}
     assert tabs["Flights"].rows[0][1] in {"seeded", "researched", "verified_live"}
-    assert tabs["Flights"].rows[0][2] == "yes"
+    assert tabs["Flights"].rows[0][2] == ""
     assert tabs["Lodging"].rows[0][1] in {"recommended", "researched"}
     assert tabs["Cars"].rows[0][8] >= 5
     timeline = tabs["Master Timeline"].rows
@@ -124,7 +122,7 @@ def test_azores_golden_path_services(
         intake.trip_id,
         tmp_path / "export" / "maps",
     )
-    assert any(pin.category == MapPinCategory.AIRPORT for pin in artifact.pins)
+    assert artifact.pins
     assert any(pin.category == MapPinCategory.ACTIVITY for pin in artifact.pins)
     assert Path(artifact.exports["json"]).exists()
 
@@ -134,36 +132,9 @@ def test_azores_golden_path_services(
     activities = ActivityShortlistService(intake_service, planner).build(intake.trip_id)
 
     assert flights.category == ShortlistCategory.FLIGHTS
-    assert flights.recommended_option_id == "flight-direct-route"
-    flight_link = flights.flight_options[0].deep_link
-    flight_params = parse_qs(urlparse(flight_link).query)
-    assert "google.com/travel/flights" in flight_link
-    assert "?q=" not in flight_link
-    assert flight_params["tfu"] == ["EgIIACIA"]
-    assert flight_params["origin"] == ["YYZ"]
-    assert flight_params["destination"] == ["PDL"]
-    assert flight_params["departure"] == ["2027-06-15"]
-    assert "f=0" not in flight_params["tfs"][0]
-    tfs_padding = "=" * (-len(flight_params["tfs"][0]) % 4)
-    tfs_payload = base64.urlsafe_b64decode(flight_params["tfs"][0] + tfs_padding)
-    assert b"YYZ" in tfs_payload
-    assert b"PDL" in tfs_payload
-    assert b"2027-06-15" in tfs_payload
-    flight_links = [
-        link
-        for option in flights.flight_options
-        for link in [option.deep_link, *option.comparison_links.values()]
-    ]
-    assert all("Flights-Search" not in link for link in flight_links)
-    assert all("flighthub.com" not in link for link in flight_links)
-    assert any(
-        "ca.kayak.com/flights/YYZ-PDL/2027-06-15/2027-06-25/5adults"
-        in link
-        for link in flight_links
-    )
-    assert any(
-        "placeholder search dates" in note for note in flights.flight_options[0].confidence_notes
-    )
+    assert flights.recommended_option_id is None
+    assert flights.flight_options == []
+    assert any("failed closed" in warning for warning in flights.warnings)
     assert lodging.lodging_options
     assert lodging.recommended_option_id is not None
     assert cars.car_options[0].booking_source == "Booking.com"
@@ -180,11 +151,6 @@ def test_azores_golden_path_services(
     assert all(
         "Airbnb Experiences" not in option.validation_links
         for option in activities.activity_options
-    )
-    assert flights.flight_options[0].row_status == ShortlistRowStatus.RESEARCHED
-    assert (
-        flights.flight_options[0].validation.verification_status
-        == VerificationStatus.MANUAL_REQUIRED
     )
     assert lodging.lodging_options[0].fit_category.value in {
         "preferred_fit",
@@ -204,7 +170,7 @@ def test_azores_golden_path_services(
     dashboard = DashboardService().build()
     planned = next(tile for tile in dashboard.planned_trips if tile.trip_id == intake.trip_id)
     assert planned.planning_status["workspace"] == "prepared_local"
-    assert planned.shortlist_status["flights"].startswith("3 option")
+    assert planned.shortlist_status["flights"].startswith("0 option")
     assert planned.planning_completeness < 100
 
 
@@ -401,7 +367,11 @@ def test_cli_azores_golden_path(
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
         assert payload["shortlist"]["trip_id"] == trip_id
-        assert payload["shortlist"]["recommended_option_id"]
+        if command == "flights":
+            assert payload["shortlist"]["recommended_option_id"] is None
+            assert payload["shortlist"]["flight_options"] == []
+        else:
+            assert payload["shortlist"]["recommended_option_id"]
 
     learning_result = runner.invoke(
         app,
@@ -434,7 +404,8 @@ def test_agent_planning_tool_routes_to_shortlist_services(
     )
 
     assert result["category"] == "flights"
-    assert result["recommended_option_id"] == "flight-direct-route"
+    assert result["recommended_option_id"] is None
+    assert result["flight_options"] == []
 
 
 def test_intake_accepts_fuzzy_duration_and_party_roster() -> None:
@@ -476,7 +447,12 @@ def test_live_validation_marks_reachable_rows_without_claiming_inventory(
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
     planner.select_option(intake.trip_id, "two-region-balanced")
-    flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
+    service = FlightShortlistService(intake_service, planner)
+    flights = service.add_candidate(
+        intake.trip_id,
+        link="https://www.google.com/travel/flights/search",
+        notes="YYZ to PDL nonstop candidate; provider evidence pending.",
+    )
 
     validator = LiveValidationService(
         fetcher=lambda _url, _timeout: (True, 200, "fake live source OK")
@@ -579,7 +555,12 @@ def test_flight_deep_research_enriches_existing_shortlist_state(
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
     planner.select_option(intake.trip_id, "two-region-balanced")
-    flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
+    service_builder = FlightShortlistService(intake_service, planner)
+    flights = service_builder.add_candidate(
+        intake.trip_id,
+        link="https://www.google.com/travel/flights/search",
+        notes="YYZ to PDL nonstop candidate; provider evidence pending.",
+    )
 
     html = """
     <html><body>
@@ -845,7 +826,17 @@ def test_flight_deep_research_handles_partial_secondary_source_text(
     planner = TripPlannerService(intake_service)
     planner.draft(intake.trip_id)
     planner.select_option(intake.trip_id, "two-region-balanced")
-    flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
+    flight_service = FlightShortlistService(intake_service, planner)
+    flights = flight_service.add_candidate(
+        intake.trip_id,
+        link="https://www.ca.kayak.com/flights/YYZ-PDL/2027-06-15/2027-06-25/5adults",
+        notes="YYZ to PDL one stop via LIS; secondary source evidence pending.",
+    )
+    flights = flight_service.add_candidate(
+        intake.trip_id,
+        link="https://www.ca.kayak.com/flights/YYZ-PDL/2027-06-15/2027-06-25/5adults",
+        notes="YYZ to PDL one stop via LIS; partial secondary source text.",
+    )
     candidate = flights.flight_options[1]
 
     html = """
@@ -935,8 +926,23 @@ def test_selecting_flight_updates_recommendation_and_workspace_timeline(
     planner.draft(intake.trip_id)
     planner.select_option(intake.trip_id, "two-region-balanced")
 
-    state = FlightShortlistService(intake_service, planner).build(intake.trip_id)
-    selected = FlightShortlistService(intake_service, planner).select_flight(
+    flight_service = FlightShortlistService(intake_service, planner)
+    state = flight_service.add_candidate(
+        intake.trip_id,
+        link="https://www.google.com/travel/flights/search",
+        notes="YYZ to PDL nonstop candidate; provider evidence pending.",
+    )
+    state = flight_service.add_candidate(
+        intake.trip_id,
+        link="https://www.google.com/travel/flights/search",
+        notes="YYZ to PDL one stop candidate; provider evidence pending.",
+    )
+    state = flight_service.add_candidate(
+        intake.trip_id,
+        link="https://www.google.com/travel/flights/search",
+        notes="PDL to YYZ return candidate; provider evidence pending.",
+    )
+    selected = flight_service.select_flight(
         intake.trip_id,
         state.flight_options[1].option_id,
     )
@@ -951,7 +957,7 @@ def test_selecting_flight_updates_recommendation_and_workspace_timeline(
     assert chosen.recommendation_label.startswith("Departure selected")
     assert selected.artifacts["flight_selection"]["selected_outbound_option_id"] == chosen.option_id
 
-    return_selected = FlightShortlistService(intake_service, planner).select_flight(
+    return_selected = flight_service.select_flight(
         intake.trip_id,
         state.flight_options[2].option_id,
         selection_kind="return",

--- a/tests/unit/test_ui_server.py
+++ b/tests/unit/test_ui_server.py
@@ -45,7 +45,8 @@ def test_ui_service_runs_planning_and_feedback_loop(
 
     assert snapshot["intake"]["party"]["total_travelers"] == 5
     assert snapshot["draft"]["selected_option_id"] == option_id
-    assert flights["shortlist"]["recommended_option_id"]
+    assert flights["shortlist"]["recommended_option_id"] is None
+    assert flights["shortlist"]["flight_options"] == []
     assert workspace["workspace"]["status"] == "prepared_local"
     assert snapshot["shortlists"]
 
@@ -574,7 +575,7 @@ def test_ui_select_flight_updates_canonical_shortlist(
     _patch_ui_paths(tmp_path, monkeypatch)
     service = TrippyUIService()
     trip_id = _create_selected_trip(service)
-    flights = service.build_shortlist(trip_id, "flights")
+    flights = _add_ui_flight_candidates(service, trip_id)
     option_id = flights["shortlist"]["flight_options"][1]["option_id"]
 
     result = service.select_flight({"trip_id": trip_id, "option_id": option_id})
@@ -608,7 +609,7 @@ def test_ui_can_confirm_core_bookings_and_hydrate_trip_packet(
     _patch_ui_paths(tmp_path, monkeypatch)
     service = TrippyUIService()
     trip_id = _create_selected_trip(service)
-    flights = service.build_shortlist(trip_id, "flights")
+    flights = _add_ui_flight_candidates(service, trip_id)
     lodging = service.build_shortlist(trip_id, "lodging")
     flight_id = flights["shortlist"]["flight_options"][0]["option_id"]
     lodging_id = lodging["shortlist"]["lodging_options"][0]["option_id"]
@@ -799,6 +800,24 @@ def _create_selected_trip(service: TrippyUIService) -> str:
     draft_result = service.draft_plan(trip_id)
     service.select_plan(trip_id, draft_result["draft"]["recommended_option_id"])
     return str(trip_id)
+
+
+def _add_ui_flight_candidates(service: TrippyUIService, trip_id: str) -> dict[str, object]:
+    service.build_shortlist(trip_id, "flights")
+    state: dict[str, object] = {}
+    for notes in [
+        "YYZ to PDL nonstop candidate; provider evidence pending.",
+        "YYZ to PDL one stop candidate; provider evidence pending.",
+        "PDL to YYZ return candidate; provider evidence pending.",
+    ]:
+        state = service.add_flight_candidate(
+            {
+                "trip_id": trip_id,
+                "link": "https://www.google.com/travel/flights/search",
+                "notes": notes,
+            }
+        )
+    return state
 
 
 def _patch_ui_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_ui_server.py
+++ b/tests/unit/test_ui_server.py
@@ -74,6 +74,40 @@ def test_ui_service_runs_planning_and_feedback_loop(
     assert logs["pending_proposals"]
 
 
+def test_ui_can_export_and_import_enriched_trip_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_ui_paths(tmp_path, monkeypatch)
+    service = TrippyUIService()
+    trip_id = _create_selected_trip(service)
+
+    exported = service.export_trip_json(trip_id)
+    assert exported["schema"] == "trippy.trip_intake.v1"
+    assert exported["resolver_evidence"]["destination_airports"]
+
+    intake_json = exported["intake"]
+    intake_json["trip_id"] = "imported-json-trip"
+    intake_json["trip_name"] = "Imported JSON Trip"
+    intake_json["geography"]["destination_airports"] = [
+        {
+            "iata_code": "ABC",
+            "city": "User Supplied City",
+            "country": "User Supplied Country",
+            "source": "ui_test",
+        }
+    ]
+    intake_json["geography"]["lodging_search_locations"] = ["User Supplied District"]
+
+    imported = service.import_trip_json({"intake": intake_json, "overwrite": True})
+
+    assert imported["intake"]["trip_id"] == "imported-json-trip"
+    assert imported["resolver_evidence"]["destination_airports"][0]["iata_code"] == "ABC"
+    assert service.export_trip_json("imported-json-trip")["intake"]["geography"][
+        "lodging_search_locations"
+    ] == ["User Supplied District"]
+
+
 def test_ui_logs_capture_backend_errors(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -177,7 +211,7 @@ def test_ui_suggest_ideas_respects_six_day_prompt_and_can_capture_idea_feedback(
     assert any(event["event_type"] == "user_feedback" for event in logs["events"])
 
 
-def test_ui_suggest_ideas_respects_caribbean_region_intent(
+def test_ui_suggest_ideas_does_not_convert_region_words_to_destination_catalog(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -198,15 +232,17 @@ def test_ui_suggest_ideas_respects_caribbean_region_intent(
         }
     )
 
-    concept_ids = {concept["concept_id"] for concept in result["comparison"]["concepts"]}
-    assert len(concept_ids) == 3
-    assert "island-nature-short-comfort" not in concept_ids
-    assert concept_ids <= {
-        "belize-reef-jungle-short",
-        "curacao-color-beach-drivable-short",
-        "st-lucia-private-rental-food-short",
-        "mexico-caribbean-food-beach-short",
-    }
+    concepts = result["comparison"]["concepts"]
+    assert len(concepts) == 3
+    output_text = " ".join(
+        [
+            *(concept["title"] for concept in concepts),
+            *(slot for concept in concepts for slot in concept["destinations"]),
+            *result["comparison"]["scoring_notes"],
+        ]
+    ).lower()
+    assert "caribbean" not in output_text
+    assert all(not concept["country_prior_signals"] for concept in concepts)
 
 
 def test_ui_suggest_ideas_respects_snorkeling_requirement(
@@ -231,17 +267,19 @@ def test_ui_suggest_ideas_respects_snorkeling_requirement(
         }
     )
 
-    concept_ids = {concept["concept_id"] for concept in result["comparison"]["concepts"]}
-    assert len(concept_ids) == 3
-    assert "quebec-city-montreal-food-short" not in concept_ids
-    assert "mexico-city-food-short" not in concept_ids
-    assert "island-nature-short-comfort" not in concept_ids
-    assert concept_ids <= {
-        "belize-reef-jungle-short",
-        "cayman-reef-food-easy-week",
-        "curacao-color-beach-drivable-short",
-        "mexico-caribbean-food-beach-short",
-    }
+    concepts = result["comparison"]["concepts"]
+    assert len(concepts) == 3
+    output_text = " ".join(
+        [
+            *(concept["title"] for concept in concepts),
+            *(slot for concept in concepts for slot in concept["destinations"]),
+        ]
+    ).lower()
+    assert "cayman" not in output_text
+    assert "belize" not in output_text
+    assert all(
+        any("snorkeling" in item for item in concept["rationale"]) for concept in concepts
+    )
 
 
 def test_ui_lodging_candidate_is_evaluated_in_shortlist(

--- a/trippy/integrations/telegram_bot.py
+++ b/trippy/integrations/telegram_bot.py
@@ -211,7 +211,7 @@ class TelegramTrippyBot:
         if text in {"/start", "/help"}:
             self._api.send_message(
                 chat_id,
-                "Text Trippy questions like: 'What confirmations are missing for Japan?' or 'Audit friction for our next trip.' Send /whoami to get your Telegram chat ID for the allowlist.",
+                "Text Trippy questions like: 'What confirmations are missing for our trip?' or 'Audit friction for our next trip.' Send /whoami to get your Telegram chat ID for the allowlist.",
             )
             return
 

--- a/trippy/models/trip.py
+++ b/trippy/models/trip.py
@@ -292,7 +292,7 @@ class SyncMetadata(BaseModel):
 
 
 def _make_trip_id(name: str) -> str:
-    """Derive a slug trip ID from a human name like 'Japan 2026'."""
+    """Derive a slug trip ID from a human trip name."""
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
     return slug
 

--- a/trippy/services/flight_shortlist.py
+++ b/trippy/services/flight_shortlist.py
@@ -82,7 +82,11 @@ class FlightShortlistService:
                 live_notes = [*live_notes, *serp_notes]
                 if serp_options:
                     live_options = serp_options
-        options = live_options or (_fallback_flight_options(ctx, gateway) if gateway else [])
+        options = live_options
+        if gateway and not options:
+            live_notes.append(
+                "No flight options were created because configured flight providers returned no usable live rows; add a user-supplied candidate or configure a live provider."
+            )
         state = ResearchShortlistState(
             trip_id=trip_id,
             category=ShortlistCategory.FLIGHTS,
@@ -91,14 +95,13 @@ class FlightShortlistService:
             flight_options=options,
             recommended_option_id=options[0].option_id if options else None,
             recommendation_summary=(
-                "Start with the lowest-friction same-ticket or nonstop shape, then verify live "
-                "availability, fare rules, baggage, seats, and Aeroplan eligibility before handoff."
+                "Flight options require explicit origin and destination airport codes plus live provider rows or user-supplied itinerary evidence."
             ),
             warnings=[
                 (
                     "Live Duffel offers populated exact flight rows."
                     if live_options
-                    else "Flight numbers and fares are not asserted unless a live provider or source link confirms them."
+                    else "Flight shortlist failed closed; no placeholder flight rows, fares, airlines, or booking links were generated."
                 ),
                 *live_notes,
                 *profile.flight_notes,
@@ -107,7 +110,7 @@ class FlightShortlistService:
                 (
                     "Review the live provider offer details, then cross-check the top option in Google Flights."
                     if live_options
-                    else "Configure DUFFEL_ACCESS_TOKEN or add a flight candidate with exact itinerary text to replace placeholders."
+                    else "Configure DUFFEL_ACCESS_TOKEN, enable a live flight adapter, or add a flight candidate with exact itinerary text."
                 ),
                 "Cross-check the same routing on Kayak.ca before booking.",
                 "Reject multi-ticket routings unless airport, baggage, and delay protection are clearly acceptable.",
@@ -215,146 +218,6 @@ class FlightShortlistService:
             ),
         )
         return self._store.save(state)
-
-
-def _fallback_flight_options(ctx: ShortlistContext, gateway: str) -> list[FlightOption]:
-    origin = ctx.intake.departure_airports[0] if ctx.intake.departure_airports else "YYZ"
-    destination = _iata_or_text(gateway)
-    destination_label = profile_for_intake(ctx.intake).title or ", ".join(ctx.intake.destination_seeds) or destination
-    traveler_count = ctx.intake.party.total_travelers
-    party_note = ctx.intake.party.summary()
-    date_hint = _flight_date_hint(ctx)
-    departure_date, return_date = _flight_dates(ctx)
-    comparison = _flight_comparison_links(origin, destination, ctx)
-    return [
-        FlightOption(
-            option_id="flight-direct-route",
-            rank=1,
-            airline=f"{origin}-{destination} nonstop candidate",
-            flight_numbers=[],
-            departure_date=departure_date.isoformat(),
-            arrival_date=departure_date.isoformat(),
-            departure_airport=origin,
-            arrival_airport=destination,
-            departure_time="Open search",
-            arrival_time="Verify time",
-            stops=0,
-            layover_airports=[],
-            layover_duration=None,
-            total_travel_duration="duration live-verify",
-            timing_fit=(
-                "Best shape if nonstop service operates on the trip dates and arrival aligns with check-in."
-            ),
-            fare_estimate_cad="live verify; often worth a premium for family smoothness",
-            price_band="live-verify band",
-            baggage_cabin_notes="Validate included bags, seat selection, and family seating before booking.",
-            booking_source="Google Flights",
-            deep_link=_flight_source_url("Google Flights", origin, destination, ctx),
-            traveler_count=traveler_count,
-            traveler_fit=f"Best fit for {party_note}: one plane, no layover, simplest baggage/seat path.",
-            comparison_links=comparison,
-            aeroplan_relevance="Low/uncertain; verify partner earning before assuming Aeroplan value.",
-            friction_score=8,
-            family_comfort_score=94,
-            recommendation_grade=RecommendationGrade.STRONG,
-            tradeoffs=[
-                f"Likely highest comfort for {destination_label} if nonstop service is available.",
-                "May cost more or operate only on certain days; verify the source before relying on it.",
-            ],
-            friction_flags=[
-                "nonstop availability must be verified",
-                "baggage and seat terms unknown",
-            ],
-            confidence_notes=[
-                "This is a source-linked candidate, not a confirmed fare.",
-                date_hint,
-            ],
-            live_data_status=LiveDataStatus.HANDOFF_REQUIRED,
-        ),
-        FlightOption(
-            option_id="flight-one-stop-same-ticket",
-            rank=2,
-            airline=f"{origin}-{destination} one-stop same-ticket candidate",
-            flight_numbers=[],
-            departure_date=departure_date.isoformat(),
-            arrival_date=departure_date.isoformat(),
-            departure_airport=origin,
-            arrival_airport=destination,
-            departure_time="Open search",
-            arrival_time="Verify time",
-            stops=1,
-            layover_airports=[],
-            layover_duration="verify connection buffer",
-            total_travel_duration="duration live-verify",
-            timing_fit="Acceptable only if the connection is protected and the arrival still works for lodging check-in.",
-            fare_estimate_cad="live verify; compare against nonstop premium",
-            price_band="live-verify band",
-            baggage_cabin_notes="Prefer same-ticket baggage through-check and long-haul seat selection clarity.",
-            booking_source="Google Flights",
-            deep_link=_flight_source_url("Google Flights", origin, destination, ctx),
-            traveler_count=traveler_count,
-            traveler_fit=f"Acceptable for {party_note} only with same-ticket baggage and a sane connection buffer.",
-            comparison_links=comparison,
-            aeroplan_relevance="Potentially relevant if booked on eligible Air Canada or partner fare; verify booking class.",
-            friction_score=24,
-            family_comfort_score=82,
-            recommendation_grade=RecommendationGrade.GOOD,
-            tradeoffs=[
-                "Can be the practical backup if nonstop is unavailable or irrationally priced.",
-                "Connection adds delay and baggage risk, especially with checked bags.",
-            ],
-            friction_flags=[
-                "layover timing needs validation",
-                "avoid overnight or very tight connection",
-            ],
-            confidence_notes=[
-                "Use as the best backup if nonstop is unavailable or irrationally expensive.",
-                date_hint,
-            ],
-        ),
-        FlightOption(
-            option_id="flight-price-sanity-check",
-            rank=3,
-            airline=f"{origin}-{destination} price sanity-check candidate",
-            flight_numbers=[],
-            departure_date=departure_date.isoformat(),
-            arrival_date=return_date.isoformat(),
-            departure_airport=origin,
-            arrival_airport=destination,
-            departure_time="Open search",
-            arrival_time="Verify time",
-            stops=1,
-            layover_airports=[],
-            layover_duration="requires generous protected buffer",
-            total_travel_duration="duration live-verify",
-            timing_fit="Weak unless protected routing and lodging timing are both unusually clean.",
-            fare_estimate_cad="live verify; only consider with a meaningful upside",
-            price_band="live-verify band",
-            baggage_cabin_notes="Do not accept unprotected baggage recheck with a tight family connection.",
-            booking_source="Kayak.ca",
-            deep_link=_flight_source_url("Kayak.ca", origin, destination, ctx),
-            traveler_count=traveler_count,
-            traveler_fit=f"Weak fit for {party_note} unless protected, because luggage/recheck risk scales with party size.",
-            comparison_links=_flight_comparison_links(origin, destination, ctx),
-            aeroplan_relevance="Weak unless a same-ticket eligible carrier routing is found.",
-            friction_score=48,
-            family_comfort_score=62,
-            recommendation_grade=RecommendationGrade.CONDITIONAL,
-            tradeoffs=[
-                "Could be cheaper, but multi-ticket or baggage recheck risk can erase the value.",
-                "Only acceptable with protected routing, sane layover, and clear luggage path.",
-            ],
-            friction_flags=[
-                "airport mismatch/recheck risk",
-                "delay protection risk",
-                "family luggage burden",
-            ],
-            confidence_notes=[
-                "Use mainly as a price sanity check, not default recommendation.",
-                date_hint,
-            ],
-        ),
-    ]
 
 
 def _duffel_live_options(
@@ -693,10 +556,7 @@ def _user_candidate_option(
         traveler_fit=(
             f"User-supplied flight for {intake.party.summary()}; verify timing, fare, baggage, and source evidence."
         ),
-        comparison_links={
-            "Google Flights": _flight_source_url("Google Flights", origin, destination, ctx),
-            "Kayak.ca": _flight_source_url("Kayak.ca", origin, destination, ctx),
-        },
+        comparison_links=_flight_comparison_links(origin, destination, ctx),
         aeroplan_relevance="User-supplied candidate; verify carrier, fare class, and Aeroplan earning.",
         friction_score=friction,
         family_comfort_score=comfort,
@@ -731,6 +591,8 @@ def _flight_source_url(
     """
     origin_code = _iata_or_text(origin)
     destination_code = _iata_or_text(destination)
+    if not _looks_like_iata(origin_code) or not _looks_like_iata(destination_code):
+        return ""
     departure_date, return_date = _flight_dates(ctx)
     adults = max(1, ctx.intake.party.adults or ctx.intake.party.total_travelers or 1)
     total_travelers = max(1, ctx.intake.party.total_travelers or ctx.intake.travelers or adults)
@@ -770,10 +632,11 @@ def _flight_comparison_links(
     ctx: ShortlistContext,
 ) -> dict[str, str]:
     """Only expose providers with route URLs that reliably preserve search fields."""
-    return {
+    links = {
         "Google Flights": _flight_source_url("Google Flights", origin, destination, ctx),
         "Kayak.ca": _flight_source_url("Kayak.ca", origin, destination, ctx),
     }
+    return {source: url for source, url in links.items() if url}
 
 
 def _looks_like_iata(value: str) -> bool:
@@ -1515,7 +1378,7 @@ def _destination_gateway(ctx: ShortlistContext, notes: str) -> str:
     profile = profile_for_intake(ctx.intake)
     if profile.gateway_airports:
         return str(profile.gateway_airports[0])
-    return ", ".join(ctx.intake.destination_seeds) or "destination TBD"
+    return "DESTINATION_AIRPORT_REQUIRED"
 
 
 def _stops_from_notes(lower: str) -> int | None:

--- a/trippy/services/friction_detector.py
+++ b/trippy/services/friction_detector.py
@@ -808,13 +808,6 @@ def _countries_for_trip(trip: Trip) -> list[str]:
         if stay.country and stay.country.lower() not in seen:
             countries.append(stay.country)
             seen.add(stay.country.lower())
-    if trip.destination_summary:
-        from trippy.services.country_priors import CountryPriorService
-
-        for fit in CountryPriorService().fit_for_text(trip.destination_summary):
-            if fit.country.lower() not in seen:
-                countries.append(fit.country)
-                seen.add(fit.country.lower())
     return countries
 
 

--- a/trippy/services/phase_planner.py
+++ b/trippy/services/phase_planner.py
@@ -91,7 +91,7 @@ class PhasePlannerService:
                 title="New trip sheet generation",
                 complete=has_sheeted_trip,
                 blockers=[] if has_sheeted_trip else ["No trip linked to a Google Sheet yet"],
-                next_step='Run: trippy phase-run 4 --trip-idea "Japan March 2027"',
+                next_step='Run: trippy phase-run 4 --trip-idea "Family trip 2027"',
             )
         )
         phases.append(

--- a/trippy/services/planning_advisor.py
+++ b/trippy/services/planning_advisor.py
@@ -162,13 +162,11 @@ class PlanningAdvisorService:
         plan_option_payload: dict[str, Any] | None = None,
         shortlist_payload: Any = None,
     ) -> str:
-        destination_text = _destination_text(
-            intake, request_payload, comparison_payload, plan_option_payload
-        )
-        country_signals = [
-            signal.model_dump(mode="json")
-            for signal in self._country_priors.fit_for_text(destination_text)
-        ]
+        country_signals = []
+        if intake and intake.geography and intake.geography.country:
+            signal = self._country_priors.fit_for_country(intake.geography.country)
+            if signal:
+                country_signals.append(signal.model_dump(mode="json"))
         memory_context = self._memory.to_context_string()
         parts = [
             f"# Trippy Planning Advisor ({_PROMPT_VERSION})",
@@ -368,24 +366,6 @@ def _shortlist_summary(state: ResearchShortlistState | None) -> dict[str, Any]:
         "artifacts": _compact_dump(state.artifacts, ["planning_advisor"]),
         "options": compact_options,
     }
-
-
-def _destination_text(
-    intake: TripIntake | None,
-    request_payload: dict[str, Any] | None,
-    comparison_payload: dict[str, Any] | None,
-    plan_option_payload: dict[str, Any] | None,
-) -> str:
-    pieces: list[str] = []
-    if intake is not None:
-        pieces.extend([intake.trip_name, *intake.destination_seeds, intake.freeform_notes or ""])
-    if request_payload:
-        pieces.extend(str(value) for value in request_payload.values())
-    if comparison_payload:
-        pieces.append(_json(comparison_payload))
-    if plan_option_payload:
-        pieces.append(_json(plan_option_payload))
-    return " ".join(pieces)
 
 
 def _compact_dump(payload: Any, excluded_keys: list[str]) -> Any:

--- a/trippy/services/trip_ideation.py
+++ b/trippy/services/trip_ideation.py
@@ -1,4 +1,9 @@
-"""Deterministic first-pass trip concept generation and comparison."""
+"""Destination-agnostic trip concept generation.
+
+Idea-stage output is intentionally a set of scanner briefs, not named destination
+recommendations. Trippy should not smuggle a hardcoded catalog of places into the
+planning flow before resolver/provider evidence has populated trip JSON.
+"""
 
 from __future__ import annotations
 
@@ -7,345 +12,200 @@ from dataclasses import dataclass
 from trippy.memory.store import MemoryStore
 from trippy.models.ideas import TripComparison, TripConcept, TripIdeaRequest
 from trippy.models.preferences import FamilyTravelPreferences
-from trippy.services.country_priors import CountryPriorService
 from trippy.services.planning_advisor import PlanningAdvisorService
 
 
 @dataclass(frozen=True)
-class _ConceptTemplate:
+class _ConceptArchetype:
     concept_id: str
     title: str
-    countries: list[str]
-    destinations: list[str]
+    destination_slots: list[str]
     recommended_duration_days: int
-    best_season: str
-    estimated_cost_band_cad: str
-    estimated_flight_hours: float
+    travel_burden_hours: float
     direct_flight_friendliness: int
-    base_family_fit: int
-    base_comfort: int
-    food_score: int
+    family_fit: int
+    comfort: int
+    food: int
     crowd_risk: int
     tags: set[str]
+    rationale_seed: list[str]
     risks: list[str]
 
 
-_TEMPLATES = [
-    _ConceptTemplate(
-        concept_id="island-nature-short-comfort",
-        title="Island Nature Easy Week",
-        countries=[],
-        destinations=["Primary island base", "Thermal or nature area", "Scenic viewpoint area"],
-        recommended_duration_days=6,
-        best_season="late summer or early fall",
-        estimated_cost_band_cad="CAD 12k-20k for a couple before final flights and lodging",
-        estimated_flight_hours=5.8,
-        direct_flight_friendliness=7,
-        base_family_fit=86,
-        base_comfort=84,
-        food_score=78,
-        crowd_risk=36,
-        tags={
-            "nature",
-            "food",
-            "island",
-            "short-flight",
-            "low-crowd",
-            "chill",
-        },
-        risks=[
-            "Weather can disrupt outdoor plans; keep flexible hot springs, food, and scenic backup days."
+_ARCHETYPES = [
+    _ConceptArchetype(
+        concept_id="json-first-low-friction-single-base",
+        title="Low-Friction Single-Base Search",
+        destination_slots=[
+            "Primary base resolved from scanner evidence",
+            "Nearby activity cluster from user-approved JSON",
         ],
-    ),
-    _ConceptTemplate(
-        concept_id="quebec-city-montreal-food-short",
-        title="Quebec City + Montreal Food Long Weekend",
-        countries=["Canada"],
-        destinations=["Montreal", "Quebec City"],
-        recommended_duration_days=5,
-        best_season="summer or fall",
-        estimated_cost_band_cad="CAD 5k-10k for a couple depending on hotels and dining",
-        estimated_flight_hours=1.5,
-        direct_flight_friendliness=10,
-        base_family_fit=84,
-        base_comfort=88,
-        food_score=90,
-        crowd_risk=45,
-        tags={"food", "culture", "city", "walkable", "short-flight", "low-friction"},
-        risks=[
-            "Old Quebec can feel crowded in peak windows; pick shoulder dates and central lodging."
-        ],
-    ),
-    _ConceptTemplate(
-        concept_id="mexico-city-food-short",
-        title="Mexico City Food + Neighborhoods",
-        countries=["Mexico"],
-        destinations=["Roma Norte", "Condesa", "Centro or Polanco"],
         recommended_duration_days=6,
-        best_season="winter or early spring",
-        estimated_cost_band_cad="CAD 8k-15k for a couple depending on dining and hotel level",
-        estimated_flight_hours=5.0,
-        direct_flight_friendliness=8,
-        base_family_fit=80,
-        base_comfort=82,
-        food_score=97,
-        crowd_risk=55,
-        tags={"food", "culture", "city", "walkable", "short-flight"},
-        risks=[
-            "Neighborhood choice and private transfers matter; avoid turning this into a stressful driving trip."
-        ],
-    ),
-    _ConceptTemplate(
-        concept_id="belize-reef-jungle-short",
-        title="Belize Reef + Easy Adventure",
-        countries=["Belize"],
-        destinations=["Ambergris Caye or Caye Caulker", "San Ignacio optional"],
-        recommended_duration_days=6,
-        best_season="winter or spring dry season",
-        estimated_cost_band_cad="CAD 9k-18k for a couple before final tours and lodging",
-        estimated_flight_hours=4.8,
-        direct_flight_friendliness=6,
-        base_family_fit=82,
-        base_comfort=78,
-        food_score=76,
-        crowd_risk=42,
-        tags={
-            "belize",
-            "caribbean",
-            "beach",
-            "nature",
-            "adventure",
-            "short-flight",
-            "water",
-            "reef",
-            "snorkel",
-            "snorkeling",
-            "chill",
-        },
-        risks=["Extra hops to islands can eat time; keep the route simple for only six days."],
-    ),
-    _ConceptTemplate(
-        concept_id="cayman-reef-food-easy-week",
-        title="Cayman Reef + Food Easy Week",
-        countries=["Cayman Islands"],
-        destinations=["Seven Mile Beach", "West Bay", "Stingray City or Rum Point"],
-        recommended_duration_days=7,
-        best_season="winter or spring, including March break if prices are acceptable",
-        estimated_cost_band_cad="CAD 18k-32k for family of 5 before exact flights, lodging, and activities",
-        estimated_flight_hours=4.2,
-        direct_flight_friendliness=8,
-        base_family_fit=84,
-        base_comfort=86,
-        food_score=82,
-        crowd_risk=50,
-        tags={
-            "cayman",
-            "cayman islands",
-            "caribbean",
-            "beach",
-            "water",
-            "reef",
-            "snorkel",
-            "snorkeling",
-            "food",
-            "family",
-            "low-friction",
-            "short-flight",
-            "chill",
-        },
-        risks=[
-            "March break pricing can be high; value needs live validation.",
-            "Use smaller operators and beach timing to avoid crowded excursion windows.",
-        ],
-    ),
-    _ConceptTemplate(
-        concept_id="curacao-color-beach-drivable-short",
-        title="Curacao Color + Beach Base",
-        countries=["Curacao"],
-        destinations=["Willemstad", "Westpunt beaches", "Klein Curacao optional"],
-        recommended_duration_days=6,
-        best_season="winter, spring, or early fall outside peak holiday pricing",
-        estimated_cost_band_cad="CAD 9k-17k for a couple before final flights, lodging, and car",
-        estimated_flight_hours=5.8,
-        direct_flight_friendliness=7,
-        base_family_fit=78,
-        base_comfort=78,
-        food_score=76,
-        crowd_risk=40,
-        tags={
-            "curacao",
-            "curaçao",
-            "caribbean",
-            "beach",
-            "island",
-            "water",
-            "reef",
-            "snorkel",
-            "snorkeling",
-            "drivable",
-            "colorful",
-            "chill",
-            "rental",
-        },
-        risks=[
-            "Historical notes are mixed: colorful and drivable, but theft/safety, cost, and food consistency need careful validation.",
-            "Do not leave valuables in a car at beaches; lodging location and parking security matter.",
-        ],
-    ),
-    _ConceptTemplate(
-        concept_id="st-lucia-private-rental-food-short",
-        title="St Lucia Private Rental + Food Week",
-        countries=["St Lucia"],
-        destinations=["Soufriere", "Rodney Bay optional", "Marigot Bay optional"],
-        recommended_duration_days=6,
-        best_season="winter or spring shoulder windows",
-        estimated_cost_band_cad="CAD 10k-18k for a couple before exact villa/hotel and car choices",
-        estimated_flight_hours=5.4,
-        direct_flight_friendliness=6,
-        base_family_fit=76,
-        base_comfort=74,
-        food_score=84,
-        crowd_risk=42,
-        tags={
-            "st lucia",
-            "saint lucia",
-            "caribbean",
-            "beach",
-            "island",
-            "food",
-            "rental",
-            "scenery",
-            "chill",
-        },
-        risks=[
-            "Historical prior likes food and Airbnb/private-stay upside, but hard roads are a major caution.",
-            "This only works if transfers or driving routes avoid road-stress and night-driving friction.",
-        ],
-    ),
-    _ConceptTemplate(
-        concept_id="mexico-caribbean-food-beach-short",
-        title="Mexico Caribbean Food + Beach Base",
-        countries=["Mexico"],
-        destinations=["Isla Mujeres or Puerto Morelos", "Valladolid optional"],
-        recommended_duration_days=6,
-        best_season="winter or early spring before heavy heat and seaweed risk",
-        estimated_cost_band_cad="CAD 8k-16k for a couple depending on beach lodging and dining",
-        estimated_flight_hours=4.2,
+        travel_burden_hours=5.0,
         direct_flight_friendliness=9,
-        base_family_fit=78,
-        base_comfort=76,
-        food_score=88,
-        crowd_risk=60,
+        family_fit=88,
+        comfort=90,
+        food=78,
+        crowd_risk=34,
         tags={
-            "mexico",
-            "caribbean",
-            "beach",
+            "low-friction",
+            "single-base",
+            "comfort",
             "food",
             "short-flight",
+            "family",
+            "beach",
             "water",
-            "reef",
-            "snorkel",
             "snorkeling",
-            "chill",
-            "value",
+            "reef",
         },
+        rationale_seed=[
+            "Keeps lodging, baggage, meals, and daily pacing simple while resolver evidence is still incomplete.",
+            "Best first pass when the family wants comfort and low transition cost.",
+        ],
         risks=[
-            "Mexico is historically strong for food, value, and weather, but safety, crowding, and beach/seaweed conditions vary sharply by area.",
-            "Avoid overbuilt resort zones unless convenience clearly beats the crowd exposure.",
+            "May underuse a broad destination if scanner evidence later proves the best activities are far apart.",
         ],
     ),
-    _ConceptTemplate(
-        concept_id="portugal-food-cities-coast",
-        title="Portugal Food Cities + Coast",
-        countries=["Portugal"],
-        destinations=["Lisbon", "Porto", "Douro Valley or Cascais"],
-        recommended_duration_days=10,
-        best_season="spring or fall",
-        estimated_cost_band_cad="CAD 18k-28k for family of 5 before splurge meals",
-        estimated_flight_hours=7.0,
-        direct_flight_friendliness=7,
-        base_family_fit=86,
-        base_comfort=84,
-        food_score=88,
-        crowd_risk=45,
-        tags={"food", "culture", "city", "coast", "walkable", "low-crowd"},
-        risks=["Lisbon hills and parking can be annoying; avoid rental car while in-city."],
-    ),
-    _ConceptTemplate(
-        concept_id="japan-food-rail-cities",
-        title="Japan Food + Rail Cities",
-        countries=["Japan"],
-        destinations=["Tokyo", "Kyoto", "Osaka or Hiroshima"],
-        recommended_duration_days=14,
-        best_season="late fall or shoulder-season spring",
-        estimated_cost_band_cad="CAD 28k-45k for family of 5 depending on flights and room setup",
-        estimated_flight_hours=13.0,
+    _ConceptArchetype(
+        concept_id="json-first-food-culture-base",
+        title="Food + Culture Base Search",
+        destination_slots=[
+            "Walkable food/culture base resolved from evidence",
+            "Optional nearby culture or market area from confirmed map locations",
+        ],
+        recommended_duration_days=6,
+        travel_burden_hours=6.0,
         direct_flight_friendliness=8,
-        base_family_fit=84,
-        base_comfort=78,
-        food_score=97,
-        crowd_risk=75,
-        tags={"food", "culture", "city", "transit", "adventure", "rail"},
-        risks=["Crowds are real; lodging must validate 3+ beds and central transit access."],
-    ),
-    _ConceptTemplate(
-        concept_id="mexico-city-oaxaca-food",
-        title="Mexico City + Oaxaca Food Trip",
-        countries=["Mexico"],
-        destinations=["Mexico City", "Oaxaca"],
-        recommended_duration_days=9,
-        best_season="winter or early spring",
-        estimated_cost_band_cad="CAD 16k-26k for family of 5",
-        estimated_flight_hours=5.5,
-        direct_flight_friendliness=8,
-        base_family_fit=80,
-        base_comfort=78,
-        food_score=96,
+        family_fit=82,
+        comfort=84,
+        food=94,
         crowd_risk=55,
-        tags={"food", "culture", "city", "walkable", "short-flight"},
-        risks=["Choose neighborhoods carefully; private transfers may beat rental car stress."],
-    ),
-    _ConceptTemplate(
-        concept_id="costa-rica-private-rental-adventure",
-        title="Costa Rica Private Rental + Adventure",
-        countries=["Costa Rica"],
-        destinations=["Arenal", "Manuel Antonio or Guanacaste"],
-        recommended_duration_days=10,
-        best_season="winter dry season",
-        estimated_cost_band_cad="CAD 20k-34k for family of 5",
-        estimated_flight_hours=5.5,
-        direct_flight_friendliness=6,
-        base_family_fit=86,
-        base_comfort=76,
-        food_score=72,
-        crowd_risk=50,
-        tags={"adventure", "nature", "beach", "rental", "chill"},
+        tags={"food", "culture", "walkable", "city", "single-base"},
+        rationale_seed=[
+            "Prioritizes food access and walkable daily structure without naming a city or neighborhood.",
+            "Works only after lodging areas and activity clusters are resolved into JSON.",
+        ],
         risks=[
-            "Driving and parking are practical in some areas, stressful in others; vet roads hard."
+            "Crowds, parking, and room fit need evidence before this becomes a recommendation.",
         ],
     ),
-    _ConceptTemplate(
-        concept_id="italy-food-culture-rail",
-        title="Italy Food + Culture By Rail",
-        countries=["Italy"],
-        destinations=["Rome", "Florence", "Bologna or Venice"],
-        recommended_duration_days=12,
-        best_season="spring or fall",
-        estimated_cost_band_cad="CAD 24k-38k for family of 5",
-        estimated_flight_hours=8.5,
+    _ConceptArchetype(
+        concept_id="json-first-nature-water-base",
+        title="Nature + Water Base Search",
+        destination_slots=[
+            "Nature or water base resolved from provider/scanner evidence",
+            "Weather-backup activity area from confirmed JSON",
+        ],
+        recommended_duration_days=6,
+        travel_burden_hours=6.0,
         direct_flight_friendliness=7,
-        base_family_fit=82,
-        base_comfort=80,
-        food_score=94,
-        crowd_risk=80,
-        tags={"food", "culture", "city", "rail", "walkable"},
-        risks=["Peak crowds can crush comfort; use shoulder season and central boutique hotels."],
+        family_fit=84,
+        comfort=80,
+        food=76,
+        crowd_risk=42,
+        tags={"nature", "beach", "water", "snorkeling", "reef", "chill", "family"},
+        rationale_seed=[
+            "Matches water/nature goals while keeping the actual place unresolved until evidence exists.",
+            "Requires weather, safety, operator, and transfer evidence before ranking exact activities.",
+        ],
+        risks=[
+            "Weather and sea conditions can invalidate activity plans; keep backup options unresolved until sourced.",
+        ],
+    ),
+    _ConceptArchetype(
+        concept_id="json-first-two-region-balanced",
+        title="Two-Region Balanced Search",
+        destination_slots=[
+            "First confirmed base from trip JSON",
+            "Second confirmed base only if evidence justifies the move",
+        ],
+        recommended_duration_days=9,
+        travel_burden_hours=7.0,
+        direct_flight_friendliness=7,
+        family_fit=80,
+        comfort=78,
+        food=84,
+        crowd_risk=48,
+        tags={"food", "culture", "nature", "two-base", "balanced"},
+        rationale_seed=[
+            "Allows more variety while still forcing each extra base to earn its transfer friction.",
+            "Good only when resolver evidence shows distinct activity/lodging clusters.",
+        ],
+        risks=[
+            "Can become unnecessary packing and check-in friction if the second base is not evidence-backed.",
+        ],
+    ),
+    _ConceptArchetype(
+        concept_id="json-first-activity-led-sampler",
+        title="Activity-Led Sampler Search",
+        destination_slots=[
+            "Primary lodging base from JSON",
+            "One or two activity clusters with provider evidence",
+        ],
+        recommended_duration_days=10,
+        travel_burden_hours=8.0,
+        direct_flight_friendliness=6,
+        family_fit=76,
+        comfort=72,
+        food=78,
+        crowd_risk=58,
+        tags={
+            "adventure",
+            "nature",
+            "activity",
+            "sampler",
+            "active",
+            "beach",
+            "water",
+            "snorkeling",
+            "reef",
+        },
+        rationale_seed=[
+            "Useful when the user's goals are activity-led and the exact destination is not yet resolved.",
+            "Keeps activities as evidence requirements rather than canned recommendations.",
+        ],
+        risks=[
+            "Higher risk of overpacking the trip; provider schedules and drive times must constrain the plan.",
+        ],
+    ),
+    _ConceptArchetype(
+        concept_id="json-first-value-flexible-search",
+        title="Value + Flexibility Search",
+        destination_slots=[
+            "Any destination candidate with explicit evidence",
+            "Lodging/search area confirmed by user before connectors run",
+        ],
+        recommended_duration_days=6,
+        travel_burden_hours=7.0,
+        direct_flight_friendliness=6,
+        family_fit=78,
+        comfort=74,
+        food=76,
+        crowd_risk=46,
+        tags={
+            "value",
+            "flexible",
+            "budget",
+            "low-crowd",
+            "beach",
+            "water",
+            "snorkeling",
+            "reef",
+        },
+        rationale_seed=[
+            "Keeps the brief broad so scanner/provider evidence can find value without hidden steering.",
+            "Requires explicit confirmation before any destination candidate becomes a selected trip.",
+        ],
+        risks=[
+            "A broad search can feel vague unless the UI quickly asks the user to confirm resolved airports and places.",
+        ],
     ),
 ]
 
 
 class TripIdeationService:
-    """Generate ranked family-fit trip concepts from loose constraints."""
+    """Generate ranked family-fit scanner briefs from loose constraints."""
 
     def __init__(
         self,
@@ -354,33 +214,30 @@ class TripIdeationService:
     ) -> None:
         self._prefs = preferences or FamilyTravelPreferences()
         self._memory = memory
-        self._country_priors = CountryPriorService()
 
     def compare(self, request: TripIdeaRequest, *, limit: int = 5) -> TripComparison:
-        region_intents = _explicit_region_intents(request)
         experience_intents = _required_experience_intents(request)
-        templates = _region_filtered_templates(_TEMPLATES, region_intents)
-        templates = _experience_filtered_templates(templates, experience_intents)
-        concepts = [self._score_template(template, request) for template in templates]
+        archetypes = _experience_filtered_archetypes(_ARCHETYPES, experience_intents)
+        concepts = [self._score_archetype(archetype, request) for archetype in archetypes]
         filtered = _duration_filtered_concepts(concepts, request, limit)
         if filtered:
             concepts = filtered
         ranked = sorted(concepts, key=lambda concept: concept.total_score, reverse=True)[:limit]
         recommendation = ranked[0].concept_id if ranked else None
         scoring_notes = [
-            "Scores are deterministic first-pass estimates, not live prices or availability.",
-            "Visa, entry, vaccination, exact fare, and listing availability require live research before booking.",
-            "Family smoothness, central lodging, food access, bed fit, and crowd/transport friction are weighted above raw price.",
+            "Ideas are destination-agnostic scanner briefs, not named destination recommendations.",
+            "No city, country, airport, neighborhood, hotel, airline, or activity is inferred from keywords.",
+            "Before planning, resolver/provider evidence must write explicit geography into TripIntake JSON.",
         ]
         if request.duration_days:
             scoring_notes.insert(
                 0,
-                f"Requested duration is {request.duration_days} day(s); suggestions are duration-fit first, not generic best trips.",
+                f"Requested duration is {request.duration_days} day(s); suggestions are duration-fit first.",
             )
-        if region_intents:
+        if _contains_regional_wording(request):
             scoring_notes.insert(
                 0,
-                f"Explicit destination intent detected: {', '.join(sorted(region_intents))}. Off-region concepts are excluded before scoring.",
+                "Regional wording was treated as user intent only; no known destination catalog was consulted.",
             )
         if experience_intents:
             scoring_notes.insert(
@@ -404,38 +261,24 @@ class TripIdeationService:
         )
         return comparison
 
-    def _score_template(self, template: _ConceptTemplate, request: TripIdeaRequest) -> TripConcept:
-        score = template.base_family_fit + template.base_comfort + template.food_score
-        party_label = "family" if request.travelers >= 3 else "couple"
-        rationale = [
-            f"Fits comfort-first {party_label} travel better than lowest-price optimization.",
-            "Food access is scored as a major trip objective.",
-        ]
-        why_not = list(template.risks)
-        country_fits = [
-            fit
-            for country in template.countries
-            if (fit := self._country_priors.fit_for_country(country))
-        ]
-        for fit in country_fits:
-            score += fit.score_adjustment
-            rationale.append(f"Fit based on past country-level history: {fit.rationale}")
-            if fit.caution_signals:
-                why_not.append(
-                    f"{fit.country} country prior has caution signals: {', '.join(fit.caution_signals[:4])}."
-                )
-
-        goals = {goal.lower() for goal in request.goals}
-        avoid = {item.lower() for item in request.avoid}
-        matched_goals = goals & template.tags
+    def _score_archetype(
+        self, archetype: _ConceptArchetype, request: TripIdeaRequest
+    ) -> TripConcept:
+        score = archetype.family_fit + archetype.comfort + archetype.food
+        rationale = list(archetype.rationale_seed)
+        why_not = list(archetype.risks)
+        goals = {_normalize_goal(goal) for goal in request.goals}
+        avoid = {_normalize_goal(item) for item in request.avoid}
+        matched_goals = goals & archetype.tags
         score += len(matched_goals) * 8
         if matched_goals:
             rationale.append(f"Matches requested goals: {', '.join(sorted(matched_goals))}.")
+
         experience_intents = _required_experience_intents(request)
         matched_experiences = {
             intent
             for intent in experience_intents
-            if _template_matches_experience(template, intent)
+            if _archetype_matches_experience(archetype, intent)
         }
         if matched_experiences:
             score += len(matched_experiences) * 18
@@ -444,7 +287,7 @@ class TripIdeationService:
             )
 
         if request.duration_days:
-            diff = abs(request.duration_days - template.recommended_duration_days)
+            diff = abs(request.duration_days - archetype.recommended_duration_days)
             if diff == 0:
                 score += 18
                 rationale.append("Duration matches the requested trip length.")
@@ -454,70 +297,65 @@ class TripIdeationService:
             elif diff <= 2:
                 score += 4
                 rationale.append("Duration is workable but needs pacing discipline.")
-            elif request.duration_days < template.recommended_duration_days:
-                score -= 20 + (template.recommended_duration_days - request.duration_days) * 8
+            elif request.duration_days < archetype.recommended_duration_days:
+                score -= 20 + (archetype.recommended_duration_days - request.duration_days) * 8
                 why_not.append(
-                    f"Ideal version is {template.recommended_duration_days} days, which does not respect the requested {request.duration_days}-day constraint without cutting scope."
+                    f"Ideal version is {archetype.recommended_duration_days} days, which does not respect the requested {request.duration_days}-day constraint without cutting scope."
                 )
             else:
                 score -= diff * 2
 
-        if request.max_flight_hours and template.estimated_flight_hours > request.max_flight_hours:
-            penalty = int((template.estimated_flight_hours - request.max_flight_hours) * 4)
+        if request.max_flight_hours and archetype.travel_burden_hours > request.max_flight_hours:
+            penalty = int((archetype.travel_burden_hours - request.max_flight_hours) * 4)
             score -= penalty
             why_not.append(
-                f"Estimated flight time around {template.estimated_flight_hours:.1f}h exceeds requested max."
+                f"Estimated travel burden around {archetype.travel_burden_hours:.1f}h exceeds requested max."
             )
 
         if request.direct_flight_preferred or self._prefs.flight.prefer_direct:
-            score += template.direct_flight_friendliness
-            if template.direct_flight_friendliness < 7:
+            score += archetype.direct_flight_friendliness
+            if archetype.direct_flight_friendliness < 7:
                 why_not.append("Direct-flight friendliness is only moderate; verify exact routing.")
 
-        if "crowds" in avoid or self._prefs.crowd.avoid_huge_crowds_when_possible:
-            crowd_penalty = max(0, template.crowd_risk - 55)
+        if "crowds" in avoid or "huge crowds" in avoid or self._prefs.crowd.avoid_huge_crowds_when_possible:
+            crowd_penalty = max(0, archetype.crowd_risk - 55)
             score -= crowd_penalty
             if crowd_penalty:
-                why_not.append("Crowd exposure needs careful season and activity selection.")
+                why_not.append("Crowd exposure needs evidence-backed season and timing choices.")
 
-        if "food" in template.tags and self._prefs.food.food_is_major_objective:
+        if "food" in archetype.tags and self._prefs.food.food_is_major_objective:
             score += 10
 
-        if "city" in template.tags and self._prefs.lodging_context.city_prefer_urban_core:
-            rationale.append("Requires central, walkable lodging to preserve comfort and time.")
-
-        if "rental" in template.tags and self._prefs.lodging_context.non_city_prefer_private_rental:
-            rationale.append(
-                "Private rental can work well outside major city cores if location and access are vetted."
-            )
+        if "city" in archetype.tags and self._prefs.lodging_context.city_prefer_urban_core:
+            rationale.append("Requires user-confirmed walkable lodging areas before connector searches.")
 
         required_research = [
+            "Resolve candidate destination names, countries, map locations, and gateway airports into TripIntake JSON.",
             "Live flight options, total travel time, layovers, baggage, seats, and loyalty application.",
-            "Exact lodging short list with bed layout, king-bed availability, location, safety, parking/access, and cancellation terms.",
-            "Visa/entry requirements, passport validity rules, vaccination or health precautions, and local cash guidance.",
-            "Small-group tour/activity operators with strong review and safety signals.",
-            "Validate country prior against exact sub-region, season, logistics, and trip style.",
+            "Exact lodging short list with bed layout, location, safety, parking/access, and cancellation terms.",
+            "Provider-backed activities/tours with strong review, safety, schedule, and weather evidence.",
+            "Entry requirements, passport validity rules, health precautions, and local cash guidance from official/current sources.",
         ]
 
         return TripConcept(
-            concept_id=template.concept_id,
-            title=template.title,
-            destinations=template.destinations,
-            recommended_duration_days=template.recommended_duration_days,
-            best_season=template.best_season,
-            estimated_cost_band_cad=template.estimated_cost_band_cad,
-            estimated_travel_burden=_travel_burden(template.estimated_flight_hours),
-            estimated_flight_hours=template.estimated_flight_hours,
-            direct_flight_friendliness=template.direct_flight_friendliness,
-            family_fit_score=template.base_family_fit,
-            comfort_convenience_score=template.base_comfort,
-            food_score=template.food_score,
-            crowd_risk=template.crowd_risk,
+            concept_id=archetype.concept_id,
+            title=archetype.title,
+            destinations=archetype.destination_slots,
+            recommended_duration_days=archetype.recommended_duration_days,
+            best_season="requires resolver/provider evidence",
+            estimated_cost_band_cad="not estimated until destination, dates, party, and providers are resolved",
+            estimated_travel_burden=_travel_burden(archetype.travel_burden_hours),
+            estimated_flight_hours=archetype.travel_burden_hours,
+            direct_flight_friendliness=archetype.direct_flight_friendliness,
+            family_fit_score=archetype.family_fit,
+            comfort_convenience_score=archetype.comfort,
+            food_score=archetype.food,
+            crowd_risk=archetype.crowd_risk,
             total_score=max(0, min(100, score // 3)),
-            country_prior_signals=[fit.rationale for fit in country_fits],
+            country_prior_signals=[],
             rationale=rationale,
             why_it_may_not_fit=why_not,
-            major_risks=template.risks,
+            major_risks=archetype.risks,
             required_research=required_research,
         )
 
@@ -530,71 +368,6 @@ def _travel_burden(flight_hours: float) -> str:
     return "high"
 
 
-def _explicit_region_intents(request: TripIdeaRequest) -> set[str]:
-    text = _request_text(request)
-    intents: set[str] = set()
-    if any(
-        term in text
-        for term in (
-            "caribbean",
-            "carribean",
-            "carribbean",
-            "west indies",
-            "antilles",
-        )
-    ):
-        intents.add("caribbean")
-    if "azores" in text:
-        intents.add("azores")
-    if "portugal" in text:
-        intents.add("portugal")
-    return intents
-
-
-def _region_filtered_templates(
-    templates: list[_ConceptTemplate],
-    region_intents: set[str],
-) -> list[_ConceptTemplate]:
-    if not region_intents:
-        return templates
-    matched = [
-        template
-        for template in templates
-        if all(_template_matches_region(template, intent) for intent in region_intents)
-    ]
-    return matched or templates
-
-
-def _template_matches_region(template: _ConceptTemplate, intent: str) -> bool:
-    haystack = _template_text(template)
-    if intent == "caribbean":
-        return "caribbean" in template.tags or any(
-            term in haystack
-            for term in (
-                "belize",
-                "curacao",
-                "curaçao",
-                "st lucia",
-                "saint lucia",
-                "st maarten",
-                "saint martin",
-                "st kitts",
-                "st thomas",
-                "cuba",
-                "dominican",
-                "barbados",
-                "jamaica",
-                "aruba",
-                "bonaire",
-                "puerto rico",
-                "isla mujeres",
-                "cancun",
-                "riviera maya",
-            )
-        )
-    return intent in template.tags or intent in haystack
-
-
 def _required_experience_intents(request: TripIdeaRequest) -> set[str]:
     text = _request_text(request)
     intents: set[str] = set()
@@ -605,26 +378,26 @@ def _required_experience_intents(request: TripIdeaRequest) -> set[str]:
     return intents
 
 
-def _experience_filtered_templates(
-    templates: list[_ConceptTemplate],
+def _experience_filtered_archetypes(
+    archetypes: list[_ConceptArchetype],
     experience_intents: set[str],
-) -> list[_ConceptTemplate]:
+) -> list[_ConceptArchetype]:
     if not experience_intents:
-        return templates
+        return archetypes
     matched = [
-        template
-        for template in templates
-        if all(_template_matches_experience(template, intent) for intent in experience_intents)
+        archetype
+        for archetype in archetypes
+        if all(_archetype_matches_experience(archetype, intent) for intent in experience_intents)
     ]
-    return matched or templates
+    return matched or archetypes
 
 
-def _template_matches_experience(template: _ConceptTemplate, intent: str) -> bool:
+def _archetype_matches_experience(archetype: _ConceptArchetype, intent: str) -> bool:
     if intent == "snorkeling":
-        return bool(template.tags & {"snorkel", "snorkeling", "reef"})
+        return bool(archetype.tags & {"snorkeling", "reef"})
     if intent == "beach_water":
-        return bool(template.tags & {"beach", "water", "reef", "snorkel", "snorkeling"})
-    return intent in template.tags
+        return bool(archetype.tags & {"beach", "water", "reef", "snorkeling"})
+    return intent in archetype.tags
 
 
 def _request_text(request: TripIdeaRequest) -> str:
@@ -639,15 +412,13 @@ def _request_text(request: TripIdeaRequest) -> str:
     return " ".join(parts).lower()
 
 
-def _template_text(template: _ConceptTemplate) -> str:
-    return " ".join(
-        [
-            template.title,
-            *template.countries,
-            *template.destinations,
-            *template.tags,
-        ]
-    ).lower()
+def _normalize_goal(value: str) -> str:
+    return " ".join(value.lower().replace("-", " ").split()).replace(" ", "-")
+
+
+def _contains_regional_wording(request: TripIdeaRequest) -> bool:
+    text = _request_text(request)
+    return any(term in text for term in ("region", "coast", "island", "caribbean", "europe", "asia"))
 
 
 def _duration_filtered_concepts(
@@ -655,12 +426,6 @@ def _duration_filtered_concepts(
     request: TripIdeaRequest,
     limit: int,
 ) -> list[TripConcept]:
-    """Prefer concepts that fit the requested trip length before generic ranking.
-
-    If the user asks for six days, a nine- or ten-day concept should not show up
-    just because it scores well on food or country priors. Longer concepts are
-    only allowed back in when there are not enough duration-fit ideas.
-    """
     if not request.duration_days:
         return []
     tolerance = 0 if request.duration_days <= 6 else 1 if request.duration_days <= 8 else 2
@@ -668,4 +433,4 @@ def _duration_filtered_concepts(
     duration_fit = [
         concept for concept in concepts if concept.recommended_duration_days <= max_days
     ]
-    return duration_fit if len(duration_fit) >= limit else []
+    return duration_fit

--- a/trippy/services/trip_planner.py
+++ b/trippy/services/trip_planner.py
@@ -156,11 +156,7 @@ class TripPlannerService:
         map_seed_queries = geography.map_seed_queries() if geography else list(intake.destination_seeds)
         single_base_region = planning_regions[0] if planning_regions else destination
         balanced_regions = planning_regions[:2] or [single_base_region]
-        signal_sources = [*intake.destination_seeds, destination]
-        if geography:
-            signal_sources.extend(
-                source for source in [geography.country, geography.primary_destination_name] if source
-            )
+        signal_sources = [geography.country] if geography and geography.country else []
         signals = [
             signal.rationale
             for seed in signal_sources

--- a/trippy/services/trip_planner.py
+++ b/trippy/services/trip_planner.py
@@ -156,12 +156,12 @@ class TripPlannerService:
         map_seed_queries = geography.map_seed_queries() if geography else list(intake.destination_seeds)
         single_base_region = planning_regions[0] if planning_regions else destination
         balanced_regions = planning_regions[:2] or [single_base_region]
-        signal_sources = [geography.country] if geography and geography.country else []
-        signals = [
-            signal.rationale
-            for seed in signal_sources
-            for signal in self._country_priors.fit_for_text(seed)
-        ]
+        signal = (
+            self._country_priors.fit_for_country(geography.country)
+            if geography and geography.country
+            else None
+        )
+        signals = [signal.rationale] if signal else []
         if not signals:
             signals = [
                 "No direct country prior matched; require live evidence and family-fit validation."

--- a/trippy/services/trip_workspace.py
+++ b/trippy/services/trip_workspace.py
@@ -493,9 +493,9 @@ class TripWorkspaceService:
                 rows=[
                     [
                         "Entry",
-                        "Portugal/Schengen entry requirements",
+                        "Destination entry requirements",
                         "seeded",
-                        "Check passport validity and any ETIAS timing.",
+                        "Check passport validity, visa, and entry timing requirements from official sources.",
                     ],
                     [
                         "Health",
@@ -507,10 +507,10 @@ class TripWorkspaceService:
                         "Cash",
                         "Local currency guidance",
                         "seeded",
-                        "Estimate euros to carry for small vendors, parking, tips, and markets.",
+                        "Estimate local cash to carry for small vendors, parking, tips, and markets.",
                     ],
                     [
-                        "Inter-island",
+                        "Local movement",
                         "Schedule buffers",
                         "seeded",
                         option.island_region_movement_friction,
@@ -816,7 +816,7 @@ def _placeholder_stays(
                 stay_type=stay_type,
                 property_name=_option_summary(linked_lodging) or f"{region} lodging shortlist",
                 city=region,
-                country="Portugal",
+                country=intake.geography.country if intake.geography and intake.geography.country else "",
                 check_in=check_in,
                 check_out=check_out,
                 confirmation_code="UNCONFIRMED",
@@ -834,10 +834,10 @@ def _workspace_checklist(option: TripPlanOption) -> list[ChecklistItem]:
         ("booking", "Shortlist lodging with 3+ beds and safe/practical location"),
         ("booking", "Validate car rental fit, luggage capacity, pickup/dropoff, and cancellation"),
         ("booking", "Research small-group tours and activity safety/review signals"),
-        ("logistics", "Validate island movement sequence and schedule buffers"),
-        ("document", "Check Portugal/Schengen entry requirements and passport validity"),
+        ("logistics", "Validate destination movement sequence and schedule buffers"),
+        ("document", "Check destination entry requirements and passport validity"),
         ("health", "Check destination health precautions and motion-sickness/weather backups"),
-        ("money", "Estimate euros to carry for parking, markets, tips, and small vendors"),
+        ("money", "Estimate local cash to carry for parking, markets, tips, and small vendors"),
         ("maps", "Build trip map artifacts and link them from the workspace"),
     ]
     return [

--- a/trippy/skills/definitions/trippy-family-itinerary-builder.md
+++ b/trippy/skills/definitions/trippy-family-itinerary-builder.md
@@ -16,9 +16,9 @@ pacing for a family with kids, buffer days, and logistics between cities.
 ## Inputs
 ```json
 {
-  "trip_id": "japan-2027",
-  "destinations": ["Tokyo", "Kyoto", "Osaka"],
-  "total_days": 14,
+  "trip_id": "family-trip-2027",
+  "destinations": ["Confirmed Base A", "Confirmed Base B"],
+  "total_days": 9,
   "interests": ["food", "culture", "nature"],
   "avoid": ["very early mornings", "packed schedules"]
 }
@@ -27,7 +27,7 @@ pacing for a family with kids, buffer days, and logistics between cities.
 ## Process
 1. Load family preferences from memory (pacing, stay length, arrival time preferences)
 2. Load family profile (5 travelers including minors — pace accordingly)
-3. Research destination logistics: city order, transport between cities, distances
+3. Use only destinations supplied from canonical trip JSON or user-approved resolver output
 4. Apply preference constraints:
    - min_nights_per_destination (≥2, prefer 3)
    - prefer_slow_travel (no more than 3 destinations per week)
@@ -36,28 +36,25 @@ pacing for a family with kids, buffer days, and logistics between cities.
    - Day 1: arrival + settle-in (no packed first day)
    - Intermediate days: activities with reasonable daily count for family
    - Last day: pack + depart (no full-day activities before a long flight)
-6. For each city: suggest 2–3 neighbourhoods to focus on
+6. For each confirmed place: leave unresolved lodging/activity areas flagged for scanner evidence
 7. Flag family-specific considerations (stroller access, kid-friendly options, etc.)
 8. Return as both structured JSON and human-readable day-by-day text
 
 ## Outputs
 ```json
 {
-  "trip_id": "japan-2027",
-  "total_days": 14,
+  "trip_id": "family-trip-2027",
+  "total_days": 9,
   "itinerary": [
-    {"day": 1, "date": "2027-03-10", "city": "Tokyo", "notes": "Arrive NRT (~14:00), transfer to hotel (Shinjuku). Easy evening — jet lag day."},
-    {"day": 2, "date": "2027-03-11", "city": "Tokyo", "notes": "Shibuya + Harajuku. Afternoon: teamLab if kids are up for it."},
+    {"day": 1, "date": "2027-03-10", "city": "Confirmed Base A", "source": "explicit_input", "requires_user_confirmation": true, "notes": "Arrive, check in, easy first evening."},
+    {"day": 2, "date": "2027-03-11", "city": "Confirmed Base A", "source": "explicit_input", "requires_user_confirmation": true, "notes": "Confirmed Base A: scanner-backed activity placeholder."},
     "..."
   ],
   "city_summary": {
-    "Tokyo": "4 nights (days 1-4)",
-    "Kyoto": "3 nights (days 5-7)",
-    "Osaka": "3 nights (days 8-10)",
-    "Tokyo": "3 nights (days 11-13)",
-    "Departure": "day 14"
+    "Confirmed Base A": "3 nights",
+    "Confirmed Base B": "3 nights"
   },
-  "warnings": ["Day 5 Kyoto shinkansen early (07:00 preferred) — check family preference"],
+  "warnings": ["All generated rows require user confirmation and scanner/provider evidence before booking."],
   "suggested_sheet_updates": [...]
 }
 ```

--- a/trippy/skills/definitions/trippy-trip-sheet-creator.md
+++ b/trippy/skills/definitions/trippy-trip-sheet-creator.md
@@ -1,7 +1,7 @@
 # Skill: trippy-trip-sheet-creator
 
 ## Purpose
-Given a rough trip idea ("Japan next March", "Costa Rica in January for 10 days"),
+Given a rough trip idea ("family trip next March", "winter trip for 10 days"),
 create a new canonical trip record and a Google Sheet using the Trippy template.
 Pre-fill the sheet with known family info, suggested structure, and preference-aware
 recommendations.
@@ -14,7 +14,7 @@ recommendations.
 ## Inputs
 ```json
 {
-  "trip_idea": "Japan, March 2027, roughly 2 weeks",
+  "trip_idea": "Family trip, March 2027, roughly 2 weeks",
   "folder_id": "Drive folder ID to create the sheet in (optional)",
   "template_sheet_id": "Override the default template (optional)"
 }
@@ -24,15 +24,15 @@ recommendations.
 1. Parse the trip idea: destination(s), dates, duration, party (assume all 5 travelers)
 2. Create a canonical Trip record with trip_id, name, status=planned
 3. Pre-populate travelers from the family profile in memory
-4. Suggest itinerary structure: key cities, recommended nights per city, logical order
+4. Suggest only unresolved structure placeholders until locations are confirmed in JSON
 5. Suggest departure time targets based on preference memory
-6. Flag known requirements (JR Pass for Japan, ETA for Canada→Japan, etc.)
+6. Flag that entry, visa, transport pass, health, and local rules require official/current evidence
 7. Call `sheets_from_template(title, template_sheet_id)` to create the Google Sheet
 8. Write the canonical data to the sheet:
    - Trip overview tab: name, dates, travelers, status
-   - Flights tab: placeholder rows for outbound + return
-   - Hotels tab: placeholder rows per city
-   - Checklist tab: pre-populated with standard + destination-specific items
+   - Flights tab: unresolved rows that require explicit IATA origin/destination before search
+   - Hotels tab: unresolved rows per user-confirmed location
+   - Checklist tab: pre-populated with standard non-destination-specific items
 9. Write canonical Trip JSON to `~/.trippy/trips/{trip_id}.json`
 10. Write trip to SQLite DB
 11. Return trip_id, sheet_id, and sheet URL
@@ -40,11 +40,11 @@ recommendations.
 ## Outputs
 ```json
 {
-  "trip_id": "japan-2027",
+  "trip_id": "family-trip-2027",
   "sheet_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
   "sheet_url": "https://docs.google.com/spreadsheets/d/...",
-  "suggestion_summary": "Suggest: Tokyo 4n → Kyoto 3n → Osaka 2n → Tokyo 2n",
-  "flags": ["Add JR Pass to checklist", "Check ETA requirement for Canadian passports"]
+  "suggestion_summary": "Confirmed Base A 4n pending evidence → Confirmed Base B 4n pending evidence",
+  "flags": ["Confirm entry, visa, transport pass, health, and local rules from official/current sources"]
 }
 ```
 

--- a/trippy/skills/runners/itinerary_builder.py
+++ b/trippy/skills/runners/itinerary_builder.py
@@ -31,7 +31,7 @@ class ItineraryBuilderRunner:
         from trippy.services.trip_state import TripStateService
 
         trip_id: str = inputs["trip_id"]
-        destinations: list[str] = inputs.get("destinations", [])
+        destinations: list[str] = [str(item).strip() for item in inputs.get("destinations", []) if str(item).strip()]
         total_days: int = inputs.get("total_days", 14)
 
         memory = self._memory_store or MemoryStore(config.MEMORY_PATH)
@@ -46,9 +46,14 @@ class ItineraryBuilderRunner:
         raw = memory.get_value("pref:preferences_object")
         prefs = FamilyTravelPreferences.model_validate(raw) if raw else FamilyTravelPreferences()
 
-        # Use trip destinations if not provided
-        if not destinations and trip.destination_summary:
-            destinations = [d.strip() for d in trip.destination_summary.split(",")]
+        if not destinations:
+            return {
+                "error": (
+                    "Itinerary builder requires explicit destinations from canonical trip JSON "
+                    "or user-approved resolver output; it will not split destination_summary text."
+                ),
+                "trip_id": trip_id,
+            }
 
         start = trip.start_date or date.today()
         itinerary = self._build_itinerary(destinations, total_days, start, prefs)
@@ -93,6 +98,8 @@ class ItineraryBuilderRunner:
                 "date": str(current_date),
                 "city": destinations[0] if destinations else "Arrival city",
                 "type": "arrival",
+                "source": "explicit_input",
+                "requires_user_confirmation": True,
                 "notes": "Arrive, check in, easy first evening. Jet lag day — no packed schedule.",
             }
         )
@@ -122,6 +129,8 @@ class ItineraryBuilderRunner:
                         "date": str(current_date),
                         "city": dest,
                         "type": "transit" if is_transit_day else "regular",
+                        "source": "explicit_input",
+                        "requires_user_confirmation": True,
                         "notes": notes,
                     }
                 )
@@ -140,6 +149,8 @@ class ItineraryBuilderRunner:
                 "date": str(start + timedelta(days=total_days - 1)),
                 "city": destinations[-1] if destinations else "Departure",
                 "type": "departure",
+                "source": "explicit_input",
+                "requires_user_confirmation": True,
                 "notes": "Pack, check out, depart. No activities — buffer for airport.",
             }
         )

--- a/trippy/skills/runners/trip_sheet_creator.py
+++ b/trippy/skills/runners/trip_sheet_creator.py
@@ -127,15 +127,9 @@ class TripSheetCreatorRunner:
                 trip.sync.google_sheet_url = sheet_result.get("url", "")
                 state_svc.save(trip)
 
-        # Destination-specific flags
-        dest_lower = " ".join(d.lower() for d in destinations)
-        if "japan" in dest_lower:
-            flags.append("Add JR Pass to checklist (if rail travel planned)")
-            flags.append("Check Japan ETA requirement for Canadian passports")
-        if "us" in dest_lower or "united states" in dest_lower:
-            flags.append("Check eTA/ESTA requirement")
-        if "europe" in dest_lower:
-            flags.append("Check ETIAS requirement (effective 2025)")
+        flags.append(
+            "Destination facts are unresolved; confirm entry, visa, transport pass, and health requirements from official/current sources."
+        )
 
         next_actions: list[str] = []
         if sheet_result.get("error"):
@@ -239,6 +233,6 @@ def _suggest_structure(destinations: list[str]) -> str:
     if not destinations:
         return "No destinations specified"
     if len(destinations) == 1:
-        return f"{destinations[0]}: suggest 7-10 nights, explore different neighbourhoods"
+        return f"{destinations[0]}: single-base structure pending resolver/provider evidence"
     days_per = 14 // len(destinations)
-    return " → ".join(f"{d} {days_per}n" for d in destinations)
+    return " → ".join(f"{d} {days_per}n pending evidence" for d in destinations)

--- a/trippy/ui/server.py
+++ b/trippy/ui/server.py
@@ -119,6 +119,48 @@ class TrippyUIService:
             ),
         }
 
+    def export_trip_json(self, trip_id: str) -> dict[str, Any]:
+        intake = self._intakes.require(trip_id)
+        geography = intake.geography
+        return {
+            "schema": "trippy.trip_intake.v1",
+            "trip_id": intake.trip_id,
+            "intake": intake.model_dump(mode="json"),
+            "resolver_evidence": {
+                "warnings": list(geography.warnings if geography else []),
+                "departure_airports": [
+                    airport.model_dump(mode="json")
+                    for airport in (geography.departure_airports if geography else [])
+                ],
+                "destination_airports": [
+                    airport.model_dump(mode="json")
+                    for airport in (geography.destination_airports if geography else [])
+                ],
+                "map_locations": [
+                    location.model_dump(mode="json")
+                    for location in (geography.map_locations if geography else [])
+                ],
+            },
+            "next_step": "Edit unresolved fields, then POST this JSON to /api/trip-json.",
+        }
+
+    def import_trip_json(self, payload: dict[str, Any]) -> dict[str, Any]:
+        raw_intake = payload.get("intake") if isinstance(payload.get("intake"), dict) else payload
+        intake = TripIntake.model_validate(raw_intake)
+        saved = self._intakes.create(intake, overwrite=bool(payload.get("overwrite", True)))
+        workflow = self._record_workflow(
+            workflow_name="ui-trip-json-import",
+            trip_id=saved.trip_id,
+            summary=f"Imported enriched TripIntake JSON for {saved.trip_name}",
+            result=saved.model_dump(mode="json"),
+        )
+        return {
+            "workflow_id": workflow.id,
+            "intake": saved.model_dump(mode="json"),
+            "resolver_evidence": self.export_trip_json(saved.trip_id)["resolver_evidence"],
+            "next_step": "Review unresolved airports and places before connector searches.",
+        }
+
     def logs(self, trip_id: str | None = None, limit: int = 50) -> dict[str, Any]:
         events = self._learning.list_events()
         workflow_trip_ids = _workflow_trip_index(events)
@@ -814,6 +856,14 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
                     return
                 self._send_json(self._ui.trip_state(trip_id))
                 return
+            if path == "/api/trip-json":
+                query = parse_qs(urlparse(self.path).query)
+                trip_id = query.get("trip_id", [""])[0]
+                if not trip_id:
+                    self._send_error("trip_id is required", HTTPStatus.BAD_REQUEST)
+                    return
+                self._send_json(self._ui.export_trip_json(trip_id))
+                return
             if path == "/api/map-file":
                 query = parse_qs(urlparse(self.path).query)
                 trip_id = query.get("trip_id", [""])[0]
@@ -838,6 +888,9 @@ class TrippyUIHandler(BaseHTTPRequestHandler):
             payload = self._read_json()
             if path == "/api/intake":
                 self._send_json(self._ui.create_intake(payload))
+                return
+            if path == "/api/trip-json":
+                self._send_json(self._ui.import_trip_json(payload))
                 return
             if path == "/api/suggest-ideas":
                 self._send_json(self._ui.suggest_ideas(payload))


### PR DESCRIPTION
## Summary
- adds a JSON-first destination-agnostic QA audit report at `docs/qa/json_first_destination_agnostic_audit.md`
- removes canned/fake fallback trip outputs and blocks raw destination text from becoming flight routes
- replaces hardcoded idea-stage destination templates with destination-agnostic scanner briefs
- removes raw destination-text country-prior matching from planner/advisor/friction paths
- hardens itinerary/trip-sheet skills so they require explicit JSON or user-approved resolver output
- adds `/api/trip-json` import/export for enriched `TripIntake` JSON plus resolver evidence

## Tests
- `uv run pytest tests/unit/test_trip_geography.py`
- `uv run pytest tests/unit/test_trip_planning_pipeline.py`
- `uv run pytest` — 346 passed, 5 skipped
- `uv run mypy trippy/` — success, no issues in 91 source files
- `uv run ruff check .` — all checks passed

## Remaining Risks
- `trippy/services/country_priors.py` still stores country prior facts, but runtime planning now uses them only from explicit enriched country fields/canonical stay country, not raw destination text
- named destinations remain in fixtures, tests, docs, and `trippy/thin_slice.py` demo data
- recommended next PRs: add CI grep guardrails and build a richer browser editor around `/api/trip-json` for resolver confirmation