### PR TITLE
Fix local UI startup to use canonical React frontend

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,3 +1,44 @@
-# Welcome to your Lovable project
+# Trippy Web UI
 
-TODO: Document your project here
+This is the canonical Trippy frontend. The older Python-rendered UI under `trippy/ui/templates` is only a backend fallback / API shell.
+
+## Run locally
+
+From the repo root:
+
+```bash
+# Terminal 1: backend API
+uv run trippy ui --port 8787 --no-open
+
+# Terminal 2: canonical React UI
+cd web
+npm install
+npm run dev
+```
+
+Open:
+
+```text
+http://127.0.0.1:8788
+```
+
+## Ports
+
+| Port | Purpose |
+|---|---|
+| 8787 | Python backend/API server |
+| 8788 | React/Vite frontend |
+
+The Vite dev server proxies `/api/*` to `http://127.0.0.1:8787` by default.
+
+Override the backend target when needed:
+
+```bash
+TRIPPY_API_PROXY_TARGET=http://127.0.0.1:8790 npm run dev
+```
+
+## Do not regress
+
+- Do not run the Python backend directly on `8788` unless you intentionally want the legacy fallback shell
+- Do not restore `trippy-canvas` as the source of truth
+- Keep the canonical UI inside this repo under `web/`

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,17 +3,23 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
+const trippyApiTarget =
+  process.env.TRIPPY_API_PROXY_TARGET ??
+  process.env.VITE_TRIPPY_API_TARGET ??
+  "http://127.0.0.1:8787";
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {
-    host: "::",
-    port: 8080,
+    host: "127.0.0.1",
+    port: 8788,
+    strictPort: true,
     hmr: {
       overlay: false,
     },
     proxy: {
       "/api": {
-        target: "http://localhost:8788",
+        target: trippyApiTarget,
         changeOrigin: true,
       },
     },
@@ -23,6 +29,13 @@ export default defineConfig(({ mode }) => ({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
-    dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime", "@tanstack/react-query", "@tanstack/query-core"],
+    dedupe: [
+      "react",
+      "react-dom",
+      "react/jsx-runtime",
+      "react/jsx-dev-runtime",
+      "@tanstack/react-query",
+      "@tanstack/query-core",
+    ],
   },
 }));


### PR DESCRIPTION
## What changed

- Makes `web/` the explicit canonical local UI again
- Moves Vite to `127.0.0.1:8788` with `strictPort: true`
- Points Vite `/api` proxy at the Python backend on `127.0.0.1:8787`
- Documents the correct two-terminal startup flow in `web/README.md`

## Why

The old Python UI was appearing because the backend was being run directly on `8788`. The new React/Lovable UI is already in this repo under `web/`, but the dev ports made it easy to accidentally serve the legacy fallback shell instead.

## Local verification

Run:

```bash
# Terminal 1
uv run trippy ui --port 8787 --no-open

# Terminal 2
cd web
npm install
npm run dev
```

Open `http://127.0.0.1:8788`.

The app should show the React UI, while API calls proxy to the backend on `8787`.