### PR TITLE
Fix flight envelope return gate and impossible date pill

### DIFF
--- a/trippy/services/flight_trip_envelope.py
+++ b/trippy/services/flight_trip_envelope.py
@@ -20,6 +20,8 @@ TRIP_ENVELOPE_ARTIFACT = "trip_envelope"
 TWO_STEP_FLOW_ARTIFACT = "two_step_flight_flow"
 DOWNSTREAM_LOCK_ARTIFACT = "downstream_planning_lock"
 DOWNSTREAM_CATEGORIES = ("lodging", "cars", "activities", "timeline")
+_RETURN_PHASES = {"return", "inbound", "homebound"}
+_TRANSFER_PHASES = {"inter_location", "interlocation", "transfer", "one_way", "in_trip"}
 _IATA_PATTERN = re.compile(r"^[A-Z]{3}$")
 
 
@@ -68,16 +70,34 @@ def select_flight_for_envelope(
     """
 
     _require_flight_state(state)
-    option = _find_option(state, option_id)
     kind = normalize_selection_kind(selection_kind)
     selection = dict(state.artifacts.get(FLIGHT_SELECTION_ARTIFACT) or {})
+
+    selected_outbound = selected_flight_option(state, "outbound") if kind == "return" else None
     if kind == "return" and not selection.get("selected_outbound_option_id"):
         raise FlightEnvelopeError(
             "Select a departure flight before searching for or selecting return options."
         )
+    if kind == "return" and selected_outbound is None:
+        raise FlightEnvelopeError(
+            "Selected departure flight is missing or invalid. Choose the departure flight again before selecting a return."
+        )
+
+    option = _find_option(
+        state,
+        option_id,
+        selection_kind=kind,
+        selected_outbound=selected_outbound,
+    )
+    if kind == "return" and selected_outbound is not None and not _is_reverse_route(option, selected_outbound):
+        raise FlightEnvelopeError(
+            "Return flight must fly from the selected destination airport back to the selected origin airport."
+        )
 
     selection[f"selected_{kind}_option_id"] = option_id
     selection["trip_envelope_locked"] = False
+    if kind == "outbound":
+        selection.pop("selected_return_option_id", None)
     state.artifacts[FLIGHT_SELECTION_ARTIFACT] = selection
 
     if kind == "outbound":
@@ -159,6 +179,8 @@ def derive_trip_envelope(state: ResearchShortlistState) -> dict[str, object] | N
     return_flight = selected_flight_option(state, "return")
     if outbound is None or return_flight is None:
         return None
+    if not _is_reverse_route(return_flight, outbound):
+        return None
 
     origin_airport = _require_iata(outbound.departure_airport, "origin_airport")
     destination_airport = _require_iata(outbound.arrival_airport, "destination_airport")
@@ -236,7 +258,20 @@ def selected_flight_option(
     option_id = str(selection.get(f"selected_{kind}_option_id") or "")
     if not option_id:
         return None
-    return next((option for option in state.flight_options if option.option_id == option_id), None)
+
+    candidates = [option for option in state.flight_options if option.option_id == option_id]
+    if kind == "return":
+        outbound = selected_flight_option(state, "outbound")
+        if outbound is not None:
+            return next((option for option in candidates if _is_reverse_route(option, outbound)), None)
+    return next(
+        (
+            option
+            for option in candidates
+            if _option_matches_selection_kind(option, kind)
+        ),
+        None,
+    )
 
 
 def split_options_by_phase(state: ResearchShortlistState) -> dict[str, object]:
@@ -251,7 +286,9 @@ def split_options_by_phase(state: ResearchShortlistState) -> dict[str, object]:
     if outbound is None:
         return {
             "phase": "departure_required",
-            "departure_options": state.flight_options,
+            "departure_options": [
+                option for option in state.flight_options if _option_matches_selection_kind(option, "outbound")
+            ],
             "return_options": [],
             "route": None,
         }
@@ -301,11 +338,67 @@ def _require_flight_state(state: ResearchShortlistState) -> None:
         raise FlightEnvelopeError("Flight envelope helpers require a flights shortlist state.")
 
 
-def _find_option(state: ResearchShortlistState, option_id: str) -> FlightOption:
-    option = next((item for item in state.flight_options if item.option_id == option_id), None)
-    if option is None:
-        raise FlightEnvelopeError(f"Flight option {option_id!r} was not found.")
-    return option
+def _find_option(
+    state: ResearchShortlistState,
+    option_id: str,
+    *,
+    selection_kind: FlightSelectionKind,
+    selected_outbound: FlightOption | None = None,
+) -> FlightOption:
+    option = next(
+        (
+            item
+            for item in state.flight_options
+            if item.option_id == option_id
+            and _option_matches_selection_kind(item, selection_kind, selected_outbound=selected_outbound)
+        ),
+        None,
+    )
+    if option is not None:
+        return option
+    if any(item.option_id == option_id for item in state.flight_options):
+        raise FlightEnvelopeError(
+            f"Flight option {option_id!r} exists, but it is not a valid {selection_kind} flight option."
+        )
+    raise FlightEnvelopeError(f"Flight option {option_id!r} was not found.")
+
+
+def _option_matches_selection_kind(
+    option: FlightOption,
+    kind: FlightSelectionKind,
+    *,
+    selected_outbound: FlightOption | None = None,
+) -> bool:
+    if kind == "return":
+        if selected_outbound is not None and _is_reverse_route(option, selected_outbound):
+            return True
+        return _is_return_phase(option)
+    return not _is_return_phase(option) and not _is_transfer_phase(option)
+
+
+def _is_return_phase(option: FlightOption) -> bool:
+    return _option_phase(option) in _RETURN_PHASES
+
+
+def _is_transfer_phase(option: FlightOption) -> bool:
+    return _option_phase(option) in _TRANSFER_PHASES
+
+
+def _option_phase(option: FlightOption) -> str:
+    return str(getattr(option, "flight_phase", "") or "").strip().lower()
+
+
+def _is_reverse_route(candidate: FlightOption, outbound: FlightOption) -> bool:
+    outbound_origin = normalized_iata_or_none(outbound.departure_airport)
+    outbound_destination = normalized_iata_or_none(outbound.arrival_airport)
+    candidate_origin = normalized_iata_or_none(candidate.departure_airport)
+    candidate_destination = normalized_iata_or_none(candidate.arrival_airport)
+    return bool(
+        outbound_origin
+        and outbound_destination
+        and candidate_origin == outbound_destination
+        and candidate_destination == outbound_origin
+    )
 
 
 def _require_iata(value: str, field_name: str) -> str:

--- a/web/src/components/ShortlistHero.tsx
+++ b/web/src/components/ShortlistHero.tsx
@@ -108,7 +108,12 @@ export function deriveTripDateRangeLabel(
   if (lockedEnvelope) {
     const envelopeStart = parseDatePrefix(lockedEnvelope.trip_start_datetime);
     const envelopeEnd = parseDatePrefix(lockedEnvelope.trip_end_datetime);
-    if (envelopeStart && envelopeEnd) return formatDateRange(envelopeStart, envelopeEnd);
+    if (envelopeStart && envelopeEnd) {
+      if (envelopeEnd.getTime() >= envelopeStart.getTime()) {
+        return formatDateRange(envelopeStart, envelopeEnd);
+      }
+      return "Flight dates invalid · reselect return";
+    }
   }
 
   if (selectedFlight && !selectedReturnFlight) {
@@ -148,13 +153,13 @@ function findSelectedFlight(shortlists?: ShortlistState[]): FlightOption | null 
   const flights = shortlists?.find((shortlist) => shortlist.category === "flights");
   if (!flights) return null;
   const outboundId = flights.artifacts?.flight_selection?.selected_outbound_option_id;
-  const outbound = flights.flight_options.find((option) => option.option_id === outboundId);
+  const outbound = flights.flight_options.find((option) => option.option_id === outboundId && option.flight_phase !== "return");
   if (outbound) return outbound;
   const selectedStatuses = new Set(["approved", "booked", "confirmed"]);
   const recommended = flights.flight_options.find((option) => option.option_id === flights.recommended_option_id);
-  if (recommended && selectedStatuses.has(recommended.row_status)) return recommended;
+  if (recommended && selectedStatuses.has(recommended.row_status) && recommended.flight_phase !== "return") return recommended;
   return (
-    flights.flight_options.find((option) => selectedStatuses.has(option.row_status)) ??
+    flights.flight_options.find((option) => selectedStatuses.has(option.row_status) && option.flight_phase !== "return") ??
     null
   );
 }
@@ -163,7 +168,7 @@ function findSelectedReturnFlight(shortlists?: ShortlistState[]): FlightOption |
   const flights = shortlists?.find((shortlist) => shortlist.category === "flights");
   if (!flights) return null;
   const returnId = flights.artifacts?.flight_selection?.selected_return_option_id;
-  return flights.flight_options.find((option) => option.option_id === returnId) ?? null;
+  return flights.flight_options.find((option) => option.option_id === returnId && option.flight_phase === "return") ?? null;
 }
 
 function findExplicitReturnDate(option: FlightOption | null, start: Date): Date | null {

--- a/web/src/pages/FlightsFlow.tsx
+++ b/web/src/pages/FlightsFlow.tsx
@@ -63,7 +63,8 @@ export default function FlightsFlow() {
     searchReturns.mutate();
   }, [flow?.phase, flow?.selected_departure?.option_id, flow?.return_options.length, autoReturnSearchFor]);
 
-  const title = flow?.phase === "locked" ? "Flights selected." : activePhase === "return" ? "Pick your return flight." : "Pick your departure flight.";
+  const title = flow?.phase === "locked" ? "Flights locked." : activePhase === "return" ? "Pick your return flight." : "Pick your departure flight.";
+  const researchLabel = activePhase === "return" ? "Research returns" : "Research departures";
 
   return (
     <AppShell>
@@ -74,9 +75,11 @@ export default function FlightsFlow() {
           <div><div className="text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground">Stage 3 · Flights</div><h2 className="font-[Fredoka] text-3xl md:text-4xl font-bold mt-1">{title}</h2></div>
           <button onClick={() => activePhase === "return" ? searchReturns.mutate() : searchDepartures.mutate()} disabled={busy} className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-card border-2 border-foreground/15 text-sm font-bold hover:border-foreground/40 transition-colors">
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
-            {activePhase === "return" ? "Research returns" : "Research departures"}
+            {researchLabel}
           </button>
         </div>
+
+        <FlightGateStatus flow={flow} />
 
         {error && <div className="rounded-2xl border-2 border-destructive/30 bg-destructive/5 p-4 mb-4 text-sm font-bold text-destructive">{(error as Error)?.message || String(error)}</div>}
         {(tripQuery.isLoading || flowQuery.isLoading) && <div className="flex items-center justify-center py-24 text-muted-foreground gap-3"><Loader2 className="h-6 w-6 animate-spin" /><span className="font-bold">Loading...</span></div>}
@@ -86,16 +89,45 @@ export default function FlightsFlow() {
         {flow?.selected_return && <SelectedFlight label="Return selected" option={flow.selected_return} />}
         {flow?.phase === "return_required" && <div className="rounded-2xl border-2 border-foreground/10 bg-card p-4 mb-4 text-sm font-bold text-muted-foreground">Return search: {flow.selected_departure?.arrival_airport} to {flow.selected_departure?.departure_airport}</div>}
 
-        {rows.length === 0 && !flowQuery.isLoading && <EmptyShortlist title={activePhase === "return" ? "No return rows yet" : "No departure options yet"} description={activePhase === "return" ? "Re-run return research. The backend should return live rows or fallback return-search rows." : "Search departure options first."} ctaLabel={activePhase === "return" ? "Research returns" : "Research departures"} onBuild={() => activePhase === "return" ? searchReturns.mutate() : searchDepartures.mutate()} isLoading={busy} isError={Boolean(error)} errorMessage={(error as Error)?.message} />}
+        {rows.length === 0 && !flowQuery.isLoading && <EmptyShortlist title={activePhase === "return" ? "No return rows yet" : "No departure options yet"} description={activePhase === "return" ? "Re-run return research. The backend should return live rows or fallback return-search rows." : "Search departure options first."} ctaLabel={researchLabel} onBuild={() => activePhase === "return" ? searchReturns.mutate() : searchDepartures.mutate()} isLoading={busy} isError={Boolean(error)} errorMessage={(error as Error)?.message} />}
 
         <div className="flex flex-col gap-4">
-          {rows.map((row) => <FlightCard key={row.option_id} option={row} selected={activePhase === "return" ? row.option_id === flow?.selected_return?.option_id : row.option_id === flow?.selected_departure?.option_id} activePhase={activePhase} busy={busy} onSelect={() => activePhase === "return" ? selectReturn.mutate(row.option_id) : selectDeparture.mutate(row.option_id)} />)}
+          {rows.map((row) => <FlightCard key={`${activePhase}-${row.option_id}`} option={row} selected={activePhase === "return" ? row.option_id === flow?.selected_return?.option_id : row.option_id === flow?.selected_departure?.option_id} activePhase={activePhase} busy={busy} onSelect={() => activePhase === "return" ? selectReturn.mutate(row.option_id) : selectDeparture.mutate(row.option_id)} />)}
         </div>
 
         {flow?.can_continue && <div className="mt-6 flex justify-end"><Button onClick={() => navigate(`/trip/${tripId}/stays`)} className="h-12 rounded-2xl bg-gradient-sunset text-primary-foreground font-bold border-2 border-foreground shadow-sticker px-8">Continue to Stays <ArrowRight className="h-4 w-4" /></Button></div>}
       </div>
     </AppShell>
   );
+}
+
+function FlightGateStatus({ flow }: { flow: FlightFlowResponse["flight_flow"] | undefined }) {
+  const departureDone = Boolean(flow?.selected_departure);
+  const returnDone = Boolean(flow?.selected_return);
+  const locked = flow?.phase === "locked" && departureDone && returnDone;
+  const items = [
+    { label: "1. Departure flight", done: departureDone, detail: departureDone ? routeLabel(flow?.selected_departure) : "required to set trip start" },
+    { label: "2. Return flight", done: returnDone, detail: returnDone ? routeLabel(flow?.selected_return) : "required to set trip end" },
+    { label: "3. Trip dates", done: locked, detail: locked ? "locked from selected flights" : "not final yet" },
+  ];
+  return (
+    <div className="rounded-2xl border-2 border-foreground/10 bg-card p-4 mb-4">
+      <div className="font-bold text-foreground mb-3">Trip date lock requires both envelope flights</div>
+      <div className="grid gap-2 md:grid-cols-3">
+        {items.map((item) => (
+          <div key={item.label} className={`rounded-xl border-2 px-3 py-2 ${item.done ? "border-palm/30 bg-palm/5" : "border-foreground/10 bg-background/60"}`}>
+            <div className="text-sm font-bold flex items-center gap-2">{item.done && <Check className="h-4 w-4 text-palm" />}{item.label}</div>
+            <div className="text-xs text-muted-foreground mt-1">{item.detail}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function routeLabel(option: FlightOption | null | undefined): string {
+  if (!option) return "";
+  return `${option.departure_airport} to ${option.arrival_airport}`;
 }
 
 function SelectedFlight({ label, option }: { label: string; option: FlightOption }) {


### PR DESCRIPTION
Fixes the current flight flow bug where Trippy can appear to lock a trip after only a departure selection or show an impossible date range.

Changes:
- Enforces the envelope sequence: departure must be selected first, return must be selected second
- Validates return selection against the reverse route of the selected departure
- Prevents duplicate/ambiguous option IDs from making a departure row count as the return row
- Clears stale return selection when the departure is changed
- Blocks invalid locked envelopes instead of deriving impossible start/end dates
- Updates the flight UI to show the explicit 3-step gate: departure, return, trip dates
- Updates the date pill to show return pending or invalid flight dates instead of impossible ranges

Why:
- Departure arrival defines the trip start
- Return departure defines the trip end
- Until both are selected, downstream lodging/cars/activities/timeline should not treat dates as final