### PR TITLE
Add scanner fallback when live providers return no rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,15 @@ context (baggage rules, cancellation windows, check-in/out, child-seat policies,
 hours/restrictions, weather dependency, amenities), while official APIs stay the
 source of truth for transactional inventory and booking-ready details.
 
+Shortlists use the same provider ladder across categories:
+
+1. Use the strongest configured live API/provider signal first.
+2. If the API/provider returns no usable rows and Firecrawl or OpenClaw is actually
+   configured, automatically run read-only scanner fallback against the source/search
+   links. This does not require adding `--validate-live` or `--deep-research`.
+3. If neither live APIs nor scanner fallback can produce evidence, keep the row as a
+   human handoff instead of inventing prices, inventory, or booking terms.
+
 ```bash
 uv run trippy trip-plan flights    --trip-id <id> --deep-research --adapter firecrawl
 uv run trippy trip-plan lodging    --trip-id <id> --deep-research --adapter firecrawl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,11 @@ def _disable_live_apis(monkeypatch):  # type: ignore[no-untyped-def]
     monkeypatch.setenv("SERPAPI_KEY", "")
     monkeypatch.setenv("DUFFEL_ACCESS_TOKEN", "")
     monkeypatch.setenv("FIRECRAWL_API_KEY", "")
+    monkeypatch.setenv("TRIPPY_SOURCE_RESEARCH_OPENCLAW_ENABLED", "false")
     monkeypatch.setattr(trippy_config, "SERPAPI_KEY", "", raising=False)
     monkeypatch.setattr(trippy_config, "DUFFEL_ACCESS_TOKEN", "", raising=False)
     monkeypatch.setattr(trippy_config, "FIRECRAWL_API_KEY", "", raising=False)
+    monkeypatch.setattr(trippy_config, "SOURCE_RESEARCH_OPENCLAW_ENABLED", False, raising=False)
     yield
 
 

--- a/tests/unit/test_trip_planning_pipeline.py
+++ b/tests/unit/test_trip_planning_pipeline.py
@@ -467,6 +467,90 @@ def test_live_validation_marks_reachable_rows_without_claiming_inventory(
     assert any("exact inventory" in note for note in first.validation.notes)
 
 
+def test_live_validation_defaults_to_provenance_only_when_env_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    monkeypatch.setattr("trippy.config.LIVE_VALIDATION_ENABLED", False)
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_intake())
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+    planner.select_option(intake.trip_id, "two-region-balanced")
+    service = FlightShortlistService(intake_service, planner)
+    flights = service.add_candidate(
+        intake.trip_id,
+        link="https://www.google.com/travel/flights/search",
+        notes="YYZ to PDL candidate; provider evidence pending.",
+    )
+
+    def forbidden_fetch(_url: str, _timeout: float) -> tuple[bool, int | None, str]:
+        raise AssertionError("live validation should not fetch unless explicitly enabled")
+
+    validator = LiveValidationService(fetcher=forbidden_fetch)
+    validated = validator.validate_state(flights)
+    first = validated.flight_options[0]
+
+    assert validated.artifacts["validation_mode"] == "provenance_only"
+    assert first.row_status == ShortlistRowStatus.RESEARCHED
+    assert first.validation.verification_status == VerificationStatus.MANUAL_REQUIRED
+    assert first.validation.freshness_status == FreshnessStatus.UNKNOWN
+
+
+def test_api_failures_run_configured_scanner_fallback_without_manual_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_planning_paths(tmp_path, monkeypatch)
+    calls: list[tuple[str, str]] = []
+
+    def fake_fallback_available() -> bool:
+        return True
+
+    def fake_run_scanner_fallback(state, *, adapter_mode: str = "auto", reason: str):
+        calls.append((state.category.value, reason))
+        state.artifacts["scanner_fallback"] = {
+            "status": "fake",
+            "adapter_mode": adapter_mode,
+            "reason": reason,
+        }
+        return state
+
+    for module in (
+        "trippy.services.flight_shortlist",
+        "trippy.services.lodging_shortlist",
+        "trippy.services.car_shortlist",
+        "trippy.services.activity_shortlist",
+    ):
+        monkeypatch.setattr(f"{module}.scanner_fallback_available", fake_fallback_available)
+        monkeypatch.setattr(f"{module}.run_scanner_fallback", fake_run_scanner_fallback)
+
+    intake_service = TripIntakeService()
+    intake = intake_service.create(_azores_intake())
+    planner = TripPlannerService(intake_service)
+    planner.draft(intake.trip_id)
+    planner.select_option(intake.trip_id, "two-region-balanced")
+
+    flights = FlightShortlistService(intake_service, planner).build(intake.trip_id)
+    lodging = LodgingShortlistService(intake_service, planner).build(intake.trip_id)
+    cars = CarShortlistService(intake_service, planner).build(intake.trip_id)
+    activities = ActivityShortlistService(intake_service, planner).build(intake.trip_id)
+
+    assert [category for category, _reason in calls] == [
+        "flights",
+        "lodging",
+        "cars",
+        "activities",
+    ]
+    assert flights.flight_options[0].option_id == "scanner-flight-search-1"
+    assert flights.artifacts["scanner_fallback"]["status"] == "fake"
+    assert lodging.artifacts["scanner_fallback"]["status"] == "fake"
+    assert cars.artifacts["scanner_fallback"]["status"] == "fake"
+    assert activities.artifacts["scanner_fallback"]["status"] == "fake"
+    assert all("Firecrawl/OpenClaw" in reason for _category, reason in calls)
+
+
 def test_lodging_deep_research_enriches_existing_shortlist_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/trippy/services/activity_shortlist.py
+++ b/trippy/services/activity_shortlist.py
@@ -19,6 +19,7 @@ from trippy.models.trip_planning import TripIntake
 from trippy.services import serpapi_client
 from trippy.services.destination_profiles import profile_for_intake
 from trippy.services.live_validation import LiveValidationService
+from trippy.services.scanner_fallback import run_scanner_fallback, scanner_fallback_available
 from trippy.services.serpapi_options import activity_options_from_serpapi
 from trippy.services.shortlist_store import (
     ShortlistContext,
@@ -98,8 +99,18 @@ class ActivityShortlistService:
         )
         _merge_existing_activity_state(state, existing)
         LiveValidationService().validate_state(state, attempt_network=validate_live)
+        fallback_research = bool(not live_options and scanner_fallback_available())
         if deep_research:
             SourceResearchService().research_state(state, adapter_mode=adapter_mode)
+        elif fallback_research:
+            state = run_scanner_fallback(
+                state,
+                adapter_mode=adapter_mode,
+                reason=(
+                    "SerpAPI did not return usable activity rows, so Trippy ran "
+                    "Firecrawl/OpenClaw scanner fallback against activity source links."
+                ),
+            )
         _write_activity_schedule_artifact(state)
         return self._store.save(state)
 

--- a/trippy/services/car_shortlist.py
+++ b/trippy/services/car_shortlist.py
@@ -18,6 +18,7 @@ from trippy.models.trip_planning import TripIntake
 from trippy.services import serpapi_client
 from trippy.services.destination_profiles import profile_for_intake
 from trippy.services.live_validation import LiveValidationService
+from trippy.services.scanner_fallback import run_scanner_fallback, scanner_fallback_available
 from trippy.services.serpapi_options import car_options_from_serpapi
 from trippy.services.shortlist_store import (
     ShortlistContext,
@@ -89,13 +90,19 @@ class CarShortlistService:
             ],
         )
         LiveValidationService().validate_state(state, attempt_network=validate_live)
-        fallback_research = bool(validate_live and not live_options)
+        fallback_research = bool(not live_options and scanner_fallback_available())
         if deep_research or fallback_research:
             if fallback_research and not deep_research:
-                state.warnings.append(
-                    "No live car inventory rows returned, so Trippy ran Firecrawl/OpenClaw-capable source research against date-aware car source links."
+                state = run_scanner_fallback(
+                    state,
+                    adapter_mode=adapter_mode,
+                    reason=(
+                        "No live car inventory rows returned, so Trippy ran "
+                        "Firecrawl/OpenClaw scanner fallback against date-aware car source links."
+                    ),
                 )
-            SourceResearchService().research_state(state, adapter_mode=adapter_mode)
+            else:
+                SourceResearchService().research_state(state, adapter_mode=adapter_mode)
         return self._store.save(state)
 
     def select_car(self, trip_id: str, option_id: str) -> ResearchShortlistState:

--- a/trippy/services/flight_shortlist.py
+++ b/trippy/services/flight_shortlist.py
@@ -29,6 +29,7 @@ from trippy.models.sources import TravelSourceCategory
 from trippy.services import serpapi_client
 from trippy.services.destination_profiles import profile_for_intake
 from trippy.services.live_validation import LiveValidationService
+from trippy.services.scanner_fallback import run_scanner_fallback, scanner_fallback_available
 from trippy.services.serpapi_options import flight_options_from_serpapi
 from trippy.services.shortlist_store import (
     ShortlistContext,
@@ -83,6 +84,11 @@ class FlightShortlistService:
                 if serp_options:
                     live_options = serp_options
         options = live_options
+        scanner_fallback = bool(gateway and not live_options and scanner_fallback_available())
+        if scanner_fallback:
+            fallback_option = _scanner_fallback_option(ctx, gateway)
+            if fallback_option is not None:
+                options = [fallback_option]
         if gateway and not options:
             live_notes.append(
                 "No flight options were created because configured flight providers returned no usable live rows; add a user-supplied candidate or configure a live provider."
@@ -119,6 +125,15 @@ class FlightShortlistService:
         LiveValidationService().validate_state(state, attempt_network=validate_live)
         if deep_research:
             SourceResearchService().research_state(state, adapter_mode=adapter_mode)
+        elif scanner_fallback and state.flight_options:
+            state = run_scanner_fallback(
+                state,
+                adapter_mode=adapter_mode,
+                reason=(
+                    "Configured flight APIs returned no usable rows, so Trippy ran "
+                    "Firecrawl/OpenClaw scanner fallback against the route search."
+                ),
+            )
         _refresh_flight_recommendations(state, ctx)
         return self._store.save(state)
 
@@ -218,6 +233,74 @@ class FlightShortlistService:
             ),
         )
         return self._store.save(state)
+
+
+def _scanner_fallback_option(
+    ctx: ShortlistContext,
+    gateway: str,
+) -> FlightOption | None:
+    origin = _iata_or_text(
+        ctx.intake.departure_airports[0] if ctx.intake.departure_airports else "YYZ"
+    )
+    destination = _iata_or_text(gateway)
+    if not _looks_like_iata(origin) or not _looks_like_iata(destination):
+        return None
+    deep_link = _flight_source_url("Google Flights", origin, destination, ctx)
+    return FlightOption(
+        option_id="scanner-flight-search-1",
+        rank=1,
+        airline="Scanner fallback route search",
+        flight_numbers=[],
+        departure_airport=origin,
+        arrival_airport=destination,
+        stops=0,
+        total_travel_duration="scanner evidence required",
+        timing_fit=(
+            "Firecrawl/OpenClaw will inspect public route evidence; no exact flight is "
+            "trusted until the scanner extracts itinerary facts."
+        ),
+        fare_estimate_cad="scanner evidence required",
+        price_band="scanner evidence required",
+        baggage_cabin_notes="Baggage and fare rules require provider evidence.",
+        booking_source="Google Flights scanner fallback",
+        deep_link=deep_link,
+        traveler_count=ctx.intake.party.total_travelers,
+        traveler_fit=f"Route search for {ctx.intake.party.total_travelers} traveler(s).",
+        comparison_links=_flight_comparison_links(origin, destination, ctx),
+        friction_score=55,
+        family_comfort_score=45,
+        recommendation_grade=RecommendationGrade.CONDITIONAL,
+        tradeoffs=[
+            "This row exists only to drive scanner fallback after API failure.",
+            "Do not treat it as an itinerary until source research extracts flight numbers, timing, fare, and baggage evidence.",
+        ],
+        friction_flags=["API search returned no usable flight rows"],
+        confidence_notes=[
+            "Scanner fallback candidate; public source evidence required before recommendation."
+        ],
+        live_data_status=LiveDataStatus.HANDOFF_REQUIRED,
+        validation=SourceValidation(
+            source_name="Google Flights scanner fallback",
+            source_type=SourceType.LIVE_SEARCH,
+            verification_status=VerificationStatus.MANUAL_REQUIRED,
+            confidence=0.2,
+            evidence_url=deep_link,
+            missing_fields=[
+                "exact_departure_date",
+                "exact_arrival_date",
+                "flight_numbers",
+                "exact_departure_time",
+                "exact_arrival_time",
+                "total_duration",
+                "exact_fare",
+                "fare_rules",
+                "baggage_terms",
+            ],
+            notes=[
+                "Generated only because configured live flight APIs returned no usable rows and scanner fallback is configured."
+            ],
+        ),
+    )
 
 
 def _duffel_live_options(

--- a/trippy/services/lodging_shortlist.py
+++ b/trippy/services/lodging_shortlist.py
@@ -29,6 +29,7 @@ from trippy.services.destination_profiles import profile_for_intake
 from trippy.services.firecrawl import FirecrawlService
 from trippy.services.live_validation import LiveValidationService
 from trippy.services.planning_advisor import PlanningAdvisorService
+from trippy.services.scanner_fallback import run_scanner_fallback, scanner_fallback_available
 from trippy.services.serpapi_options import lodging_options_from_serpapi
 from trippy.services.shortlist_store import (
     ShortlistContext,
@@ -163,13 +164,21 @@ class LodgingShortlistService:
             if advisor.night_plan:
                 structure["advisor_night_plan"] = advisor.night_plan
         LiveValidationService().validate_state(state, attempt_network=validate_live)
-        fallback_research = bool(validate_live and not live_options and _serpapi_lodging_problem(live_notes))
+        fallback_research = bool(
+            not live_options and _serpapi_lodging_problem(live_notes) and scanner_fallback_available()
+        )
         if deep_research or fallback_research:
             if fallback_research and not deep_research:
-                state.warnings.append(
-                    "SerpAPI did not return usable lodging rows, so Trippy ran Firecrawl/OpenClaw-capable source research against source links."
+                state = run_scanner_fallback(
+                    state,
+                    adapter_mode=adapter_mode,
+                    reason=(
+                        "SerpAPI did not return usable lodging rows, so Trippy ran "
+                        "Firecrawl/OpenClaw scanner fallback against lodging source links."
+                    ),
                 )
-            SourceResearchService().research_state(state, adapter_mode=adapter_mode)
+            else:
+                SourceResearchService().research_state(state, adapter_mode=adapter_mode)
         if deep_research:
             _review_lodging_discovery_sources(state, ctx.intake)
             state.recommended_option_id = _recommended_lodging_option_id(state.lodging_options)

--- a/trippy/services/scanner_fallback.py
+++ b/trippy/services/scanner_fallback.py
@@ -1,0 +1,69 @@
+"""Shared Firecrawl/OpenClaw fallback for shortlist source research."""
+
+from __future__ import annotations
+
+import shutil
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from trippy import config
+from trippy.models.shortlists import ResearchShortlistState
+from trippy.services.source_research import (
+    FirecrawlResearchAdapter,
+    LinkResearchAdapter,
+    OpenClawResearchAdapter,
+    SourceResearchService,
+)
+
+
+def scanner_fallback_available() -> bool:
+    """Return whether an API-failure scanner fallback can do useful live research."""
+    firecrawl_ready = bool(config.FIRECRAWL_ENABLED and config.FIRECRAWL_API_KEY.strip())
+    openclaw_ready = _openclaw_ready()
+    return firecrawl_ready or openclaw_ready
+
+
+def _openclaw_ready() -> bool:
+    if not config.SOURCE_RESEARCH_OPENCLAW_ENABLED:
+        return False
+    if shutil.which(config.OPENCLAW_COMMAND) is None:
+        return False
+    try:
+        request = Request(
+            config.OPENCLAW_GATEWAY_URL.rstrip("/") + "/health",
+            headers={"User-Agent": "Trippy/0.2 scanner fallback health"},
+        )
+        with urlopen(request, timeout=0.5) as response:  # noqa: S310 - localhost health probe
+            return 200 <= int(getattr(response, "status", 200)) < 400
+    except (HTTPError, URLError, OSError, TimeoutError, ValueError):
+        return False
+
+
+def run_scanner_fallback(
+    state: ResearchShortlistState,
+    *,
+    adapter_mode: str = "auto",
+    reason: str,
+) -> ResearchShortlistState:
+    """Run read-only scanner research without falling through to raw HTTP scraping.
+
+    The normal deep-research path can still use every adapter. This fallback is specifically
+    for provider/API failure, where Firecrawl and OpenClaw are the intended second line.
+    """
+    state.warnings.append(reason)
+    state.artifacts["scanner_fallback"] = {
+        "status": "attempted",
+        "adapter_mode": adapter_mode,
+        "reason": reason,
+    }
+    researched = SourceResearchService(
+        adapters=[
+            FirecrawlResearchAdapter(),
+            OpenClawResearchAdapter(),
+            LinkResearchAdapter(),
+        ]
+    ).research_state(state, adapter_mode=adapter_mode)
+    researched.artifacts["scanner_fallback"]["status"] = researched.artifacts.get(
+        "deep_research", {}
+    ).get("status", "unknown")
+    return researched


### PR DESCRIPTION
## Summary

- Preserves the local leftover work from `review/json-first-leftovers-clean-merge`
- Adds a shared scanner fallback helper for Firecrawl/OpenClaw-backed source research
- Runs scanner fallback automatically when configured live APIs/providers return no usable rows
- Keeps fallback rows as handoff/evidence-required instead of inventing prices, inventory, booking terms, or exact itineraries
- Adds tests covering disabled live validation and scanner fallback invocation across flights/lodging/cars/activities
- Documents the shortlist provider ladder in README

## Review notes

This is cleanly based on current `main` (`bc35da2`) and should merge without conflicts.

Important safety check before merge:
- The flight fallback row is intentionally a scanner/search placeholder, not a real flight. Confirm it stays `HANDOFF_REQUIRED`, `MANUAL_REQUIRED`, and evidence-required in the UI.
- Because fallback runs automatically when Firecrawl/OpenClaw is configured, expect additional Firecrawl/OpenClaw usage during live tests when primary providers fail.

## Tests to run

```bash
uv run ruff format --check .
uv run ruff check .
uv run mypy trippy/
uv run pytest
```
