### PR TITLE
Refactor flights into backend-owned trip-date constraint flow

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,14 +1,18 @@
-"""Runtime patches for local Trippy development.
+"""Runtime compatibility hooks for local Trippy development.
 
-This module is imported automatically by Python when the repository root is on
-sys.path. It keeps the current local UI server compatible while flights are
-being refactored from a generic shortlist into a backend-owned two-step flow.
+The real flight state machine now lives in :mod:`trippy.services.flight_flow`.
+This file only wires the existing lightweight local HTTP server to the new
+flight-flow endpoints without forcing a large server.py rewrite in this PR.
 """
 
 from __future__ import annotations
 
+import json
 from datetime import date, timedelta
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 
 def _install_two_step_return_patch() -> None:
@@ -285,10 +289,7 @@ def _install_two_step_return_patch() -> None:
         if existing is None:
             return False
         selection = existing.artifacts.get("flight_selection") or {}
-        return bool(
-            selection.get("selected_outbound_option_id")
-            and not selection.get("selected_return_option_id")
-        )
+        return bool(selection.get("selected_outbound_option_id") and not selection.get("selected_return_option_id"))
 
     def _selected_outbound(existing: ResearchShortlistState) -> FlightOption | None:
         selection = existing.artifacts.get("flight_selection") or {}
@@ -337,4 +338,101 @@ def _install_two_step_return_patch() -> None:
     cls._trippy_two_step_return_patch = True
 
 
+def _install_flight_flow_routes() -> None:
+    try:
+        import trippy.ui.server as ui_server
+        from trippy.services.flight_flow import FlightFlowService
+    except Exception:
+        return
+
+    for value in vars(ui_server).values():
+        if not isinstance(value, type):
+            continue
+        if not issubclass(value, BaseHTTPRequestHandler):
+            continue
+        if getattr(value, "_trippy_flight_flow_routes", False):
+            continue
+        _patch_handler(value, FlightFlowService)
+
+
+def _patch_handler(handler_cls: type[BaseHTTPRequestHandler], service_cls: type[Any]) -> None:
+    original_get = getattr(handler_cls, "do_GET", None)
+    original_post = getattr(handler_cls, "do_POST", None)
+
+    def do_GET(self: BaseHTTPRequestHandler) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/flights/state":
+            query = parse_qs(parsed.query)
+            trip_id = (query.get("trip_id") or [""])[0]
+            _write_json(self, service_cls().get_state(trip_id))
+            return
+        if original_get is not None:
+            return original_get(self)
+        self.send_error(HTTPStatus.NOT_FOUND)
+
+    def do_POST(self: BaseHTTPRequestHandler) -> None:
+        parsed = urlparse(self.path)
+        if not parsed.path.startswith("/api/flights/"):
+            if original_post is not None:
+                return original_post(self)
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        try:
+            payload = _read_json(self)
+            trip_id = str(payload.get("trip_id") or "")
+            option_id = str(payload.get("option_id") or "")
+            service = service_cls()
+            if parsed.path == "/api/flights/search-departures":
+                result = service.search_departures(
+                    trip_id,
+                    validate_live=bool(payload.get("validate_live", True)),
+                    deep_research=bool(payload.get("deep_research", True)),
+                    adapter_mode=str(payload.get("adapter") or "auto"),
+                )
+            elif parsed.path == "/api/flights/select-departure":
+                result = service.select_departure(trip_id, option_id)
+            elif parsed.path == "/api/flights/search-returns":
+                result = service.search_returns(
+                    trip_id,
+                    validate_live=bool(payload.get("validate_live", True)),
+                    deep_research=bool(payload.get("deep_research", False)),
+                    adapter_mode=str(payload.get("adapter") or "auto"),
+                )
+            elif parsed.path == "/api/flights/select-return":
+                result = service.select_return(trip_id, option_id)
+            elif parsed.path == "/api/flights/reset-departure":
+                result = service.reset_departure(trip_id)
+            else:
+                self.send_error(HTTPStatus.NOT_FOUND)
+                return
+            _write_json(self, result)
+        except Exception as exc:
+            _write_json(self, {"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+
+    handler_cls.do_GET = do_GET
+    handler_cls.do_POST = do_POST
+    handler_cls._trippy_flight_flow_routes = True
+
+
+def _read_json(handler: BaseHTTPRequestHandler) -> dict[str, Any]:
+    length = int(handler.headers.get("Content-Length") or "0")
+    if length <= 0:
+        return {}
+    raw = handler.rfile.read(length).decode("utf-8")
+    if not raw.strip():
+        return {}
+    data = json.loads(raw)
+    return data if isinstance(data, dict) else {}
+
+
+def _write_json(handler: BaseHTTPRequestHandler, payload: dict[str, Any], status: int = HTTPStatus.OK) -> None:
+    data = json.dumps(payload, default=str).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(data)))
+    handler.end_headers()
+    handler.wfile.write(data)
+
+
 _install_two_step_return_patch()
+_install_flight_flow_routes()

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,340 @@
+"""Runtime patches for local Trippy development.
+
+This module is imported automatically by Python when the repository root is on
+sys.path. It keeps the current local UI server compatible while flights are
+being refactored from a generic shortlist into a backend-owned two-step flow.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+
+def _install_two_step_return_patch() -> None:
+    try:
+        import trippy.services.flight_shortlist as flight_shortlist
+        from trippy.models.shortlists import (
+            FlightOption,
+            LiveDataStatus,
+            RecommendationGrade,
+            ResearchShortlistState,
+            ShortlistCategory,
+            ShortlistRowStatus,
+            SourceType,
+            SourceValidation,
+            VerificationStatus,
+        )
+        from trippy.models.sources import TravelSourceCategory
+        from trippy.services.flight_trip_envelope import apply_trip_envelope_artifacts
+        from trippy.services.shortlist_store import source_plan, source_plan_payload
+    except Exception:
+        return
+
+    cls = flight_shortlist.FlightShortlistService
+    if getattr(cls, "_trippy_two_step_return_patch", False):
+        return
+
+    original_build = cls.build
+
+    def patched_build(
+        self: Any,
+        trip_id: str,
+        *,
+        flight_phase: str = "departure",
+        validate_live: bool | None = None,
+        deep_research: bool = False,
+        adapter_mode: str = "auto",
+    ) -> ResearchShortlistState:
+        existing = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
+        requested_phase = _normalize_phase(flight_phase)
+        auto_return = _should_auto_search_return(existing)
+        phase = "return" if requested_phase == "return" or auto_return else "departure"
+        if phase != "return":
+            return original_build(
+                self,
+                trip_id,
+                flight_phase="departure",
+                validate_live=validate_live,
+                deep_research=deep_research,
+                adapter_mode=adapter_mode,
+            )
+        return _build_return_state(
+            self,
+            trip_id,
+            existing,
+            validate_live=validate_live,
+            deep_research=deep_research,
+            adapter_mode=adapter_mode,
+        )
+
+    def _build_return_state(
+        self: Any,
+        trip_id: str,
+        existing: ResearchShortlistState | None,
+        *,
+        validate_live: bool | None,
+        deep_research: bool,
+        adapter_mode: str,
+    ) -> ResearchShortlistState:
+        if existing is None:
+            return original_build(
+                self,
+                trip_id,
+                flight_phase="departure",
+                validate_live=validate_live,
+                deep_research=deep_research,
+                adapter_mode=adapter_mode,
+            )
+
+        ctx = flight_shortlist.ShortlistContext(
+            trip_id,
+            intake_service=self._intakes,
+            planner_service=self._planner,
+        )
+        outbound = _selected_outbound(existing)
+        if outbound is None:
+            return original_build(
+                self,
+                trip_id,
+                flight_phase="departure",
+                validate_live=validate_live,
+                deep_research=deep_research,
+                adapter_mode=adapter_mode,
+            )
+
+        live_notes: list[str] = []
+        return_options: list[FlightOption] = []
+        gateway = (outbound.arrival_airport or "").strip().upper()
+
+        if gateway:
+            try:
+                return_options, notes = flight_shortlist._duffel_live_options(
+                    ctx,
+                    gateway,
+                    flight_phase="return",
+                )
+                live_notes.extend(notes)
+            except Exception as exc:
+                live_notes.append(f"Duffel return search failed: {exc}")
+
+        if not return_options and gateway and hasattr(flight_shortlist, "_serpapi_live_flights"):
+            try:
+                serp_options, notes = flight_shortlist._serpapi_live_flights(
+                    ctx,
+                    gateway,
+                    flight_phase="return",
+                )
+                live_notes.extend(notes)
+                return_options = serp_options
+            except Exception as exc:
+                live_notes.append(f"SerpAPI return search failed: {exc}")
+
+        fallback_used = False
+        if not return_options:
+            return_options = _fallback_return_options(ctx, existing, outbound)
+            fallback_used = bool(return_options)
+            if fallback_used:
+                live_notes.append(
+                    "No exact live return offers were returned; created date-specific return search rows from the selected departure and flexible trip window."
+                )
+
+        for option in return_options:
+            option.flight_phase = "return"
+
+        departure_options = [
+            option
+            for option in existing.flight_options
+            if getattr(option, "flight_phase", "departure") != "return"
+        ]
+        artifacts = dict(existing.artifacts or {})
+        if fallback_used:
+            artifacts["return_search"] = _return_search_artifact(ctx, outbound, return_options)
+
+        plan = source_plan(TravelSourceCategory.FLIGHTS)
+        state = ResearchShortlistState(
+            trip_id=trip_id,
+            category=ShortlistCategory.FLIGHTS,
+            selected_plan_option_id=ctx.draft.selected_option_id or ctx.draft.recommended_option_id,
+            source_routing=source_plan_payload(plan),
+            flight_options=[*departure_options, *return_options],
+            recommended_option_id=return_options[0].option_id if return_options else existing.recommended_option_id,
+            recommendation_summary=(
+                "Return flight options are generated only after a departure is selected. The selected return locks the trip envelope."
+            ),
+            artifacts=artifacts,
+            warnings=[
+                "Return search uses the selected departure arrival airport and the home/origin airport.",
+                *live_notes,
+            ],
+            next_actions=[
+                "Select a return flight to lock the trip envelope.",
+                "Use fallback return search rows only as handoffs until exact airline, time, price, and baggage terms are verified.",
+            ],
+        )
+        try:
+            flight_shortlist._refresh_flight_recommendations(state, ctx, preserve_selection=True)
+        except TypeError:
+            flight_shortlist._refresh_flight_recommendations(state, ctx)
+        apply_trip_envelope_artifacts(state)
+        return self._store.save(state)
+
+    def _fallback_return_options(
+        ctx: Any,
+        existing: ResearchShortlistState,
+        outbound: FlightOption,
+    ) -> list[FlightOption]:
+        origin = (outbound.arrival_airport or "").strip().upper()
+        destination = (outbound.departure_airport or "").strip().upper()
+        if not _looks_like_iata(origin) or not _looks_like_iata(destination):
+            return []
+        arrival_date = _parse_date(outbound.arrival_date)
+        if arrival_date is None:
+            return []
+
+        duration_days = _duration_days(ctx)
+        base_nights = max(1, duration_days - 1)
+        candidate_nights = sorted({base_nights - 1, base_nights, base_nights + 1, base_nights + 2})
+        candidate_dates = [arrival_date + timedelta(days=nights) for nights in candidate_nights if nights >= 1]
+        candidate_dates = candidate_dates[:5]
+
+        rows: list[FlightOption] = []
+        for index, return_date in enumerate(candidate_dates, start=1):
+            link = _return_search_link(origin, destination, return_date)
+            rows.append(
+                FlightOption(
+                    option_id=f"return-search-{index}",
+                    rank=index,
+                    airline=f"Return search · {return_date.isoformat()}",
+                    flight_numbers=[],
+                    departure_date=return_date.isoformat(),
+                    arrival_date=return_date.isoformat(),
+                    departure_airport=origin,
+                    arrival_airport=destination,
+                    departure_time="Open search",
+                    arrival_time="Verify time",
+                    stops=0,
+                    total_travel_duration="provider search required",
+                    timing_fit="Open this date-specific return search and choose the best verified option.",
+                    timing_implication="Return timing will define final-day checkout, car dropoff, and timeline buffers.",
+                    date_viability_signal="candidate return date from selected departure and trip duration window",
+                    recommendation_label="Return search option",
+                    recommendation_rationale="Fallback date-specific return search generated because no exact live return rows were returned.",
+                    planning_next_step="Open search, choose an exact return itinerary, then paste it back if required.",
+                    fare_estimate_cad="live quote required",
+                    price_band="live quote required",
+                    baggage_cabin_notes="Baggage, fare, and seat terms require provider verification.",
+                    booking_source="Google Flights search handoff",
+                    deep_link=link,
+                    traveler_count=ctx.intake.party.total_travelers,
+                    traveler_fit=f"Return search for {ctx.intake.party.summary()}.",
+                    comparison_links={"Google Flights": link},
+                    friction_score=55,
+                    family_comfort_score=50,
+                    recommendation_grade=RecommendationGrade.CONDITIONAL,
+                    tradeoffs=[
+                        "Search handoff only; not verified inventory.",
+                        "Exact airline, time, price, baggage, and cancellation terms still need confirmation.",
+                    ],
+                    friction_flags=[
+                        "exact return flight not verified yet",
+                        "provider search required before booking",
+                    ],
+                    confidence_notes=[
+                        "Generated from selected departure arrival date and trip duration window.",
+                    ],
+                    flight_phase="return",
+                    live_data_status=LiveDataStatus.HANDOFF_REQUIRED,
+                    row_status=ShortlistRowStatus.RESEARCHED,
+                    validation=SourceValidation(
+                        source_name="Google Flights search handoff",
+                        source_type=SourceType.SEARCH_HANDOFF,
+                        verification_status=VerificationStatus.MANUAL_REQUIRED,
+                        confidence=0.25,
+                        evidence_url=link,
+                        missing_fields=[
+                            "exact_return_airline",
+                            "exact_return_flight_numbers",
+                            "exact_return_departure_time",
+                            "exact_return_arrival_time",
+                            "exact_return_fare",
+                            "baggage_terms",
+                        ],
+                        notes=["Fallback return search row; not a confirmed live offer."],
+                    ),
+                )
+            )
+        return rows
+
+    def _return_search_artifact(
+        ctx: Any,
+        outbound: FlightOption,
+        return_options: list[FlightOption],
+    ) -> dict[str, Any]:
+        candidate_dates = [option.departure_date for option in return_options if option.departure_date]
+        return {
+            "based_on_outbound_option_id": outbound.option_id,
+            "origin_airport": outbound.arrival_airport,
+            "destination_airport": outbound.departure_airport,
+            "candidate_return_dates": candidate_dates,
+            "flexible_window_used": len(set(candidate_dates)) > 1,
+            "source": "runtime_two_step_return_flow",
+        }
+
+    def _should_auto_search_return(existing: ResearchShortlistState | None) -> bool:
+        if existing is None:
+            return False
+        selection = existing.artifacts.get("flight_selection") or {}
+        return bool(
+            selection.get("selected_outbound_option_id")
+            and not selection.get("selected_return_option_id")
+        )
+
+    def _selected_outbound(existing: ResearchShortlistState) -> FlightOption | None:
+        selection = existing.artifacts.get("flight_selection") or {}
+        selected_id = str(selection.get("selected_outbound_option_id") or "")
+        if selected_id:
+            match = next((option for option in existing.flight_options if option.option_id == selected_id), None)
+            if match is not None:
+                return match
+        return next(
+            (
+                option
+                for option in existing.flight_options
+                if getattr(option, "flight_phase", "departure") == "departure"
+                and option.row_status == ShortlistRowStatus.APPROVED
+            ),
+            None,
+        )
+
+    def _duration_days(ctx: Any) -> int:
+        value = getattr(ctx.intake, "duration_days", None) or 7
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 7
+
+    def _return_search_link(origin: str, destination: str, return_date: date) -> str:
+        return (
+            "https://www.google.com/travel/flights/search?"
+            f"q={origin}%20to%20{destination}%20{return_date.isoformat()}"
+            "&hl=en-CA&gl=ca&curr=CAD"
+        )
+
+    def _parse_date(value: str) -> date | None:
+        try:
+            return date.fromisoformat((value or "").strip())
+        except ValueError:
+            return None
+
+    def _looks_like_iata(value: str) -> bool:
+        return len((value or "").strip()) == 3 and (value or "").strip().isalpha()
+
+    def _normalize_phase(value: str) -> str:
+        return "return" if (value or "").strip().lower() in {"return", "inbound", "homebound"} else "departure"
+
+    cls.build = patched_build
+    cls._trippy_two_step_return_patch = True
+
+
+_install_two_step_return_patch()

--- a/trippy/services/flight_flow.py
+++ b/trippy/services/flight_flow.py
@@ -1,7 +1,19 @@
-"""Backend-owned two-step flight flow.
+"""Backend-owned flight flow and trip-date constraint engine.
 
-This service makes flights a real state machine instead of asking the generic
-shortlist UI to infer departure/return phase from mixed rows.
+Flights are not just another shortlist. Trippy has two different flight jobs:
+
+1. Envelope flights
+   - departure from home/origin to trip destination
+   - return from trip destination to home/origin
+   - these are the only flights that lock the trip start/end dates
+
+2. In-trip transfer flights
+   - optional one-way inter-location flights inside the already-locked trip
+   - these may be needed later depending on trip shape
+   - these must never redefine the overall trip envelope
+
+This service owns the departure -> return -> locked-envelope state machine so the
+UI and downstream planners do not infer dates from mixed shortlist rows.
 """
 
 from __future__ import annotations
@@ -25,10 +37,16 @@ from trippy.services.trip_intake import TripIntakeService
 from trippy.services.trip_planner import TripPlannerService
 
 FlightFlowPhase = Literal["departure_required", "return_required", "locked"]
+EnvelopeFlightPhase = Literal["departure", "return"]
 
 
 class FlightFlowService:
-    """Owns Trippy's departure -> return -> locked-envelope flight flow."""
+    """Owns Trippy's envelope-flight flow.
+
+    Only the selected departure and selected return are allowed to lock the trip
+    envelope. Future in-trip one-way flights are treated as transfer flights and
+    remain downstream consumers of the envelope, not producers of it.
+    """
 
     def __init__(
         self,
@@ -59,6 +77,7 @@ class FlightFlowService:
             deep_research=deep_research,
             adapter_mode=adapter_mode,
         )
+        self._mark_envelope_role(state, "departure")
         return self._payload(trip_id, state)
 
     def select_departure(self, trip_id: str, option_id: str) -> dict[str, Any]:
@@ -67,6 +86,7 @@ class FlightFlowService:
             option_id,
             selection_kind="outbound",
         )
+        self._mark_envelope_role(state, "departure")
         return self._payload(trip_id, state)
 
     def search_returns(
@@ -87,6 +107,7 @@ class FlightFlowService:
             deep_research=deep_research,
             adapter_mode=adapter_mode,
         )
+        self._mark_envelope_role(state, "return")
         return self._payload(trip_id, state)
 
     def select_return(self, trip_id: str, option_id: str) -> dict[str, Any]:
@@ -95,9 +116,11 @@ class FlightFlowService:
             option_id,
             selection_kind="return",
         )
+        self._mark_envelope_role(state, "return")
         return self._payload(trip_id, state)
 
     def reset_departure(self, trip_id: str) -> dict[str, Any]:
+        """Clear the envelope and all return/transfer state derived from it."""
         state = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
         if state is None:
             return self._payload(trip_id, None)
@@ -109,12 +132,15 @@ class FlightFlowService:
             "two_step_flight_flow",
             "downstream_planning_lock",
             "return_search",
+            "inter_location_flights",
+            "flight_flow",
         ):
             artifacts.pop(key, None)
 
         kept_options: list[FlightOption] = []
         for option in state.flight_options:
-            if getattr(option, "flight_phase", "departure") == "return":
+            role = self._flight_role(option)
+            if role in {"return", "inter_location"}:
                 continue
             if option.row_status == ShortlistRowStatus.APPROVED:
                 option.row_status = ShortlistRowStatus.RESEARCHED
@@ -130,17 +156,29 @@ class FlightFlowService:
         saved = self._store.save(state)
         return self._payload(trip_id, saved)
 
+    def require_locked_envelope(self, trip_id: str) -> dict[str, Any]:
+        """Return the locked envelope or fail fast for downstream finalization."""
+        state = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
+        envelope = derive_trip_envelope(state) if state else None
+        if not envelope:
+            raise FlightEnvelopeError(
+                "Trip envelope is not locked. Select both departure and return flights first."
+            )
+        return envelope
+
     def _payload(
         self,
         trip_id: str,
         state: ResearchShortlistState | None,
     ) -> dict[str, Any]:
         if state is not None:
+            self._write_flow_artifact(state)
             apply_trip_envelope_artifacts(state)
             state = self._store.save(state)
 
         departure_options = self._departure_options(state)
         return_options = self._return_options(state)
+        transfer_options = self._inter_location_options(state)
         selected_departure = self._selected_departure(state) if state else None
         selected_return = self._selected_return(state) if state else None
         envelope = derive_trip_envelope(state) if state else None
@@ -160,32 +198,63 @@ class FlightFlowService:
             "trip_envelope": envelope,
             "departure_options": [self._option_json(option) for option in departure_options],
             "return_options": [self._option_json(option) for option in return_options],
+            "inter_location_options": [self._option_json(option) for option in transfer_options],
             "return_search": (state.artifacts or {}).get("return_search") if state else None,
             "can_continue": phase == "locked",
+            "downstream_unlocked": phase == "locked",
+            "date_source": "locked_trip_envelope" if phase == "locked" else "target_window_only",
             "next_action": self._next_action(phase),
+            "invariants": {
+                "final_dates_require_return": True,
+                "inter_location_flights_do_not_define_trip_dates": True,
+                "downstream_finalization_requires_locked_envelope": True,
+            },
         }
         return {
             "flight_flow": flow,
             "shortlist": state.model_dump(mode="json") if state else None,
         }
 
+    def _write_flow_artifact(self, state: ResearchShortlistState) -> None:
+        artifacts = dict(state.artifacts or {})
+        artifacts["flight_flow"] = {
+            "schema": "trippy.flight_flow.v1",
+            "envelope_flight_phases": ["departure", "return"],
+            "transfer_flight_phase": "inter_location",
+            "date_constraint_owner": "selected_departure_plus_selected_return",
+            "inter_location_flights_are_downstream": True,
+        }
+        state.artifacts = artifacts
+
+    def _mark_envelope_role(self, state: ResearchShortlistState, phase: EnvelopeFlightPhase) -> None:
+        for option in state.flight_options:
+            if phase == "departure" and getattr(option, "flight_phase", "departure") != "return":
+                option.flight_phase = "departure"
+            elif phase == "return" and getattr(option, "flight_phase", "departure") == "return":
+                option.flight_phase = "return"
+
     def _departure_options(self, state: ResearchShortlistState | None) -> list[FlightOption]:
         if state is None:
             return []
-        return [
-            option
-            for option in state.flight_options
-            if getattr(option, "flight_phase", "departure") != "return"
-        ]
+        return [option for option in state.flight_options if self._flight_role(option) == "departure"]
 
     def _return_options(self, state: ResearchShortlistState | None) -> list[FlightOption]:
         if state is None:
             return []
-        return [
-            option
-            for option in state.flight_options
-            if getattr(option, "flight_phase", "departure") == "return"
-        ]
+        return [option for option in state.flight_options if self._flight_role(option) == "return"]
+
+    def _inter_location_options(self, state: ResearchShortlistState | None) -> list[FlightOption]:
+        if state is None:
+            return []
+        return [option for option in state.flight_options if self._flight_role(option) == "inter_location"]
+
+    def _flight_role(self, option: FlightOption) -> str:
+        phase = str(getattr(option, "flight_phase", "departure") or "departure").lower()
+        if phase in {"return", "inbound", "homebound"}:
+            return "return"
+        if phase in {"inter_location", "interlocation", "transfer", "one_way", "in_trip"}:
+            return "inter_location"
+        return "departure"
 
     def _selected_departure(self, state: ResearchShortlistState | None) -> FlightOption | None:
         if state is None:
@@ -193,7 +262,7 @@ class FlightFlowService:
         selection = state.artifacts.get("flight_selection") or {}
         option_id = str(selection.get("selected_outbound_option_id") or "")
         if option_id:
-            match = next((option for option in state.flight_options if option.option_id == option_id), None)
+            match = next((option for option in self._departure_options(state) if option.option_id == option_id), None)
             if match:
                 return match
         return next(
@@ -212,7 +281,7 @@ class FlightFlowService:
         option_id = str(selection.get("selected_return_option_id") or "")
         if not option_id:
             return None
-        return next((option for option in state.flight_options if option.option_id == option_id), None)
+        return next((option for option in self._return_options(state) if option.option_id == option_id), None)
 
     def _option_json(self, option: FlightOption | None) -> dict[str, Any] | None:
         return option.model_dump(mode="json") if option is not None else None
@@ -222,4 +291,4 @@ class FlightFlowService:
             return "Search and choose a departure flight."
         if phase == "return_required":
             return "Search and choose a return flight based on the selected departure."
-        return "Flight envelope is locked; continue to stays."
+        return "Flight envelope is locked; continue to stays. Inter-location flights can be planned later inside this envelope."

--- a/trippy/services/flight_flow.py
+++ b/trippy/services/flight_flow.py
@@ -1,0 +1,225 @@
+"""Backend-owned two-step flight flow.
+
+This service makes flights a real state machine instead of asking the generic
+shortlist UI to infer departure/return phase from mixed rows.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from trippy.models.shortlists import (
+    FlightOption,
+    ResearchShortlistState,
+    ShortlistCategory,
+    ShortlistRowStatus,
+)
+from trippy.services.flight_shortlist import FlightShortlistService
+from trippy.services.flight_trip_envelope import (
+    FlightEnvelopeError,
+    apply_trip_envelope_artifacts,
+    derive_trip_envelope,
+)
+from trippy.services.shortlist_store import ShortlistStore
+from trippy.services.trip_intake import TripIntakeService
+from trippy.services.trip_planner import TripPlannerService
+
+FlightFlowPhase = Literal["departure_required", "return_required", "locked"]
+
+
+class FlightFlowService:
+    """Owns Trippy's departure -> return -> locked-envelope flight flow."""
+
+    def __init__(
+        self,
+        intake_service: TripIntakeService | None = None,
+        planner_service: TripPlannerService | None = None,
+        store: ShortlistStore | None = None,
+    ) -> None:
+        self._intakes = intake_service or TripIntakeService()
+        self._planner = planner_service or TripPlannerService(self._intakes)
+        self._store = store or ShortlistStore()
+
+    def get_state(self, trip_id: str) -> dict[str, Any]:
+        state = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
+        return self._payload(trip_id, state)
+
+    def search_departures(
+        self,
+        trip_id: str,
+        *,
+        validate_live: bool = True,
+        deep_research: bool = True,
+        adapter_mode: str = "auto",
+    ) -> dict[str, Any]:
+        state = FlightShortlistService(self._intakes, self._planner).build(
+            trip_id,
+            flight_phase="departure",
+            validate_live=validate_live,
+            deep_research=deep_research,
+            adapter_mode=adapter_mode,
+        )
+        return self._payload(trip_id, state)
+
+    def select_departure(self, trip_id: str, option_id: str) -> dict[str, Any]:
+        state = FlightShortlistService(self._intakes, self._planner).select_flight(
+            trip_id,
+            option_id,
+            selection_kind="outbound",
+        )
+        return self._payload(trip_id, state)
+
+    def search_returns(
+        self,
+        trip_id: str,
+        *,
+        validate_live: bool = True,
+        deep_research: bool = False,
+        adapter_mode: str = "auto",
+    ) -> dict[str, Any]:
+        existing = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
+        if existing is None or self._selected_departure(existing) is None:
+            raise FlightEnvelopeError("Select a departure flight before searching returns.")
+        state = FlightShortlistService(self._intakes, self._planner).build(
+            trip_id,
+            flight_phase="return",
+            validate_live=validate_live,
+            deep_research=deep_research,
+            adapter_mode=adapter_mode,
+        )
+        return self._payload(trip_id, state)
+
+    def select_return(self, trip_id: str, option_id: str) -> dict[str, Any]:
+        state = FlightShortlistService(self._intakes, self._planner).select_flight(
+            trip_id,
+            option_id,
+            selection_kind="return",
+        )
+        return self._payload(trip_id, state)
+
+    def reset_departure(self, trip_id: str) -> dict[str, Any]:
+        state = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
+        if state is None:
+            return self._payload(trip_id, None)
+
+        artifacts = dict(state.artifacts or {})
+        for key in (
+            "flight_selection",
+            "trip_envelope",
+            "two_step_flight_flow",
+            "downstream_planning_lock",
+            "return_search",
+        ):
+            artifacts.pop(key, None)
+
+        kept_options: list[FlightOption] = []
+        for option in state.flight_options:
+            if getattr(option, "flight_phase", "departure") == "return":
+                continue
+            if option.row_status == ShortlistRowStatus.APPROVED:
+                option.row_status = ShortlistRowStatus.RESEARCHED
+            if "selected" in (option.recommendation_label or "").lower():
+                option.recommendation_label = ""
+            kept_options.append(option)
+
+        state.flight_options = kept_options
+        state.artifacts = artifacts
+        state.recommended_option_id = None
+        state.recommendation_summary = "Choose a departure flight first. Return options come after that selection."
+        state.next_actions = ["Choose a departure flight to start the two-step flight flow."]
+        saved = self._store.save(state)
+        return self._payload(trip_id, saved)
+
+    def _payload(
+        self,
+        trip_id: str,
+        state: ResearchShortlistState | None,
+    ) -> dict[str, Any]:
+        if state is not None:
+            apply_trip_envelope_artifacts(state)
+            state = self._store.save(state)
+
+        departure_options = self._departure_options(state)
+        return_options = self._return_options(state)
+        selected_departure = self._selected_departure(state) if state else None
+        selected_return = self._selected_return(state) if state else None
+        envelope = derive_trip_envelope(state) if state else None
+        phase: FlightFlowPhase
+        if envelope:
+            phase = "locked"
+        elif selected_departure:
+            phase = "return_required"
+        else:
+            phase = "departure_required"
+
+        flow = {
+            "trip_id": trip_id,
+            "phase": phase,
+            "selected_departure": self._option_json(selected_departure),
+            "selected_return": self._option_json(selected_return),
+            "trip_envelope": envelope,
+            "departure_options": [self._option_json(option) for option in departure_options],
+            "return_options": [self._option_json(option) for option in return_options],
+            "return_search": (state.artifacts or {}).get("return_search") if state else None,
+            "can_continue": phase == "locked",
+            "next_action": self._next_action(phase),
+        }
+        return {
+            "flight_flow": flow,
+            "shortlist": state.model_dump(mode="json") if state else None,
+        }
+
+    def _departure_options(self, state: ResearchShortlistState | None) -> list[FlightOption]:
+        if state is None:
+            return []
+        return [
+            option
+            for option in state.flight_options
+            if getattr(option, "flight_phase", "departure") != "return"
+        ]
+
+    def _return_options(self, state: ResearchShortlistState | None) -> list[FlightOption]:
+        if state is None:
+            return []
+        return [
+            option
+            for option in state.flight_options
+            if getattr(option, "flight_phase", "departure") == "return"
+        ]
+
+    def _selected_departure(self, state: ResearchShortlistState | None) -> FlightOption | None:
+        if state is None:
+            return None
+        selection = state.artifacts.get("flight_selection") or {}
+        option_id = str(selection.get("selected_outbound_option_id") or "")
+        if option_id:
+            match = next((option for option in state.flight_options if option.option_id == option_id), None)
+            if match:
+                return match
+        return next(
+            (
+                option
+                for option in self._departure_options(state)
+                if option.row_status == ShortlistRowStatus.APPROVED
+            ),
+            None,
+        )
+
+    def _selected_return(self, state: ResearchShortlistState | None) -> FlightOption | None:
+        if state is None:
+            return None
+        selection = state.artifacts.get("flight_selection") or {}
+        option_id = str(selection.get("selected_return_option_id") or "")
+        if not option_id:
+            return None
+        return next((option for option in state.flight_options if option.option_id == option_id), None)
+
+    def _option_json(self, option: FlightOption | None) -> dict[str, Any] | None:
+        return option.model_dump(mode="json") if option is not None else None
+
+    def _next_action(self, phase: FlightFlowPhase) -> str:
+        if phase == "departure_required":
+            return "Search and choose a departure flight."
+        if phase == "return_required":
+            return "Search and choose a return flight based on the selected departure."
+        return "Flight envelope is locked; continue to stays."

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import Index from "./pages/Index.tsx";
 import NewTrip from "./pages/NewTrip.tsx";
 import TripShape from "./pages/TripShape.tsx";
-import Flights from "./pages/Flights.tsx";
+import FlightsFlow from "./pages/FlightsFlow.tsx";
 import Stays from "./pages/Stays.tsx";
 import Cars from "./pages/Cars.tsx";
 import Do from "./pages/Do.tsx";
@@ -27,7 +27,7 @@ const App = () => (
           <Route path="/new" element={<NewTrip />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/trip/:tripId/shape" element={<TripShape />} />
-          <Route path="/trip/:tripId/flights" element={<Flights />} />
+          <Route path="/trip/:tripId/flights" element={<FlightsFlow />} />
           <Route path="/trip/:tripId/stays" element={<Stays />} />
           <Route path="/trip/:tripId/cars" element={<Cars />} />
           <Route path="/trip/:tripId/do" element={<Do />} />

--- a/web/src/components/ShortlistHero.tsx
+++ b/web/src/components/ShortlistHero.tsx
@@ -103,19 +103,45 @@ export function deriveTripDateRangeLabel(
 ): string {
   const selectedFlight = findSelectedFlight(shortlists);
   const selectedReturnFlight = findSelectedReturnFlight(shortlists);
-  const flightStart = parseIsoDateOnly(selectedFlight?.departure_date);
-  const flightEnd = flightStart
-    ? findExplicitReturnDate(selectedReturnFlight, flightStart) ??
-      (selectedFlight ? findFlightReturnDate(selectedFlight, flightStart) : null)
-    : null;
+  const lockedEnvelope = findLockedTripEnvelope(shortlists);
+
+  if (lockedEnvelope) {
+    const envelopeStart = parseDatePrefix(lockedEnvelope.trip_start_datetime);
+    const envelopeEnd = parseDatePrefix(lockedEnvelope.trip_end_datetime);
+    if (envelopeStart && envelopeEnd) return formatDateRange(envelopeStart, envelopeEnd);
+  }
+
+  if (selectedFlight && !selectedReturnFlight) {
+    const arrival = parseIsoDateOnly(selectedFlight.arrival_date);
+    return arrival ? `Departure selected · return pending after ${formatSingleDate(arrival)}` : "Departure selected · return pending";
+  }
+
+  if (selectedFlight && selectedReturnFlight) {
+    const flightStart = parseIsoDateOnly(selectedFlight.arrival_date) ?? parseIsoDateOnly(selectedFlight.departure_date);
+    const flightEnd = findExplicitReturnDate(selectedReturnFlight, flightStart ?? new Date(0));
+    if (flightStart && flightEnd) return formatDateRange(flightStart, flightEnd);
+  }
+
   const intakeStart = parseIsoDateOnly(intake?.travel_window?.start_date);
   const intakeEnd = parseIsoDateOnly(intake?.travel_window?.end_date);
-  const start = flightStart ?? intakeStart;
-  const end = flightEnd ?? intakeEnd;
-
-  if (start && end) return formatDateRange(start, end);
-  if (start) return formatSingleDate(start);
+  if (intakeStart && intakeEnd) return `Target window · ${formatDateRange(intakeStart, intakeEnd)}`;
+  if (intakeStart) return `Target window · ${formatSingleDate(intakeStart)}`;
   return "";
+}
+
+function findLockedTripEnvelope(shortlists?: ShortlistState[]): { trip_start_datetime?: string; trip_end_datetime?: string } | null {
+  const flights = shortlists?.find((shortlist) => shortlist.category === "flights");
+  const envelope = flights?.artifacts?.trip_envelope;
+  if (!envelope || typeof envelope !== "object") return null;
+  const data = envelope as Record<string, unknown>;
+  if (data.status !== "locked") return null;
+  if (typeof data.trip_start_datetime !== "string" || typeof data.trip_end_datetime !== "string") {
+    return null;
+  }
+  return {
+    trip_start_datetime: data.trip_start_datetime,
+    trip_end_datetime: data.trip_end_datetime,
+  };
 }
 
 function findSelectedFlight(shortlists?: ShortlistState[]): FlightOption | null {
@@ -150,22 +176,9 @@ function findExplicitReturnDate(option: FlightOption | null, start: Date): Date 
   return candidates.sort((a, b) => b.getTime() - a.getTime())[0];
 }
 
-function findFlightReturnDate(option: FlightOption, start: Date): Date | null {
-  const candidates = [
-    ...isoDatesFromText(option.deep_link),
-    ...Object.values(option.comparison_links ?? {}).flatMap(isoDatesFromText),
-  ]
-    .map(parseIsoDateOnly)
-    .filter((date): date is Date => Boolean(date))
-    .filter((date) => date.getTime() >= start.getTime());
-
-  if (candidates.length === 0) return null;
-  return candidates.sort((a, b) => b.getTime() - a.getTime())[0];
-}
-
-function isoDatesFromText(value: unknown): string[] {
-  if (typeof value !== "string") return [];
-  return value.match(/\b\d{4}-\d{2}-\d{2}\b/g) ?? [];
+function parseDatePrefix(value: unknown): Date | null {
+  if (typeof value !== "string") return null;
+  return parseIsoDateOnly(value.slice(0, 10));
 }
 
 function parseIsoDateOnly(value: unknown): Date | null {

--- a/web/src/lib/flightFlowApi.ts
+++ b/web/src/lib/flightFlowApi.ts
@@ -1,0 +1,74 @@
+import type { FlightOption, ShortlistState } from "@/lib/api";
+
+export type FlightFlowPhase = "departure_required" | "return_required" | "locked";
+
+export interface FlightFlowState {
+  trip_id: string;
+  phase: FlightFlowPhase;
+  selected_departure: FlightOption | null;
+  selected_return: FlightOption | null;
+  trip_envelope: Record<string, unknown> | null;
+  departure_options: FlightOption[];
+  return_options: FlightOption[];
+  return_search: Record<string, unknown> | null;
+  can_continue: boolean;
+  next_action: string;
+}
+
+export interface FlightFlowResponse {
+  flight_flow: FlightFlowState;
+  shortlist: ShortlistState | null;
+}
+
+async function get<T>(path: string): Promise<T> {
+  const res = await fetch(path);
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || `GET ${path} → ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || `POST ${path} → ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const flightFlowApi = {
+  getState: (tripId: string) =>
+    get<FlightFlowResponse>(`/api/flights/state?trip_id=${encodeURIComponent(tripId)}`),
+  searchDepartures: (tripId: string) =>
+    post<FlightFlowResponse>("/api/flights/search-departures", {
+      trip_id: tripId,
+      validate_live: true,
+      deep_research: true,
+    }),
+  selectDeparture: (tripId: string, optionId: string) =>
+    post<FlightFlowResponse>("/api/flights/select-departure", {
+      trip_id: tripId,
+      option_id: optionId,
+    }),
+  searchReturns: (tripId: string) =>
+    post<FlightFlowResponse>("/api/flights/search-returns", {
+      trip_id: tripId,
+      validate_live: true,
+      deep_research: false,
+    }),
+  selectReturn: (tripId: string, optionId: string) =>
+    post<FlightFlowResponse>("/api/flights/select-return", {
+      trip_id: tripId,
+      option_id: optionId,
+    }),
+  resetDeparture: (tripId: string) =>
+    post<FlightFlowResponse>("/api/flights/reset-departure", {
+      trip_id: tripId,
+    }),
+};

--- a/web/src/pages/FlightsFlow.tsx
+++ b/web/src/pages/FlightsFlow.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowRight, Check, ExternalLink, Loader2, RefreshCcw } from "lucide-react";
+import { AppShell } from "@/components/AppShell";
+import { EmptyShortlist } from "@/components/EmptyShortlist";
+import { ShortlistHero } from "@/components/ShortlistHero";
+import { StageNav } from "@/components/StageNav";
+import { Button } from "@/components/ui/button";
+import { api, mergeShortlistIntoTrip, type FlightOption, type TripState } from "@/lib/api";
+import { flightFlowApi, type FlightFlowResponse } from "@/lib/flightFlowApi";
+import { buildStages } from "@/lib/stages";
+
+export default function FlightsFlow() {
+  const { tripId } = useParams<{ tripId: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [autoReturnSearchFor, setAutoReturnSearchFor] = useState("");
+
+  const tripQuery = useQuery({
+    queryKey: ["trip", tripId],
+    queryFn: () => api.getTrip(tripId!),
+    enabled: !!tripId,
+    staleTime: 30_000,
+  });
+  const flowQuery = useQuery({
+    queryKey: ["flight-flow", tripId],
+    queryFn: () => flightFlowApi.getState(tripId!),
+    enabled: !!tripId,
+    staleTime: 10_000,
+  });
+
+  function mergeFlow(response: FlightFlowResponse) {
+    queryClient.setQueryData<FlightFlowResponse>(["flight-flow", tripId], response);
+    if (response.shortlist) {
+      queryClient.setQueryData<TripState>(["trip", tripId], (current) =>
+        mergeShortlistIntoTrip(current, response.shortlist!),
+      );
+    }
+    queryClient.invalidateQueries({ queryKey: ["trip", tripId] });
+    queryClient.invalidateQueries({ queryKey: ["flight-flow", tripId] });
+  }
+
+  const searchDepartures = useMutation({ mutationFn: () => flightFlowApi.searchDepartures(tripId!), onSuccess: mergeFlow });
+  const selectDeparture = useMutation({ mutationFn: (id: string) => flightFlowApi.selectDeparture(tripId!, id), onSuccess: (r) => { setAutoReturnSearchFor(""); mergeFlow(r); } });
+  const searchReturns = useMutation({ mutationFn: () => flightFlowApi.searchReturns(tripId!), onSuccess: mergeFlow });
+  const selectReturn = useMutation({ mutationFn: (id: string) => flightFlowApi.selectReturn(tripId!, id), onSuccess: mergeFlow });
+  const resetDeparture = useMutation({ mutationFn: () => flightFlowApi.resetDeparture(tripId!), onSuccess: (r) => { setAutoReturnSearchFor(""); mergeFlow(r); } });
+
+  const trip = tripQuery.data;
+  const flow = flowQuery.data?.flight_flow;
+  const stages = buildStages(trip, "flights");
+  const activePhase = flow?.phase === "return_required" ? "return" : "departure";
+  const rows = (activePhase === "return" ? flow?.return_options ?? [] : flow?.departure_options ?? []).filter(isVisibleFlight);
+  const busy = searchDepartures.isPending || selectDeparture.isPending || searchReturns.isPending || selectReturn.isPending || resetDeparture.isPending;
+  const error = tripQuery.error || flowQuery.error || searchDepartures.error || searchReturns.error || selectDeparture.error || selectReturn.error || resetDeparture.error;
+
+  useEffect(() => {
+    if (!flow || flow.phase !== "return_required") return;
+    const id = flow.selected_departure?.option_id;
+    if (!id || flow.return_options.length > 0 || autoReturnSearchFor === id) return;
+    setAutoReturnSearchFor(id);
+    searchReturns.mutate();
+  }, [flow?.phase, flow?.selected_departure?.option_id, flow?.return_options.length, autoReturnSearchFor]);
+
+  const title = flow?.phase === "locked" ? "Flights selected." : activePhase === "return" ? "Pick your return flight." : "Pick your departure flight.";
+
+  return (
+    <AppShell>
+      <ShortlistHero intake={trip?.intake} shortlists={trip?.shortlists} stageLabel="Flights" stageNumber={3} flagCount={rows.reduce((sum, row) => sum + row.friction_flags.length, 0)} />
+      <div className="px-4 md:px-6 lg:px-8 py-4 border-b-2 border-foreground/10 bg-card/60 backdrop-blur sticky top-0 z-30"><StageNav stages={stages} /></div>
+      <div className="px-4 md:px-6 lg:px-8 py-6">
+        <div className="flex items-end justify-between flex-wrap gap-3 mb-4">
+          <div><div className="text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground">Stage 3 · Flights</div><h2 className="font-[Fredoka] text-3xl md:text-4xl font-bold mt-1">{title}</h2></div>
+          <button onClick={() => activePhase === "return" ? searchReturns.mutate() : searchDepartures.mutate()} disabled={busy} className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-card border-2 border-foreground/15 text-sm font-bold hover:border-foreground/40 transition-colors">
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
+            {activePhase === "return" ? "Research returns" : "Research departures"}
+          </button>
+        </div>
+
+        {error && <div className="rounded-2xl border-2 border-destructive/30 bg-destructive/5 p-4 mb-4 text-sm font-bold text-destructive">{(error as Error)?.message || String(error)}</div>}
+        {(tripQuery.isLoading || flowQuery.isLoading) && <div className="flex items-center justify-center py-24 text-muted-foreground gap-3"><Loader2 className="h-6 w-6 animate-spin" /><span className="font-bold">Loading...</span></div>}
+
+        {flow?.selected_departure && <SelectedFlight label="Departure selected" option={flow.selected_departure} />}
+        {flow?.phase === "return_required" && <div className="mb-4 flex gap-2 flex-wrap"><Button variant="outline" className="rounded-xl border-2 font-bold" disabled={busy} onClick={() => resetDeparture.mutate()}>Change departure</Button><Button variant="outline" className="rounded-xl border-2 font-bold" disabled={busy} onClick={() => searchReturns.mutate()}><RefreshCcw className="h-4 w-4" /> Re-research returns</Button></div>}
+        {flow?.selected_return && <SelectedFlight label="Return selected" option={flow.selected_return} />}
+        {flow?.phase === "return_required" && <div className="rounded-2xl border-2 border-foreground/10 bg-card p-4 mb-4 text-sm font-bold text-muted-foreground">Return search: {flow.selected_departure?.arrival_airport} to {flow.selected_departure?.departure_airport}</div>}
+
+        {rows.length === 0 && !flowQuery.isLoading && <EmptyShortlist title={activePhase === "return" ? "No return rows yet" : "No departure options yet"} description={activePhase === "return" ? "Re-run return research. The backend should return live rows or fallback return-search rows." : "Search departure options first."} ctaLabel={activePhase === "return" ? "Research returns" : "Research departures"} onBuild={() => activePhase === "return" ? searchReturns.mutate() : searchDepartures.mutate()} isLoading={busy} isError={Boolean(error)} errorMessage={(error as Error)?.message} />}
+
+        <div className="flex flex-col gap-4">
+          {rows.map((row) => <FlightCard key={row.option_id} option={row} selected={activePhase === "return" ? row.option_id === flow?.selected_return?.option_id : row.option_id === flow?.selected_departure?.option_id} activePhase={activePhase} busy={busy} onSelect={() => activePhase === "return" ? selectReturn.mutate(row.option_id) : selectDeparture.mutate(row.option_id)} />)}
+        </div>
+
+        {flow?.can_continue && <div className="mt-6 flex justify-end"><Button onClick={() => navigate(`/trip/${tripId}/stays`)} className="h-12 rounded-2xl bg-gradient-sunset text-primary-foreground font-bold border-2 border-foreground shadow-sticker px-8">Continue to Stays <ArrowRight className="h-4 w-4" /></Button></div>}
+      </div>
+    </AppShell>
+  );
+}
+
+function SelectedFlight({ label, option }: { label: string; option: FlightOption }) {
+  return <div className="rounded-2xl border-2 border-foreground/10 bg-card p-4 mb-4 text-sm"><div className="font-bold text-foreground">{label}</div><div className="text-muted-foreground mt-1">{option.departure_airport} to {option.arrival_airport} · arrives {option.arrival_date} {option.arrival_time} · {option.airline}</div></div>;
+}
+
+function FlightCard({ option, selected, activePhase, busy, onSelect }: { option: FlightOption; selected: boolean; activePhase: "departure" | "return"; busy: boolean; onSelect: () => void }) {
+  return <article className={`rounded-3xl border-2 bg-card overflow-hidden ${selected ? "border-foreground shadow-sticker" : "border-foreground/10 shadow-card"}`}><div className="px-5 py-3 border-b-2 border-foreground/10 flex items-center gap-3"><span className="font-bold truncate">{option.airline}</span><span className="text-xs text-muted-foreground font-mono">{option.flight_numbers.join(" → ")}</span></div><div className="grid grid-cols-1 md:grid-cols-3 gap-5 px-5 py-5"><TimeBlock time={option.departure_time} subline={`${option.departure_date} · ${option.departure_airport}`} /><TimeBlock time={option.arrival_time} subline={`${option.arrival_date} · ${option.arrival_airport}`} /><div className="md:text-right font-[Fredoka] text-3xl font-bold text-palm">{priceText(option)}</div></div>{option.friction_flags.length > 0 && <div className="mx-5 mb-4 rounded-xl border border-coral/40 bg-coral/5 px-3 py-2 text-xs">{option.friction_flags.slice(0, 3).join(" · ")}</div>}<div className="px-5 py-3 border-t-2 border-foreground/10 flex items-center gap-3"><Button onClick={onSelect} disabled={busy} className="h-10 rounded-xl font-bold border-2 px-5">{selected ? <><Check className="h-4 w-4" /> Selected</> : activePhase === "return" ? "Select return" : "Select departure"}</Button>{option.deep_link && <a href={option.deep_link} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm font-bold text-foreground/80 hover:text-foreground"><ExternalLink className="h-3.5 w-3.5" /> Open search</a>}</div></article>;
+}
+
+function TimeBlock({ time, subline }: { time: string; subline: string }) { return <div><div className="font-[Fredoka] text-3xl md:text-4xl font-bold">{time || "-"}</div><div className="text-xs font-bold uppercase tracking-wider text-muted-foreground mt-1.5">{subline}</div></div>; }
+function isVisibleFlight(option: FlightOption): boolean { return !/duffel airways/i.test(option.airline || "") && !(option.flight_numbers || []).some((n) => /^ZZ/i.test(n)); }
+function priceText(option: FlightOption): string { return option.fare_estimate_cad || option.price_band || "Quote required"; }


### PR DESCRIPTION
## Summary
- Adds `FlightFlowService` as the backend-owned departure -> return -> locked-envelope state machine
- Hardens flights as the **trip date constraint engine**, not a generic shortlist
- Separates two flight concepts:
  - envelope flights: home/origin -> destination departure and destination -> home/origin return
  - inter-location flights: later optional one-way/in-trip transfers that must never redefine trip dates
- Adds `/api/flights/*` route wiring through the local server compatibility hook
- Adds typed React API client in `web/src/lib/flightFlowApi.ts`
- Adds new `FlightsFlow.tsx` page that renders backend flight-flow state instead of inferring phase from mixed shortlist rows
- Routes `/trip/:tripId/flights` to the new backend-owned flight flow page
- Keeps fallback return-search rows when live providers return no exact return offers
- Prevents top trip date pill from showing final trip dates until `trip_envelope.status === locked`

## Flight flow contract
- `departure_required`: show departure options only
- `return_required`: show selected departure summary and return options only
- `locked`: selected departure + selected return define the trip envelope and unlock downstream planning

## Hardening added
- `FlightFlowService.require_locked_envelope(trip_id)` for downstream finalization gates
- `flight_flow` artifact with schema and invariants
- `date_source` in flow payload:
  - `target_window_only` before return is selected
  - `locked_trip_envelope` after return is selected
- `downstream_unlocked` and `can_continue` are true only when the envelope is locked
- reset departure clears return selection, trip envelope, downstream lock, return search, and inter-location flight state
- inter-location/one-way flight role is explicitly reserved for later trip-shape transfer planning and excluded from envelope calculations

## Manual QA target
- New trip -> Flights shows departure step only
- Select departure -> page moves to return step
- Return step uses selected departure arrival airport back to origin
- Return step shows live rows or fallback `Return search · YYYY-MM-DD` rows
- Change departure resets return rows, return selection, envelope, downstream lock, and inter-location flight state
- Header does not show final dates until return is selected
- Continue to Stays only appears when flow is locked

## Remaining cleanup
This PR still uses a small `sitecustomize.py` route shim to avoid a risky large rewrite of the existing `trippy/ui/server.py` in the same patch. The core architecture now lives in `trippy/services/flight_flow.py`, so the shim can be removed later by moving those exact `/api/flights/*` handlers directly into `server.py`.