### PR TITLE
Fix flight flow orphan return state

### DIFF
--- a/tests/unit/test_flight_flow.py
+++ b/tests/unit/test_flight_flow.py
@@ -1,0 +1,93 @@
+"""Tests for the backend-owned flight flow state machine."""
+
+from __future__ import annotations
+
+from trippy.models.shortlists import (
+    FlightOption,
+    RecommendationGrade,
+    ResearchShortlistState,
+    ShortlistCategory,
+)
+from trippy.services.flight_flow import FlightFlowService
+
+
+class _FakeStore:
+    def __init__(self, state: ResearchShortlistState | None) -> None:
+        self.state = state
+
+    def load(
+        self,
+        trip_id: str,
+        category: ShortlistCategory,
+    ) -> ResearchShortlistState | None:
+        return self.state
+
+    def save(self, state: ResearchShortlistState) -> ResearchShortlistState:
+        self.state = state
+        return state
+
+
+def test_flight_flow_repairs_orphan_return_selection() -> None:
+    state = ResearchShortlistState(
+        trip_id="azores-family-2026",
+        category=ShortlistCategory.FLIGHTS,
+        flight_options=[
+            _option("departure-1", "departure", "YYZ", "PDL"),
+            _option("return-1", "return", "PDL", "YYZ"),
+        ],
+        artifacts={
+            "flight_selection": {
+                "selected_return_option_id": "return-1",
+                "trip_envelope_locked": True,
+            },
+            "return_search": {"origin_airport": "PDL", "destination_airport": "YYZ"},
+            "trip_envelope": {"status": "locked"},
+        },
+    )
+
+    service = FlightFlowService(store=_FakeStore(state))
+    response = service.get_state("azores-family-2026")
+    flow = response["flight_flow"]
+    repaired = response["shortlist"]
+
+    assert flow["phase"] == "departure_required"
+    assert flow["selected_departure"] is None
+    assert flow["selected_return"] is None
+    assert flow["return_options"] == []
+    assert [option["option_id"] for option in flow["departure_options"]] == ["departure-1"]
+    assert repaired["artifacts"]["flight_selection"]["trip_envelope_locked"] is False
+    assert "selected_return_option_id" not in repaired["artifacts"]["flight_selection"]
+    assert "return_search" not in repaired["artifacts"]
+    assert [option["option_id"] for option in repaired["flight_options"]] == ["departure-1"]
+
+
+def _option(
+    option_id: str,
+    phase: str,
+    origin: str,
+    destination: str,
+) -> FlightOption:
+    return FlightOption(
+        option_id=option_id,
+        rank=1,
+        airline="WestJet",
+        flight_numbers=["WS1"],
+        flight_phase=phase,
+        departure_date="2026-08-24",
+        arrival_date="2026-08-24",
+        departure_airport=origin,
+        arrival_airport=destination,
+        departure_time="8:00 AM",
+        arrival_time="12:10 PM",
+        stops=0,
+        total_travel_duration="5h 10m",
+        fare_estimate_cad="CAD 1,200 total; CAD 240 per person",
+        price_band="CAD 1,200 total; CAD 240 per person",
+        baggage_cabin_notes="verify bags",
+        booking_source="Duffel",
+        deep_link="https://www.google.com/travel/flights/search",
+        traveler_count=5,
+        friction_score=10,
+        family_comfort_score=90,
+        recommendation_grade=RecommendationGrade.STRONG,
+    )

--- a/trippy/services/flight_flow.py
+++ b/trippy/services/flight_flow.py
@@ -172,6 +172,7 @@ class FlightFlowService:
         state: ResearchShortlistState | None,
     ) -> dict[str, Any]:
         if state is not None:
+            self._repair_orphan_return_state(state)
             self._write_flow_artifact(state)
             apply_trip_envelope_artifacts(state)
             state = self._store.save(state)
@@ -215,6 +216,63 @@ class FlightFlowService:
             "shortlist": state.model_dump(mode="json") if state else None,
         }
 
+    def _repair_orphan_return_state(self, state: ResearchShortlistState) -> None:
+        """Drop stale return state when the selected departure is missing.
+
+        This protects the UI from impossible states such as "Return selected" while
+        the flow is still asking for a departure. Return rows are only valid after a
+        departure route has been selected because they are derived from that route.
+        """
+        if self._selected_departure(state) is not None:
+            return
+
+        artifacts = dict(state.artifacts or {})
+        selection = dict(artifacts.get("flight_selection") or {})
+        changed = False
+
+        if selection.get("selected_return_option_id") or selection.get("trip_envelope_locked"):
+            selection.pop("selected_return_option_id", None)
+            selection["trip_envelope_locked"] = False
+            artifacts["flight_selection"] = selection
+            changed = True
+
+        for key in (
+            "trip_envelope",
+            "two_step_flight_flow",
+            "downstream_planning_lock",
+            "return_search",
+            "inter_location_flights",
+        ):
+            if key in artifacts:
+                artifacts.pop(key, None)
+                changed = True
+
+        kept_options: list[FlightOption] = []
+        for option in state.flight_options:
+            role = self._flight_role(option)
+            if role in {"return", "inter_location"}:
+                changed = True
+                continue
+            if option.row_status == ShortlistRowStatus.APPROVED:
+                option.row_status = ShortlistRowStatus.RESEARCHED
+                changed = True
+            if "selected" in (option.recommendation_label or "").lower():
+                option.recommendation_label = ""
+                changed = True
+            kept_options.append(option)
+
+        if not changed:
+            return
+
+        state.flight_options = kept_options
+        state.artifacts = artifacts
+        state.recommended_option_id = kept_options[0].option_id if kept_options else None
+        state.recommendation_summary = "Choose a departure flight first. Return options come after that selection."
+        state.next_actions = [
+            "Choose a departure flight to start the two-step flight flow.",
+            *[action for action in state.next_actions if "return" not in action.lower()],
+        ]
+
     def _write_flow_artifact(self, state: ResearchShortlistState) -> None:
         artifacts = dict(state.artifacts or {})
         artifacts["flight_flow"] = {
@@ -240,6 +298,8 @@ class FlightFlowService:
 
     def _return_options(self, state: ResearchShortlistState | None) -> list[FlightOption]:
         if state is None:
+            return []
+        if self._selected_departure(state) is None:
             return []
         return [option for option in state.flight_options if self._flight_role(option) == "return"]
 
@@ -276,6 +336,9 @@ class FlightFlowService:
 
     def _selected_return(self, state: ResearchShortlistState | None) -> FlightOption | None:
         if state is None:
+            return None
+        selected_departure = self._selected_departure(state)
+        if selected_departure is None:
             return None
         selection = state.artifacts.get("flight_selection") or {}
         option_id = str(selection.get("selected_return_option_id") or "")


### PR DESCRIPTION
## Summary
- Repairs impossible flight-flow state where a return flight can appear selected before a departure flight is selected
- Hides/removes stale return rows until the departure route is selected
- Clears stale trip envelope, return search, and downstream planning locks when the departure selection is missing
- Adds a regression test for the screenshot state: return selected, no departure options visible, trip dates not locked

## Why
The flights step must be a strict two-step gate:
1. Select departure flight
2. Select return flight
3. Lock trip dates for stays/cars/do/timeline

The UI was showing a stale return selection while the flow still needed a departure, so the user could not navigate cleanly between departure and return and no departure options rendered.

## Tests
- Added `tests/unit/test_flight_flow.py`
- Not run in this environment