### PR TITLE
Harden flight scanners for all flight phases

### DIFF
--- a/tests/unit/test_flight_flow.py
+++ b/tests/unit/test_flight_flow.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import pytest
+
 from trippy.models.shortlists import (
     FlightOption,
     RecommendationGrade,
     ResearchShortlistState,
     ShortlistCategory,
+    ShortlistRowStatus,
 )
 from trippy.services.flight_flow import FlightFlowService
+from trippy.services.flight_trip_envelope import FlightEnvelopeError
 
 
 class _FakeStore:
@@ -61,11 +65,73 @@ def test_flight_flow_repairs_orphan_return_selection() -> None:
     assert [option["option_id"] for option in repaired["flight_options"]] == ["departure-1"]
 
 
+def test_inter_location_search_creates_scanner_handoff_without_fake_flight_data() -> None:
+    state = ResearchShortlistState(
+        trip_id="azores-family-2026",
+        category=ShortlistCategory.FLIGHTS,
+        flight_options=[
+            _option(
+                "departure-1",
+                "departure",
+                "YYZ",
+                "PDL",
+                row_status=ShortlistRowStatus.APPROVED,
+            ),
+        ],
+        artifacts={"flight_selection": {"selected_outbound_option_id": "departure-1"}},
+    )
+
+    service = FlightFlowService(store=_FakeStore(state))
+    response = service.search_inter_location(
+        "azores-family-2026",
+        origin_airport="PDL",
+        destination_airport="LIS",
+        departure_date="2026-08-27",
+    )
+    transfer_options = response["flight_flow"]["inter_location_options"]
+
+    assert len(transfer_options) == 1
+    row = transfer_options[0]
+    assert row["option_id"] == "scanner-inter_location-PDL-LIS"
+    assert row["flight_phase"] == "inter_location"
+    assert row["departure_airport"] == "PDL"
+    assert row["arrival_airport"] == "LIS"
+    assert row["airline"] == "Flight scanner handoff — exact evidence required"
+    assert row["flight_numbers"] == []
+    assert row["fare_estimate_cad"] == "source evidence required"
+    assert row["total_travel_duration"] == "source evidence required"
+    assert row["validation"]["verification_status"] == "manual_required"
+    assert "flight_numbers" in row["validation"]["missing_fields"]
+
+
+def test_scanner_handoff_rows_are_not_selectable() -> None:
+    service = FlightFlowService(store=_FakeStore(None))
+    scanner_row = service._scanner_handoff_option(  # noqa: SLF001 - explicit contract regression
+        "azores-family-2026",
+        phase="departure",
+        origin="YYZ",
+        destination="PDL",
+        departure_date="2026-08-24",
+        rank=1,
+    )
+    state = ResearchShortlistState(
+        trip_id="azores-family-2026",
+        category=ShortlistCategory.FLIGHTS,
+        flight_options=[scanner_row],
+    )
+    service = FlightFlowService(store=_FakeStore(state))
+
+    with pytest.raises(FlightEnvelopeError, match="scanner handoff"):
+        service.select_departure("azores-family-2026", scanner_row.option_id)
+
+
 def _option(
     option_id: str,
     phase: str,
     origin: str,
     destination: str,
+    *,
+    row_status: ShortlistRowStatus = ShortlistRowStatus.RESEARCHED,
 ) -> FlightOption:
     return FlightOption(
         option_id=option_id,
@@ -90,4 +156,5 @@ def _option(
         friction_score=10,
         family_comfort_score=90,
         recommendation_grade=RecommendationGrade.STRONG,
+        row_status=row_status,
     )

--- a/trippy/services/flight_flow.py
+++ b/trippy/services/flight_flow.py
@@ -18,26 +18,48 @@ UI and downstream planners do not infer dates from mixed shortlist rows.
 
 from __future__ import annotations
 
+import re
 from typing import Any, Literal
+from urllib.parse import quote_plus
 
 from trippy.models.shortlists import (
     FlightOption,
+    LiveDataStatus,
+    RecommendationGrade,
     ResearchShortlistState,
     ShortlistCategory,
     ShortlistRowStatus,
+    SourceType,
+    SourceValidation,
+    VerificationStatus,
 )
+from trippy.services.destination_profiles import profile_for_intake
 from trippy.services.flight_shortlist import FlightShortlistService
 from trippy.services.flight_trip_envelope import (
     FlightEnvelopeError,
     apply_trip_envelope_artifacts,
     derive_trip_envelope,
 )
+from trippy.services.scanner_fallback import run_scanner_fallback, scanner_fallback_available
 from trippy.services.shortlist_store import ShortlistStore
 from trippy.services.trip_intake import TripIntakeService
 from trippy.services.trip_planner import TripPlannerService
 
 FlightFlowPhase = Literal["departure_required", "return_required", "locked"]
 EnvelopeFlightPhase = Literal["departure", "return"]
+FlightRoutePhase = Literal["departure", "return", "inter_location"]
+_IATA_PATTERN = re.compile(r"^[A-Z]{3}$")
+_SCANNER_REQUIRED_FIELDS = [
+    "flight_numbers",
+    "exact_departure_date",
+    "exact_arrival_date",
+    "exact_departure_time",
+    "exact_arrival_time",
+    "total_duration",
+    "exact_fare",
+    "fare_rules",
+    "baggage_terms",
+]
 
 
 class FlightFlowService:
@@ -70,7 +92,7 @@ class FlightFlowService:
         deep_research: bool = True,
         adapter_mode: str = "auto",
     ) -> dict[str, Any]:
-        state = FlightShortlistService(self._intakes, self._planner).build(
+        state = FlightShortlistService(self._intakes, self._planner, store=self._store).build(
             trip_id,
             flight_phase="departure",
             validate_live=validate_live,
@@ -78,10 +100,18 @@ class FlightFlowService:
             adapter_mode=adapter_mode,
         )
         self._mark_envelope_role(state, "departure")
+        state = self._ensure_scanner_handoff(
+            trip_id,
+            state,
+            "departure",
+            adapter_mode=adapter_mode,
+        )
         return self._payload(trip_id, state)
 
     def select_departure(self, trip_id: str, option_id: str) -> dict[str, Any]:
-        state = FlightShortlistService(self._intakes, self._planner).select_flight(
+        existing = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
+        self._assert_selectable_flight(existing, option_id)
+        state = FlightShortlistService(self._intakes, self._planner, store=self._store).select_flight(
             trip_id,
             option_id,
             selection_kind="outbound",
@@ -100,7 +130,7 @@ class FlightFlowService:
         existing = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
         if existing is None or self._selected_departure(existing) is None:
             raise FlightEnvelopeError("Select a departure flight before searching returns.")
-        state = FlightShortlistService(self._intakes, self._planner).build(
+        state = FlightShortlistService(self._intakes, self._planner, store=self._store).build(
             trip_id,
             flight_phase="return",
             validate_live=validate_live,
@@ -108,16 +138,79 @@ class FlightFlowService:
             adapter_mode=adapter_mode,
         )
         self._mark_envelope_role(state, "return")
+        state = self._ensure_scanner_handoff(
+            trip_id,
+            state,
+            "return",
+            adapter_mode=adapter_mode,
+        )
         return self._payload(trip_id, state)
 
     def select_return(self, trip_id: str, option_id: str) -> dict[str, Any]:
-        state = FlightShortlistService(self._intakes, self._planner).select_flight(
+        existing = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
+        self._assert_selectable_flight(existing, option_id)
+        state = FlightShortlistService(self._intakes, self._planner, store=self._store).select_flight(
             trip_id,
             option_id,
             selection_kind="return",
         )
         self._mark_envelope_role(state, "return")
         return self._payload(trip_id, state)
+
+    def search_inter_location(
+        self,
+        trip_id: str,
+        *,
+        origin_airport: str,
+        destination_airport: str,
+        departure_date: str = "",
+        adapter_mode: str = "auto",
+    ) -> dict[str, Any]:
+        """Create or refresh a scanner-backed in-trip transfer flight search.
+
+        Inter-location flights are downstream of the locked envelope. They can be
+        searched, scanned, and compared, but they never define the trip start/end.
+        """
+        origin = _iata_or_none(origin_airport)
+        destination = _iata_or_none(destination_airport)
+        if not origin or not destination:
+            raise FlightEnvelopeError(
+                "Inter-location flight search requires normalized IATA origin and destination airports."
+            )
+        state = self._store.load(trip_id, ShortlistCategory.FLIGHTS)
+        if state is None:
+            state = ResearchShortlistState(
+                trip_id=trip_id,
+                category=ShortlistCategory.FLIGHTS,
+                recommendation_summary=(
+                    "In-trip transfer flights are scanner-backed research rows until exact itinerary evidence is extracted."
+                ),
+            )
+        option = self._scanner_handoff_option(
+            trip_id,
+            phase="inter_location",
+            origin=origin,
+            destination=destination,
+            departure_date=departure_date,
+            rank=max((item.rank for item in state.flight_options), default=0) + 1,
+        )
+        state.flight_options = [
+            item
+            for item in state.flight_options
+            if item.option_id != option.option_id
+        ]
+        state.flight_options.append(option)
+        state = self._run_or_record_scanner(
+            state,
+            option_phase="inter_location",
+            adapter_mode=adapter_mode,
+            reason=(
+                f"No exact API row existed for in-trip flight {origin}-{destination}; "
+                "Trippy created a scanner handoff row that must be populated from live evidence."
+            ),
+        )
+        saved = self._store.save(state)
+        return self._payload(trip_id, saved)
 
     def reset_departure(self, trip_id: str) -> dict[str, Any]:
         """Clear the envelope and all return/transfer state derived from it."""
@@ -209,12 +302,235 @@ class FlightFlowService:
                 "final_dates_require_return": True,
                 "inter_location_flights_do_not_define_trip_dates": True,
                 "downstream_finalization_requires_locked_envelope": True,
+                "scanner_handoff_rows_are_not_selectable_until_exact_evidence_exists": True,
             },
         }
         return {
             "flight_flow": flow,
             "shortlist": state.model_dump(mode="json") if state else None,
         }
+
+    def _ensure_scanner_handoff(
+        self,
+        trip_id: str,
+        state: ResearchShortlistState,
+        phase: FlightRoutePhase,
+        *,
+        adapter_mode: str,
+    ) -> ResearchShortlistState:
+        route_options = self._options_for_phase(state, phase)
+        if route_options and any(not self._is_scanner_handoff(option) for option in route_options):
+            return state
+
+        route = self._route_for_phase(trip_id, state, phase)
+        if route is None:
+            state.warnings.append(
+                f"No scanner route was created for {phase} flights because normalized airport codes were not available."
+            )
+            return state
+
+        origin, destination, departure_date = route
+        if not route_options:
+            state.flight_options.append(
+                self._scanner_handoff_option(
+                    trip_id,
+                    phase=phase,
+                    origin=origin,
+                    destination=destination,
+                    departure_date=departure_date,
+                    rank=max((item.rank for item in state.flight_options), default=0) + 1,
+                )
+            )
+        return self._run_or_record_scanner(
+            state,
+            option_phase=phase,
+            adapter_mode=adapter_mode,
+            reason=(
+                f"Configured flight APIs returned no exact {phase} rows for {origin}-{destination}; "
+                "Trippy used the scanner fallback path without inventing airline, fare, timing, or booking data."
+            ),
+        )
+
+    def _run_or_record_scanner(
+        self,
+        state: ResearchShortlistState,
+        *,
+        option_phase: FlightRoutePhase,
+        adapter_mode: str,
+        reason: str,
+    ) -> ResearchShortlistState:
+        artifacts = dict(state.artifacts or {})
+        scanner = dict(artifacts.get("scanner_fallback") or {})
+        scanner.setdefault("routes", [])
+        scanner["routes"].append(
+            {
+                "phase": option_phase,
+                "status": "attempted" if scanner_fallback_available() else "unavailable",
+                "reason": reason,
+                "data_policy": "exact_facts_only_no_generated_flight_details",
+            }
+        )
+        artifacts["scanner_fallback"] = scanner
+        state.artifacts = artifacts
+        state.next_actions = _dedupe(
+            [
+                "Scanner rows are search tasks, not bookable recommendations, until live itinerary evidence fills exact fields.",
+                *state.next_actions,
+            ]
+        )
+        if not scanner_fallback_available():
+            state.warnings.append(
+                "No exact flight rows were returned, and Firecrawl/OpenClaw scanner fallback is not configured or reachable. No made-up flight data was generated."
+            )
+            return state
+        return run_scanner_fallback(
+            state,
+            adapter_mode=adapter_mode,
+            reason=reason,
+        )
+
+    def _scanner_handoff_option(
+        self,
+        trip_id: str,
+        *,
+        phase: FlightRoutePhase,
+        origin: str,
+        destination: str,
+        departure_date: str = "",
+        rank: int,
+    ) -> FlightOption:
+        option_id = f"scanner-{phase}-{origin}-{destination}"
+        deep_link = _flight_search_url(origin, destination, departure_date)
+        return FlightOption(
+            option_id=option_id,
+            rank=rank,
+            airline="Flight scanner handoff — exact evidence required",
+            flight_numbers=[],
+            flight_phase=phase,
+            departure_date=departure_date,
+            arrival_date="",
+            departure_airport=origin,
+            arrival_airport=destination,
+            departure_time="source evidence required",
+            arrival_time="source evidence required",
+            stops=0,
+            layover_airports=[],
+            total_travel_duration="source evidence required",
+            timing_fit=(
+                "Not selectable yet. Firecrawl/OpenClaw or a live API must extract exact itinerary evidence first."
+            ),
+            recommendation_label="Scanner handoff",
+            recommendation_rationale=(
+                "This row prevents empty flight states but does not claim a flight exists. It must be populated from live source evidence before selection."
+            ),
+            planning_next_step="Run scanner fallback or paste an exact itinerary with source evidence.",
+            fare_estimate_cad="source evidence required",
+            price_band="source evidence required",
+            baggage_cabin_notes="source evidence required",
+            booking_source="Scanner fallback",
+            deep_link=deep_link,
+            traveler_count=0,
+            traveler_fit="Traveler fit requires exact fare, baggage, seats, and itinerary evidence.",
+            comparison_links={"Google Flights search": deep_link},
+            aeroplan_relevance="Unknown until carrier and fare class are extracted from source evidence.",
+            friction_score=70,
+            family_comfort_score=30,
+            recommendation_grade=RecommendationGrade.CONDITIONAL,
+            tradeoffs=[
+                "Created only because exact API rows were unavailable.",
+                "Not a recommendation and not selectable until exact source evidence exists.",
+            ],
+            friction_flags=["Exact flight evidence missing", "Scanner handoff row only"],
+            confidence_notes=[
+                "No airline, flight number, fare, baggage, timing, or availability has been invented.",
+                f"Route: {origin}-{destination}; phase: {phase}; trip: {trip_id}.",
+            ],
+            live_data_status=LiveDataStatus.HANDOFF_REQUIRED,
+            row_status=ShortlistRowStatus.RESEARCHED,
+            validation=SourceValidation(
+                source_name="Flight scanner fallback",
+                source_type=SourceType.SEARCH_HANDOFF,
+                verification_status=VerificationStatus.MANUAL_REQUIRED,
+                confidence=0.15,
+                evidence_url=deep_link,
+                adapter_used="firecrawl/openclaw pending",
+                missing_fields=list(_SCANNER_REQUIRED_FIELDS),
+                notes=[
+                    "Scanner handoff row only. It is blocked from flight selection until exact source evidence is extracted."
+                ],
+            ),
+        )
+
+    def _route_for_phase(
+        self,
+        trip_id: str,
+        state: ResearchShortlistState,
+        phase: FlightRoutePhase,
+    ) -> tuple[str, str, str] | None:
+        if phase == "return":
+            departure = self._selected_departure(state)
+            if departure is None:
+                return None
+            origin = _iata_or_none(departure.arrival_airport)
+            destination = _iata_or_none(departure.departure_airport)
+            return_date = _intake_end_date(self._intakes.load(trip_id))
+            if origin and destination:
+                return (origin, destination, return_date)
+            return None
+
+        if phase == "inter_location":
+            return None
+
+        intake = self._intakes.load(trip_id)
+        if intake is None:
+            return None
+        profile = profile_for_intake(intake)
+        origin = _iata_or_none(intake.departure_airports[0] if intake.departure_airports else "")
+        destination = _iata_or_none(profile.gateway_airports[0] if profile.gateway_airports else "")
+        if origin and destination:
+            return (origin, destination, _intake_start_date(intake))
+        return None
+
+    def _options_for_phase(
+        self,
+        state: ResearchShortlistState,
+        phase: FlightRoutePhase,
+    ) -> list[FlightOption]:
+        if phase == "departure":
+            return self._departure_options(state)
+        if phase == "return":
+            return self._return_options(state)
+        return self._inter_location_options(state)
+
+    def _assert_selectable_flight(
+        self,
+        state: ResearchShortlistState | None,
+        option_id: str,
+    ) -> None:
+        if state is None:
+            return
+        option = next((item for item in state.flight_options if item.option_id == option_id), None)
+        if option is None:
+            return
+        if self._is_scanner_handoff(option):
+            raise FlightEnvelopeError(
+                "This is a scanner handoff row, not an exact flight. Run Firecrawl/OpenClaw extraction or paste an exact itinerary before selecting it."
+            )
+
+    def _is_scanner_handoff(self, option: FlightOption) -> bool:
+        if not option.option_id.startswith("scanner-"):
+            return False
+        if option.validation.verification_status == VerificationStatus.LIVE_VERIFIED:
+            return False
+        if any("evidence required" in value.lower() for value in (
+            option.departure_time,
+            option.arrival_time,
+            option.total_travel_duration,
+            option.fare_estimate_cad,
+            option.price_band,
+        )):
+            return True
+        return bool(option.validation.missing_fields)
 
     def _repair_orphan_return_state(self, state: ResearchShortlistState) -> None:
         """Drop stale return state when the selected departure is missing.
@@ -281,6 +597,7 @@ class FlightFlowService:
             "transfer_flight_phase": "inter_location",
             "date_constraint_owner": "selected_departure_plus_selected_return",
             "inter_location_flights_are_downstream": True,
+            "scanner_handoff_policy": "exact_evidence_required_no_made_up_flight_data",
         }
         state.artifacts = artifacts
 
@@ -323,13 +640,14 @@ class FlightFlowService:
         option_id = str(selection.get("selected_outbound_option_id") or "")
         if option_id:
             match = next((option for option in self._departure_options(state) if option.option_id == option_id), None)
-            if match:
+            if match and not self._is_scanner_handoff(match):
                 return match
         return next(
             (
                 option
                 for option in self._departure_options(state)
                 if option.row_status == ShortlistRowStatus.APPROVED
+                and not self._is_scanner_handoff(option)
             ),
             None,
         )
@@ -344,7 +662,10 @@ class FlightFlowService:
         option_id = str(selection.get("selected_return_option_id") or "")
         if not option_id:
             return None
-        return next((option for option in self._return_options(state) if option.option_id == option_id), None)
+        match = next((option for option in self._return_options(state) if option.option_id == option_id), None)
+        if match and not self._is_scanner_handoff(match):
+            return match
+        return None
 
     def _option_json(self, option: FlightOption | None) -> dict[str, Any] | None:
         return option.model_dump(mode="json") if option is not None else None
@@ -355,3 +676,35 @@ class FlightFlowService:
         if phase == "return_required":
             return "Search and choose a return flight based on the selected departure."
         return "Flight envelope is locked; continue to stays. Inter-location flights can be planned later inside this envelope."
+
+
+def _iata_or_none(value: str) -> str | None:
+    candidate = (value or "").strip().upper()
+    return candidate if _IATA_PATTERN.fullmatch(candidate) else None
+
+
+def _flight_search_url(origin: str, destination: str, departure_date: str = "") -> str:
+    query = f"flights {origin} to {destination}"
+    if departure_date:
+        query += f" {departure_date}"
+    return "https://www.google.com/travel/flights/search?q=" + quote_plus(query) + "&hl=en-CA&gl=ca&curr=CAD"
+
+
+def _intake_start_date(intake: Any | None) -> str:
+    window = getattr(intake, "travel_window", None)
+    value = getattr(window, "start_date", None)
+    return value.isoformat() if value else ""
+
+
+def _intake_end_date(intake: Any | None) -> str:
+    window = getattr(intake, "travel_window", None)
+    value = getattr(window, "end_date", None)
+    return value.isoformat() if value else ""
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if value and value not in result:
+            result.append(value)
+    return result


### PR DESCRIPTION
## Summary
- Extends flight scanner fallback handling beyond departures to returns and in-trip/inter-location flights
- Adds scanner handoff rows when APIs return no exact usable flight rows, without inventing airline, fare, timing, baggage, or booking data
- Blocks scanner handoff rows from being selected as real flights until exact evidence is extracted
- Adds scanner policy metadata to flight-flow invariants/artifacts
- Adds backend method for in-trip transfer flight scanning so stop-to-stop flights are downstream of the locked trip envelope and never redefine trip dates
- Adds tests for scanner handoff rows and non-selectability

## Data policy
- Exact API/live rows can be selectable
- Firecrawl/OpenClaw scanner rows are evidence-gathering tasks only
- No fake flight numbers, airlines, fares, times, baggage rules, or availability are generated

## Tests
- Added/updated `tests/unit/test_flight_flow.py`
- Not run in this environment